### PR TITLE
Ensure Clang produces Build IDs so that matching matching dylibs with symbols is easier.

### DIFF
--- a/build/toolchain/gcc_toolchain.gni
+++ b/build/toolchain/gcc_toolchain.gni
@@ -147,8 +147,7 @@ template("gcc_toolchain") {
       # existing .TOC file, overwrite it, otherwise, don't change it.
       tocfile = sofile + ".TOC"
       temporary_tocname = sofile + ".tmp"
-      link_command =
-          "$ld -shared {{ldflags}} -o $sofile -Wl,-soname=$soname @$rspfile"
+      link_command = "$ld -shared {{ldflags}} -o $sofile -Wl,--build-id -Wl,-soname=$soname @$rspfile"
       toc_command = "{ $readelf -d $sofile | grep SONAME ; $nm -gD -f p $sofile | cut -f1-2 -d' '; } > $temporary_tocname"
       replace_command = "if ! cmp -s $temporary_tocname $tocfile; then mv $temporary_tocname $tocfile; fi"
 
@@ -198,10 +197,11 @@ template("gcc_toolchain") {
         unstripped_outfile = "{{root_out_dir}}/exe.unstripped/$exename"
       }
 
-      command = "$ld {{ldflags}} -o $unstripped_outfile -Wl,--start-group @$rspfile {{solibs}} -Wl,--end-group $libs_section_prefix {{libs}} $libs_section_postfix"
+      command = "$ld {{ldflags}} -o $unstripped_outfile -Wl,--build-id -Wl,--start-group @$rspfile {{solibs}} -Wl,--end-group $libs_section_prefix {{libs}} $libs_section_postfix"
       if (defined(invoker.strip)) {
         strip = invoker.strip
-        strip_command = "${strip} --strip-unneeded -o $outfile $unstripped_outfile"
+        strip_command =
+            "${strip} --strip-unneeded -o $outfile $unstripped_outfile"
         command += " && " + strip_command
       }
       if (defined(invoker.postlink)) {


### PR DESCRIPTION
This is already the default in GCC.