### PR TITLE
Fix the name of the 32 bit mac toolchain

### DIFF
--- a/build/toolchain/mac/BUILD.gn
+++ b/build/toolchain/mac/BUILD.gn
@@ -257,7 +257,7 @@ mac_toolchain("clang_x64") {
 }
 
 # Toolchain used for Mac host (i386) targets.
-mac_toolchain("clang_i386") {
+mac_toolchain("clang_x86") {
   toolchain_cpu = "i386"
   toolchain_os = "mac"
   prefix = rebase_path(llvm_bin_path, root_build_dir)


### PR DESCRIPTION
This will allow https://github.com/flutter/engine/pull/4308 to be relanded.