### PR TITLE
Explicitly specify the language on ObjC/ObjC++ files and allows analyzing headers of the same.

### DIFF
--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -24,7 +24,9 @@ path_flags = [
 
 source_extensions = [
   ".cc",
+  ".mm",
   ".cpp",
+  ".m",
   ".c",
 ]
 
@@ -60,6 +62,14 @@ def FlagsForNamedFile(filename):
 
   if not info:
     return None
+
+  extension = filename.rsplit(".", 1)[1]
+
+  if extension == "mm":
+    info.compiler_flags_.append("-x objc++")
+
+  if extension == "m":
+    info.compiler_flags_.append("-x objc")
 
   return MakeFlagsAbsolute(info.compiler_working_dir_,
                            info.compiler_flags_)


### PR DESCRIPTION
This fixes a couple of issues with YCM processing of Objective-C files:

* Allow analysis of headers of ObjC files.
* Fix a YCM issue where it does not pick up the language of the file from the extension.