### PR TITLE
Don't fall back to C++11 on x86 Android targets.

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -434,7 +434,7 @@ config("compiler") {
   # check can then be removed. So far, the only target that need x86 don't
   # also require C++14.
   # Tracked in https://fuchsia.atlassian.net/browse/TO-61
-  if (current_cpu == "x86") {
+  if (is_linux && current_cpu == "x86") {
     cc_std = [ "-std=c++11" ]
   } else {
     cc_std = [ "-std=c++14" ]


### PR DESCRIPTION
The workaround https://fuchsia.atlassian.net/browse/TO-61 was only for Linux hosts on x86. The previous check also caught Android x86 unintentionally.