### PR TITLE
Switch to a lower API level to fix eabi issue

### DIFF
--- a/build/config/android/config.gni
+++ b/build/config/android/config.gni
@@ -94,7 +94,7 @@ if (is_android) {
 
   # Subdirectories inside android_ndk_root that contain the sysroot for the
   # associated platform.
-  _android_api_level = 24
+  _android_api_level = 22
   x86_android_sysroot_subdir =
       "platforms/android-${_android_api_level}/arch-x86"
   arm_android_sysroot_subdir =


### PR DESCRIPTION
Previously, we couldn't find the `__aeabi_memcpy` symbol, which is due to an
error in the NDK (see https://android-review.googlesource.com/#/c/195350/).

Fixes https://github.com/flutter/flutter/issues/6149