### PR TITLE
Fix link order of libunwind so that Android exectuables link successfully.

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -423,7 +423,8 @@ config("compiler") {
     defines += [ "HAVE_SYS_UIO_H" ]
 
     # Use gold for Android for most CPU architectures.
-    if (current_cpu == "x86" || current_cpu == "x64" || current_cpu == "arm" || current_cpu == "arm64") {
+    if (current_cpu == "x86" || current_cpu == "x64" || current_cpu == "arm" ||
+        current_cpu == "arm64") {
       ldflags += [ "-fuse-ld=gold" ]
       if (is_clang) {
         # Let clang find the ld.gold in the NDK.
@@ -550,14 +551,17 @@ config("runtime_library") {
 
     lib_dirs += [ "$android_libcpp_root/libs/$android_app_abi" ]
 
+    libs += [
+      "$android_libcpp_library",
+      "c++abi",
+      "android_support",
+    ]
+
     if (current_cpu == "arm") {
       libs += [ "unwind" ]
     }
 
     libs += [
-      "$android_libcpp_library",
-      "c++abi",
-      "android_support",
       "gcc",
       "c",
       "dl",
@@ -579,15 +583,16 @@ config("runtime_library") {
   # also require C++14.
   # Tracked in https://fuchsia.atlassian.net/browse/TO-61
   if (is_linux && current_cpu != "x86") {
-    cflags_cc += [
-      "-stdlib=libc++"
-    ]
+    cflags_cc += [ "-stdlib=libc++" ]
     ldflags += [
       "-stdlib=libc++",
       "-static-libstdc++",
+
       # Remove one the toolchain distribution is fixed
       # https://github.com/flutter/flutter/issues/6145
-      "-Wl,-Bstatic", "-lc++abi", "-Wl,-Bdynamic",
+      "-Wl,-Bstatic",
+      "-lc++abi",
+      "-Wl,-Bdynamic",
       "-fuse-ld=lld",
     ]
   }
@@ -608,6 +613,7 @@ if (is_win) {
   default_warning_flags += [
     # Permanent.
     "/wd4091",  # typedef warning from dbghelp.h
+
     # Investigate.
     "/wd4312",  # int to pointer of greater size conversion.
     "/wd4838",  # Narrowing conversion required.


### PR DESCRIPTION
This allows us to link `gtest` executables for Android and run them after an `adb push`. This does not affect `SkyShell.so` linking.