### PR TITLE
Always use the x86_64 Android toolchain.

### DIFF
--- a/build/config/android/config.gni
+++ b/build/config/android/config.gni
@@ -54,10 +54,8 @@ if (is_android) {
 
   # Defines the name the Android build gives to the current host CPU
   # architecture, which is different than the names GN uses.
-  if (host_cpu == "x64") {
+  if (host_cpu == "x64" || host_cpu == "x86") {
     android_host_arch = "x86_64"
-  } else if (host_cpu == "x86") {
-    android_host_arch = "x86"
   } else {
     assert(false, "Need Android toolchain support for your build CPU arch.")
   }


### PR DESCRIPTION
This is a step towards removing the dart_host_toolchain GN argument. This selects the Android toolchain that runs on x86_64 even if host_cpu is x86. This matches what Dart does in its GN config for Android.