### PR TITLE
upgrade to Dart SDK 1.24.2

### DIFF
--- a/tools/dart/update.py
+++ b/tools/dart/update.py
@@ -19,7 +19,7 @@ import zipfile
 # How to roll the dart sdk: Just change this url! We write this to the stamp
 # file after we download, and then check the stamp file for differences.
 SDK_URL_BASE = ('http://gsdview.appspot.com/dart-archive/channels/stable/raw/'
-                '1.21.0/sdk/')
+                '1.24.2/sdk/')
 
 LINUX_64_SDK = 'dartsdk-linux-x64-release.zip'
 MACOS_64_SDK = 'dartsdk-macos-x64-release.zip'


### PR DESCRIPTION
This has type system fixes around `Null` vs `void` types.