### PR TITLE
Fix target triple for x86 and x64 Clang builds.

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -554,8 +554,11 @@ config("compiler") {
         cflags += [ "--target=arm-linux-androideabi" ]
         ldflags += [ "--target=arm-linux-androideabi" ]
       } else if (current_cpu == "x86") {
-        cflags += [ "--target=x86-linux-androideabi" ]
-        ldflags += [ "--target=x86-linux-androideabi" ]
+        cflags += [ "--target=i686-linux-androideabi" ]
+        ldflags += [ "--target=i686-linux-androideabi" ]
+      } else if (current_cpu == "x64") {
+        cflags += [ "--target=x86_64-linux-androideabi" ]
+        ldflags += [ "--target=x86_64-linux-androideabi" ]
       }
     }
   }


### PR DESCRIPTION
The original code referenced an invalid triple for x86 and didn't specify one at all for x64. Fixes both.