### PR TITLE
Eliminate is_nacl from build config

### DIFF
--- a/build/config/BUILD.gn
+++ b/build/config/BUILD.gn
@@ -87,10 +87,6 @@ config("debug") {
     "WTF_USE_DYNAMIC_ANNOTATIONS=1",
   ]
 
-  if (is_nacl) {
-    defines += [ "DYNAMIC_ANNOTATIONS_PREFIX=NACL_" ]
-  }
-
   if (is_win) {
     if (disable_iterator_debugging) {
       # Iterator debugging is enabled by the compiler on debug builds, and we
@@ -119,11 +115,7 @@ config("release") {
     ]
   } else {
     defines += [ "NVALGRIND" ]
-    if (!is_nacl) {
-      # NaCl always enables dynamic annotations. Currently this value is set to
-      # 1 for all .nexes.
-      defines += [ "DYNAMIC_ANNOTATIONS_ENABLED=0" ]
-    }
+    defines += [ "DYNAMIC_ANNOTATIONS_ENABLED=0" ]
   }
 }
 

--- a/build/config/BUILDCONFIG.gn
+++ b/build/config/BUILDCONFIG.gn
@@ -188,7 +188,6 @@ if (current_os == "win") {
   is_ios = false
   is_linux = false
   is_mac = false
-  is_nacl = false
   is_posix = false
   is_win = true
 } else if (current_os == "mac") {
@@ -200,7 +199,6 @@ if (current_os == "win") {
   is_ios = false
   is_linux = false
   is_mac = true
-  is_nacl = false
   is_posix = true
   is_win = false
 } else if (current_os == "android") {
@@ -212,7 +210,6 @@ if (current_os == "win") {
   is_ios = false
   is_linux = false
   is_mac = false
-  is_nacl = false
   is_posix = true
   is_win = false
 } else if (current_os == "chromeos") {
@@ -224,7 +221,6 @@ if (current_os == "win") {
   is_ios = false
   is_linux = true
   is_mac = false
-  is_nacl = false
   is_posix = true
   is_win = false
 } else if (current_os == "nacl") {
@@ -239,7 +235,6 @@ if (current_os == "win") {
   is_ios = false
   is_linux = false
   is_mac = false
-  is_nacl = true
   is_posix = true
   is_win = false
 } else if (current_os == "ios") {
@@ -251,7 +246,6 @@ if (current_os == "win") {
   is_ios = true
   is_linux = false
   is_mac = false
-  is_nacl = false
   is_posix = true
   is_win = false
 } else if (current_os == "linux") {
@@ -263,7 +257,6 @@ if (current_os == "win") {
   is_ios = false
   is_linux = true
   is_mac = false
-  is_nacl = false
   is_posix = true
   is_win = false
 } else if (current_os == "fuchsia") {
@@ -274,7 +267,6 @@ if (current_os == "win") {
   is_ios = false
   is_linux = true
   is_mac = false
-  is_nacl = false
   is_posix = true
   is_win = false
 }
@@ -625,12 +617,6 @@ if (is_win) {
   } else {
     set_default_toolchain("//build/toolchain/mac:ios_clang_arm")
   }
-} else if (is_nacl) {
-  # TODO(GYP): This will need to change when we get NaCl working
-  # on multiple platforms, but this whole block of code (how we define
-  # host_toolchain) needs to be reworked regardless to key off of host_os
-  # and host_cpu rather than the is_* variables.
-  host_toolchain = "//build/toolchain/linux:clang_x64"
 }
 
 # ==============================================================================

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -624,15 +624,10 @@ if (is_win) {
   ]
 
   if (is_mac || is_ios) {
-    # TODO(abarth): Re-enable once https://github.com/domokit/mojo/issues/728
-    #               is fixed.
-    # default_warning_flags += [ "-Wnewline-eof" ]
-    if (!is_nacl) {
-      # When compiling Objective-C, warns if a method is used whose
-      # availability is newer than the deployment target. This is not
-      # required when compiling Chrome for iOS.
-      default_warning_flags += [ "-Wunguarded-availability" ]
-    }
+    # When compiling Objective-C, warns if a method is used whose
+    # availability is newer than the deployment target. This is not
+    # required when compiling Chrome for iOS.
+    default_warning_flags += [ "-Wunguarded-availability" ]
   }
 }
 


### PR DESCRIPTION
Given our lack of use of NaCL and its deprecation, eliminating it seems
like generally not a bad idea.