### PR TITLE
Eliminate -Wno-enum-compare-switch

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -622,11 +622,6 @@ if (is_win) {
     # Disables.
     "-Wno-missing-field-initializers",  # "struct foo f = {0};"
     "-Wno-unused-parameter",  # Unused function parameters.
-
-    # TODO(jsimmons): This is needed for building Flutter's current version of
-    # third_party/icu with the clang-6.0 toolchain.  Remove this when we upgrade
-    # to a more recent version of ICU.
-    "-Wno-enum-compare-switch",
   ]
 
   if (is_mac) {


### PR DESCRIPTION
Was required for third_party/icu under clang-6.0 but appears to be no
longer necessary after flutter/engine#4005. Originally introduced in
b9b34de.