### PR TITLE
Enable -Wunguaraded-availability for iOS builds

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -623,7 +623,7 @@ if (is_win) {
     "-Wno-unused-parameter",  # Unused function parameters.
   ]
 
-  if (is_mac) {
+  if (is_mac || is_ios) {
     # TODO(abarth): Re-enable once https://github.com/domokit/mojo/issues/728
     #               is fixed.
     # default_warning_flags += [ "-Wnewline-eof" ]
@@ -631,7 +631,7 @@ if (is_win) {
       # When compiling Objective-C, warns if a method is used whose
       # availability is newer than the deployment target. This is not
       # required when compiling Chrome for iOS.
-      default_warning_flags += [ "-Wpartial-availability" ]
+      default_warning_flags += [ "-Wunguarded-availability" ]
     }
   }
 }


### PR DESCRIPTION
Ensures we don't accidentally add any dependencies on iOS APIs > iOS 8
without putting them behind an @available guard.

Note that -Wunguarded-availability implies the older
-Wpartial-availability (which is actually an alias for it in recent
clang toolchains).