### PR TITLE
Revert disable -Wtautological-constant-compare

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -622,11 +622,6 @@ if (is_win) {
     # Disables.
     "-Wno-missing-field-initializers",  # "struct foo f = {0};"
     "-Wno-unused-parameter",  # Unused function parameters.
-
-    # TODO(cbracken): Temporarily disable this warning type because the current
-    # clang implementation is too agressive and is reporting cases that are
-    # generally safe. Remove once https://reviews.llvm.org/D39462 lands.
-    "-Wno-tautological-constant-compare",
   ]
 
   if (is_mac) {


### PR DESCRIPTION
This is required to revert the Fuchsia clang toolchain to an older
commit where this option does not yet exist.