### PR TITLE
Move downloaed dart in flutter engine to dev.47 form dev.20.

### DIFF
--- a/tools/dart/update.py
+++ b/tools/dart/update.py
@@ -19,7 +19,7 @@ import zipfile
 # How to roll the dart sdk: Just change this url! We write this to the stamp
 # file after we download, and then check the stamp file for differences.
 SDK_URL_BASE = ('http://gsdview.appspot.com/dart-archive/channels/dev/raw/'
-                '2.0.0-dev.20.0/sdk/')
+                '2.0.0-dev.47.0/sdk/')
 
 LINUX_64_SDK = 'dartsdk-linux-x64-release.zip'
 MACOS_64_SDK = 'dartsdk-macos-x64-release.zip'


### PR DESCRIPTION
This is needed to build engine after dart sdk commit 973a1a0219 as without this compile_platform complains about `jsonEncode`:

```
python ../../third_party/dart/tools/compile_platform.py --target=flutter --strong dart:core ../../flutter/lib/snapshot/libraries.json flutter_patched_sdk/platform_strong.dill flutter_patched_sdk/vm_outline_strong.dill
Unhandled exception:
NoSuchMethodError: No top-level method 'jsonEncode' declared.
Receiver: top-level
Tried calling: jsonEncode(_LinkedHashMap len:4)
#0      NoSuchMethodError._throwNew (dart:core-patch/dart:core/errors_patch.dart:192)
#1      reportCrash (package:front_end/src/fasta/deprecated_problems.dart:119:17)
````