### PR TITLE
Don't set Unix file permissions when extracting Dart SDK on Windows

### DIFF
--- a/tools/dart/update.py
+++ b/tools/dart/update.py
@@ -38,6 +38,7 @@ def main():
   # Only get the SDK if we don't have a stamp for or have an out of date stamp
   # file.
   get_sdk = False
+  set_unix_file_modes = True
   if sys.platform.startswith('linux'):
     sdk_url = SDK_URL_BASE + LINUX_64_SDK
     output_file = os.path.join(DART_SDK_DIR, LINUX_64_SDK)
@@ -47,6 +48,7 @@ def main():
   elif sys.platform.startswith('win'):
     sdk_url = SDK_URL_BASE + WINDOWS_64_SDK
     output_file = os.path.join(DART_SDK_DIR, WINDOWS_64_SDK)
+    set_unix_file_modes = False
   else:
     print "Platform not supported"
     return 1
@@ -71,8 +73,11 @@ def main():
     with zipfile.ZipFile(output_file, 'r') as zip_ref:
       for zip_info in zip_ref.infolist():
         zip_ref.extract(zip_info, path=DART_SDK_DIR)
-        mode = (zip_info.external_attr >> 16) & 0xFFF
-        os.chmod(os.path.join(DART_SDK_DIR, zip_info.filename), mode)
+        if set_unix_file_modes:
+            # external_attr is 32 in size with the unix mode in the
+            # high order 16 bit
+            mode = (zip_info.external_attr >> 16) & 0xFFF
+            os.chmod(os.path.join(DART_SDK_DIR, zip_info.filename), mode)
 
     # Write our stamp file so we don't redownload the sdk.
     with open(STAMP_FILE, "w") as stamp_file:


### PR DESCRIPTION
Prevents from setting dart.exe incorrectly to read-only which causes failures when the bot tries to delete it.