### PR TITLE
Be explicit about the iOS SDK version and deployment targets.

### DIFF
--- a/build/config/ios/ios_sdk.gni
+++ b/build/config/ios/ios_sdk.gni
@@ -16,6 +16,10 @@ declare_args() {
   # Version of iOS that we're targeting.
   ios_deployment_target = "8.0"
 
+  # Version of the iOS SDK to use (may be higher than the deployment target if
+  # the code has been written with appropriate version checks).
+  ios_sdk_target = "10.3"
+
   # The path to the iOS device SDK.
   ios_device_sdk_path = ""
 
@@ -23,23 +27,33 @@ declare_args() {
   ios_simulator_sdk_path = ""
 }
 
-if (ios_device_sdk_path == "") {
-  _ios_device_sdk_result =
-      exec_script("ios_sdk.py", [ "iphoneos" ], "list lines")
-  ios_device_sdk_path = _ios_device_sdk_result[0]
-}
+if (ios_sdk_path == "") {
+  if (!use_ios_simulator && ios_device_sdk_path == "") {
+    _ios_device_sdk_result = exec_script("ios_sdk.py",
+                                         [
+                                           "iphoneos",
+                                           ios_sdk_target,
+                                         ],
+                                         "list lines")
+    ios_device_sdk_path = _ios_device_sdk_result[0]
+  }
 
-if (ios_simulator_sdk_path == "") {
-  _ios_sim_sdk_result =
-      exec_script("ios_sdk.py", [ "iphonesimulator" ], "list lines")
-  ios_simulator_sdk_path = _ios_sim_sdk_result[0]
-}
+  if (use_ios_simulator && ios_simulator_sdk_path == "") {
+    _ios_sim_sdk_result = exec_script("ios_sdk.py",
+                                      [
+                                        "iphonesimulator",
+                                        ios_sdk_target,
+                                      ],
+                                      "list lines")
+    ios_simulator_sdk_path = _ios_sim_sdk_result[0]
+  }
 
-if (ios_sdk_path != "") {
   # Compute default target.
   if (use_ios_simulator) {
+    assert(ios_simulator_sdk_path != "")
     ios_sdk_path = ios_simulator_sdk_path
   } else {
+    assert(ios_device_sdk_path != "")
     ios_sdk_path = ios_device_sdk_path
   }
 }

--- a/build/config/ios/ios_sdk.py
+++ b/build/config/ios/ios_sdk.py
@@ -7,13 +7,17 @@ import sys
 
 # This script returns the path to the SDK of the given type. Pass the type of
 # SDK you want, which is typically "iphone" or "iphonesimulator".
-#
-# In the GYP build, this is done inside GYP itself based on the SDKROOT
-# variable.
 
-if len(sys.argv) != 2:
-  print "Takes one arg (SDK to find)"
+if len(sys.argv) != 3:
+  print "Takes two args (SDK to find and the version)"
   sys.exit(1)
 
-print subprocess.check_output(['xcodebuild', '-version', '-sdk',
-                               sys.argv[1], 'Path']).strip()
+command =  [
+  'xcodebuild',
+  '-version',
+  '-sdk',
+  ''.join([sys.argv[1], sys.argv[2]]),
+  'Path'
+]
+
+print subprocess.check_output(command).strip()


### PR DESCRIPTION
Our minimum supported iOS version was 8.0. But the SDK we used was the first one returned by “xcodebuild —version —sdk”. Now we are explicit about that version too. This way, we can use newer features guarded by the appropriate version checks. If the Xcode installed on the host is too old or does not include the appropriate SDK, the GN step itself will terminate with a error.