### PR TITLE
Checkout prebuilt dart into standalone dart location.

### DIFF
--- a/tools/dart/update.py
+++ b/tools/dart/update.py
@@ -28,10 +28,7 @@ WINDOWS_64_SDK = 'dartsdk-windows-x64-release.zip'
 # Path constants. (All of these should be absolute paths.)
 THIS_DIR = os.path.abspath(os.path.dirname(__file__))
 MOJO_DIR = os.path.abspath(os.path.join(THIS_DIR, '..', '..'))
-DART_SDK_DIR = os.path.join(MOJO_DIR, 'third_party', 'dart-sdk')
-STAMP_FILE = os.path.join(DART_SDK_DIR, 'STAMP_FILE')
-LIBRARIES_FILE = os.path.join(DART_SDK_DIR,'dart-sdk',
-                              'lib', '_internal', 'libraries.dart')
+DART_SDKS_DIR = os.path.join(MOJO_DIR, 'dart/tools/sdks')
 PATCH_FILE = os.path.join(MOJO_DIR, 'tools', 'dart', 'patch_sdk.diff')
 
 def main():
@@ -39,43 +36,47 @@ def main():
   # file.
   get_sdk = False
   if sys.platform.startswith('linux'):
-    sdk_url = SDK_URL_BASE + LINUX_64_SDK
-    output_file = os.path.join(DART_SDK_DIR, LINUX_64_SDK)
+    os_infix = 'linux'
+    zip_filename = LINUX_64_SDK
   elif sys.platform.startswith('darwin'):
-    sdk_url = SDK_URL_BASE + MACOS_64_SDK
-    output_file = os.path.join(DART_SDK_DIR, MACOS_64_SDK)
+    os_infix = 'mac'
+    zip_filename = MACOS_64_SDK
   elif sys.platform.startswith('win'):
-    sdk_url = SDK_URL_BASE + WINDOWS_64_SDK
-    output_file = os.path.join(DART_SDK_DIR, WINDOWS_64_SDK)
+    os_infix = 'win'
+    zip_filename = WINDOWS_64_SDK
   else:
     print "Platform not supported"
     return 1
 
-  if not os.path.exists(STAMP_FILE):
+  sdk_url = SDK_URL_BASE + zip_filename
+  dart_sdk_dir = os.path.join(DART_SDKS_DIR, os_infix)
+  output_file = os.path.join(dart_sdk_dir, zip_filename)
+
+  stamp_file = os.path.join(dart_sdk_dir, 'dart-sdk/STAMP_FILE')
+  if not os.path.exists(stamp_file):
     get_sdk = True
   else:
     # Get the contents of the stamp file.
-    with open(STAMP_FILE, "r") as stamp_file:
+    with open(stamp_file, "r") as stamp_file:
       stamp_url = stamp_file.read().replace('\n', '')
       if stamp_url != sdk_url:
         get_sdk = True
 
   if get_sdk:
     # Completely remove all traces of the previous SDK.
-    if os.path.exists(DART_SDK_DIR):
-      shutil.rmtree(DART_SDK_DIR)
-    os.mkdir(DART_SDK_DIR)
+    if os.path.exists(dart_sdk_dir):
+      shutil.rmtree(dart_sdk_dir)
+    os.mkdir(dart_sdk_dir)
 
     urllib.urlretrieve(sdk_url, output_file)
-    print(output_file)
     with zipfile.ZipFile(output_file, 'r') as zip_ref:
       for zip_info in zip_ref.infolist():
-        zip_ref.extract(zip_info, path=DART_SDK_DIR)
+        zip_ref.extract(zip_info, path=dart_sdk_dir)
         mode = (zip_info.external_attr >> 16) & 0xFFF
-        os.chmod(os.path.join(DART_SDK_DIR, zip_info.filename), mode)
+        os.chmod(os.path.join(dart_sdk_dir, zip_info.filename), mode)
 
     # Write our stamp file so we don't redownload the sdk.
-    with open(STAMP_FILE, "w") as stamp_file:
+    with open(stamp_file, "w") as stamp_file:
       stamp_file.write(sdk_url)
 
   return 0


### PR DESCRIPTION
If we check out prebuilt dart executables into the same location where standalone dart sdk expects it, we don't need to customize that location for flutter vs dart. This simplifies scripts and fixes the problem where for andorid flutter build patched_sdk step doesn't use prebuilt dart binary, uses [slow] dart binary that targets arm, runs via simulator.