### PR TITLE
Make some hooks portable to run on Windows.

### DIFF
--- a/tools/android/download_android_tools.py
+++ b/tools/android/download_android_tools.py
@@ -49,7 +49,8 @@ def VersionStampName(tools_name):
   elif sys.platform == 'darwin':
     return 'VERSION_MACOSX_' + tools_name.upper()
   else:
-    raise Exception('Unsupported platform: ' + sys.platform)
+    print('NOTE: Will not download android tools. Unsupported platform: ' + sys.platform)
+    sys.exit(0)
 
 def UpdateTools(tools_name):
   """Downloads zipped tools from Google Cloud Storage and extracts them,


### PR DESCRIPTION
* tools/dart/update.py can now also update the Dart SDK on Windows
* tools/android/download_android_tools.py does not error on Windows anymore (it exits gracefully with a notice)

The Android Tools are not needed on a Windows host because we are prebuilding the Android binaries on a Linux host.

required for flutter/flutter#138