### PR TITLE
Remove support for XIBs on desktop Mac targets.

### DIFF
--- a/build/config/mac/rules.gni
+++ b/build/config/mac/rules.gni
@@ -7,10 +7,8 @@ mac_app_script = "//build/config/mac/mac_app.py"
 template("code_sign_mac") {
   assert(defined(invoker.entitlements_path),
          "The path to the entitlements .xcent file")
-  assert(defined(invoker.identity),
-         "The code signing identity")
-  assert(defined(invoker.application_path),
-         "The application to code sign")
+  assert(defined(invoker.identity), "The code signing identity")
+  assert(defined(invoker.application_path), "The application to code sign")
   assert(defined(invoker.deps))
 
   action(target_name) {
@@ -23,7 +21,7 @@ template("code_sign_mac") {
     script = mac_app_script
 
     outputs = [
-      "$_application_path/_CodeSignature/CodeResources"
+      "$_application_path/_CodeSignature/CodeResources",
     ]
 
     args = [
@@ -40,44 +38,12 @@ template("code_sign_mac") {
   }
 }
 
-template("process_nibs_mac") {
-  assert(defined(invoker.sources),
-         "The nib sources must be specified")
-  assert(defined(invoker.module),
-         "The nib module must be specified")
-  assert(defined(invoker.output_dir),
-         "The output directory must be specified")
-
-  action_foreach(target_name) {
-    sources = invoker.sources
-
-    script = mac_app_script
-
-    invoker_out_dir = invoker.output_dir
-
-    outputs = [
-      "$root_build_dir/$invoker_out_dir/{{source_name_part}}.nib"
-    ]
-
-    args = [
-      "nib",
-      "-i",
-      "{{source}}",
-      "-o",
-      rebase_path("$root_build_dir/$invoker_out_dir"),
-      "-m",
-      invoker.module,
-    ]
-  }
-}
-
 template("resource_copy_mac") {
   assert(defined(invoker.resources),
          "The source list of resources to copy over")
   assert(defined(invoker.bundle_directory),
          "The directory within the bundle to place the sources in")
-  assert(defined(invoker.app_name),
-         "The name of the application")
+  assert(defined(invoker.app_name), "The name of the application")
 
   _bundle_directory = invoker.bundle_directory
   _app_name = invoker.app_name
@@ -86,7 +52,9 @@ template("resource_copy_mac") {
   copy(target_name) {
     set_sources_assignment_filter([])
     sources = _resources
-    outputs = [ "$root_build_dir/$_app_name.app/$_bundle_directory/Contents/Resources/{{source_file_part}}" ]
+    outputs = [
+      "$root_build_dir/$_app_name.app/$_bundle_directory/Contents/Resources/{{source_file_part}}",
+    ]
 
     if (defined(invoker.deps)) {
       deps = invoker.deps
@@ -95,19 +63,12 @@ template("resource_copy_mac") {
 }
 
 template("mac_app") {
-
   assert(defined(invoker.deps),
          "Dependencies must be specified for $target_name")
   assert(defined(invoker.info_plist),
          "The application plist file must be specified for $target_name")
   assert(defined(invoker.app_name),
          "The name of Mac application for $target_name")
-  assert(defined(invoker.xibs),
-         "The list of XIB files must be specified for $target_name")
-  # assert(defined(invoker.entitlements_path),
-  #        "The entitlements path must be specified for $target_name")
-  # assert(defined(invoker.code_signing_identity),
-  #        "The entitlements path must be specified for $target_name")
 
   # We just create a variable so we can use the same in interpolation
   app_name = invoker.app_name
@@ -117,20 +78,20 @@ template("mac_app") {
   struct_gen_target_name = target_name + "_struct"
 
   action(struct_gen_target_name) {
-
     script = mac_app_script
 
     sources = []
-    outputs = [ "$root_build_dir/$app_name.app" ]
+    outputs = [
+      "$root_build_dir/$app_name.app",
+    ]
 
     args = [
       "structure",
       "-d",
       rebase_path(root_build_dir),
       "-n",
-      app_name
+      app_name,
     ]
-
   }
 
   # Generate the executable
@@ -147,11 +108,14 @@ template("mac_app") {
   plist_gen_target_name = target_name + "_plist"
 
   action(plist_gen_target_name) {
-
     script = mac_app_script
 
-    sources = [ invoker.info_plist ]
-    outputs = [ "$root_build_dir/plist/$app_name/Info.plist" ]
+    sources = [
+      invoker.info_plist,
+    ]
+    outputs = [
+      "$root_build_dir/plist/$app_name/Info.plist",
+    ]
 
     args = [
       "plist",
@@ -171,7 +135,7 @@ template("mac_app") {
     ]
 
     outputs = [
-      "$root_build_dir/$app_name.app/Contents/{{source_file_part}}"
+      "$root_build_dir/$app_name.app/Contents/{{source_file_part}}",
     ]
 
     deps = [
@@ -186,7 +150,7 @@ template("mac_app") {
     ]
 
     outputs = [
-      "$root_build_dir/$app_name.app/Contents/MacOS/{{source_file_part}}"
+      "$root_build_dir/$app_name.app/Contents/MacOS/{{source_file_part}}",
     ]
 
     deps = [
@@ -194,27 +158,20 @@ template("mac_app") {
     ]
   }
 
-  copy_xib_target_name = target_name + "_xib_copy"
-  process_nibs_mac(copy_xib_target_name) {
-    sources = invoker.xibs
-    module = app_name
-    output_dir = "$app_name.app/Contents/Resources"
-  }
-
   copy_all_target_name = target_name + "_all_copy"
   group(copy_all_target_name) {
     deps = [
-      ":$struct_gen_target_name",
-      ":$copy_plist_gen_target_name",
       ":$copy_bin_target_name",
-      ":$copy_xib_target_name",
+      ":$copy_plist_gen_target_name",
+      ":$struct_gen_target_name",
     ]
   }
 
   # Top level group
 
   group(target_name) {
-    deps = [ ":$copy_all_target_name" ]
+    deps = [
+      ":$copy_all_target_name",
+    ]
   }
-
 }


### PR DESCRIPTION
This is in preparation for the shell refactor. The desktop mac target no longer uses XIB files (and will be removed entirely in the future as the embedder API already supports everything necessary).