### PR TITLE
Roll dart-sdk to 2.0.0-dev.16.0

### DIFF
--- a/tools/dart/update.py
+++ b/tools/dart/update.py
@@ -19,7 +19,7 @@ import zipfile
 # How to roll the dart sdk: Just change this url! We write this to the stamp
 # file after we download, and then check the stamp file for differences.
 SDK_URL_BASE = ('http://gsdview.appspot.com/dart-archive/channels/dev/raw/'
-                '1.25.0-dev.11.0/sdk/')
+                '2.0.0-dev.16.0/sdk/')
 
 LINUX_64_SDK = 'dartsdk-linux-x64-release.zip'
 MACOS_64_SDK = 'dartsdk-macos-x64-release.zip'


### PR DESCRIPTION
This is follow-up to https://github.com/flutter/engine/pull/4554 to fix https://build.chromium.org/p/client.flutter buildbots.