### PR TITLE
Revert "Remove ldflag no longer necessary with the new toolchain. (#1…

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -394,12 +394,6 @@ config("compiler") {
   # Android-specific flags setup.
   # -----------------------------
   if (is_android) {
-    # Use stdinc++ from the NDK.
-    cflags += [
-      "-nostdinc++"
-    ]
-
-    # Common Android flags
     cflags += [
       "-ffunction-sections",
       "-funwind-tables",
@@ -583,6 +577,7 @@ config("runtime_library") {
       # Remove one the toolchain distribution is fixed
       # https://github.com/flutter/flutter/issues/6145
       "-Wl,-Bstatic",
+      "-lc++abi",
       "-Wl,-Bdynamic",
       "-fuse-ld=lld",
     ]


### PR DESCRIPTION
…37)"

This reverts commit 92c86d0e042d3a51c408486f81f29693ecca3611.

Revert "Use -nostdinc++ on Android since those headers need to be picked up from the NDK. (#136)"

This reverts commit 634be5f235e38b92aaac38c8f76f9d4e34f11b6b.

Because buildtools has not been rolled, these interfer with rolling the Windows GN change.