### PR TITLE
Update Mac OSX min SDK to Yosemite.

### DIFF
--- a/build/config/mac/mac_sdk.gni
+++ b/build/config/mac/mac_sdk.gni
@@ -4,7 +4,7 @@
 
 declare_args() {
   # Minimum supported version of the Mac SDK.
-  mac_sdk_min = "10.8"
+  mac_sdk_min = "10.10"
 
   # Path to a specific version of the Mac SDKJ, not including a backslash at
   # the end. If empty, the path to the lowest version greater than or equal to
@@ -12,7 +12,10 @@ declare_args() {
   mac_sdk_path = ""
 }
 
-find_sdk_args = [ "--print_sdk_path", mac_sdk_min ]
+find_sdk_args = [
+  "--print_sdk_path",
+  mac_sdk_min,
+]
 
 # The tool will print the SDK path on the first line, and the version on the
 # second line.


### PR DESCRIPTION
We started performing version checks using `-[NSProcessInfo isOperatingSystemAtLeastVersion:]` in FML. This call was introduced in 10.10 and greatly eases making such checks. Since the update was made about 2 years ago, I feel it is safe to switch to the same. This makes no difference to our support of the mobile shells.