### PR TITLE
Be explicit about the iOS SDK version and deployment targets.

### DIFF
--- a/build/config/ios/ios_sdk.gni
+++ b/build/config/ios/ios_sdk.gni
@@ -14,7 +14,11 @@ declare_args() {
   use_ios_simulator = true
 
   # Version of iOS that we're targeting.
-  ios_deployment_target = "6.0"
+  ios_deployment_target = "8.0"
+
+  # Version of the iOS SDK to use (may be higher than the deployment target if
+  # the code has been written with appropriate version checks).
+  ios_sdk_target = "10.3"
 
   # The iOS Code signing identity to use
   ios_code_signing_identity = ""
@@ -27,14 +31,22 @@ declare_args() {
 }
 
 if (ios_device_sdk_path == "") {
-  _ios_device_sdk_result =
-      exec_script("ios_sdk.py", [ "iphoneos" ], "list lines")
+  _ios_device_sdk_result = exec_script("ios_sdk.py",
+                                       [
+                                         "iphoneos",
+                                         ios_sdk_target,
+                                       ],
+                                       "list lines")
   ios_device_sdk_path = _ios_device_sdk_result[0]
 }
 
 if (ios_simulator_sdk_path == "") {
-  _ios_sim_sdk_result =
-      exec_script("ios_sdk.py", [ "iphonesimulator" ], "list lines")
+  _ios_sim_sdk_result = exec_script("ios_sdk.py",
+                                    [
+                                      "iphonesimulator",
+                                      ios_sdk_target,
+                                    ],
+                                    "list lines")
   ios_simulator_sdk_path = _ios_sim_sdk_result[0]
 }
 
@@ -51,8 +63,7 @@ if (use_ios_simulator) {
 } else {
   # If an identity is not provided, look for one on the host
   if (ios_code_signing_identity == "") {
-    _ios_identities = exec_script("find_signing_identity.py", 
-                                  [], "list lines")
+    _ios_identities = exec_script("find_signing_identity.py", [], "list lines")
     ios_code_signing_identity = _ios_identities[0]
   }
 }

--- a/build/config/ios/ios_sdk.py
+++ b/build/config/ios/ios_sdk.py
@@ -11,9 +11,14 @@ import sys
 # In the GYP build, this is done inside GYP itself based on the SDKROOT
 # variable.
 
-if len(sys.argv) != 2:
-  print "Takes one arg (SDK to find)"
+if len(sys.argv) != 3:
+  print "Takes two args (SDK to find and the version)"
   sys.exit(1)
 
-print subprocess.check_output(['xcodebuild', '-version', '-sdk',
-                               sys.argv[1], 'Path']).strip()
+print subprocess.check_output([
+  'xcodebuild',
+  '-version',
+  '-sdk',
+  ''.join([sys.argv[1], sys.argv[2]]),
+  'Path'
+]).strip()


### PR DESCRIPTION
We used to pick the iOS SDK that was pointed to by the symlink in Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs which could point to a build platform specified version of the SDK. Now, we need to be explicit about the target iOS SDK.