### PR TITLE
Strip symbols of clang_x86 binaries

### DIFF
--- a/build/toolchain/linux/BUILD.gn
+++ b/build/toolchain/linux/BUILD.gn
@@ -45,6 +45,7 @@ gcc_toolchain("clang_x86") {
   nm = "nm"
   ar = "ar"
   ld = cxx
+  strip = "strip"
 
   toolchain_cpu = "x86"
   toolchain_os = "linux"


### PR DESCRIPTION
The clang_x86 toolchain is used by gen_snapshot in profile/release build modes