### PR TITLE
Add the fontconfig target for Linux.

### DIFF
--- a/build/secondary/third_party/BUILD.gn
+++ b/build/secondary/third_party/BUILD.gn
@@ -1,0 +1,9 @@
+# Copyright 2016 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+source_set("fontconfig") {
+  if (is_linux) {
+    libs = [ "fontconfig" ]
+  }
+}


### PR DESCRIPTION
Needed for Linux builds. All it does is find the system fontconfig. Regressed in #30 