### PR TITLE
Pad rpath in Linux host binaries to make space for patching

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -649,6 +649,7 @@ config("runtime_library") {
       # https://github.com/flutter/flutter/issues/6145
       "-Wl,-Bstatic", "-lc++abi", "-Wl,-Bdynamic",
       "-fuse-ld=lld",
+      "-Wl,-rpath=\$ORIGIN/././././././././././././././././././././",
     ]
   }
 }


### PR DESCRIPTION
To be able to run Linux host binaries on certain systems we patch the
rpath entry. The tool that does this (patchelf) corrupts the binary if
it needs to resize the rpath entry. This puts a bunch of no-op padding
in the rpath entry at link time so it can be patched without resizing.