### PR TITLE
Fix link order of libunwind so that Android exectuables link successfully.

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -550,14 +550,17 @@ config("runtime_library") {
 
     lib_dirs += [ "$android_libcpp_root/libs/$android_app_abi" ]
 
+    libs += [
+      "$android_libcpp_library",
+      "c++abi",
+      "android_support",
+    ]
+
     if (current_cpu == "arm") {
       libs += [ "unwind" ]
     }
 
     libs += [
-      "$android_libcpp_library",
-      "c++abi",
-      "android_support",
       "gcc",
       "c",
       "dl",


### PR DESCRIPTION
I had submitted this patch earlier for Android unit test executables and @jason-simmons had asked for a version without formatting changes. Since it was in buildroot, I forgot about the unapplied patch. Here it is now.