### PR TITLE
Removed build flag which was causing issues on Windows

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -81,7 +81,6 @@ config("compiler") {
     # Windows compiler flags setup.
     # -----------------------------
     cflags += [
-      "/Gy",  # Enable function-level linking.
       "/GS",  # Enable buffer security checking.
       "/FS",  # Preserve previous PDB behavior.
     ]


### PR DESCRIPTION
Removed build flag which was causing issues on Windows when building SkJumper_generated_win.S.