### PR TITLE
Bump up Mac min SDK version to 10.12.

### DIFF
--- a/build/config/mac/mac_sdk.gni
+++ b/build/config/mac/mac_sdk.gni
@@ -4,7 +4,7 @@
 
 declare_args() {
   # Minimum supported version of the Mac SDK.
-  mac_sdk_min = "10.10"
+  mac_sdk_min = "10.12"
 
   # Path to a specific version of the Mac SDKJ, not including a backslash at
   # the end. If empty, the path to the lowest version greater than or equal to


### PR DESCRIPTION
This is required for some hosts test for the upcoming Abseil dependency. @cbracken says this is safe.