### PR TITLE
Follow-up to switch to Fuchsia's ICU

### DIFF
--- a/build/config/BUILD.gn
+++ b/build/config/BUILD.gn
@@ -236,7 +236,7 @@ config("precompiled_headers") {
 config("symbol_visibility_hidden") {
   # Note that -fvisibility-inlines-hidden is set globally in the compiler
   # config since that can almost always be applied.
-  if (!enable_profiling) {
+  if (is_posix && !enable_profiling) {
     cflags = [ "-fvisibility=hidden" ]
   }
 }

--- a/build/config/BUILDCONFIG.gn
+++ b/build/config/BUILDCONFIG.gn
@@ -413,6 +413,7 @@ _native_compiler_configs = [
   "//build/config/compiler:default_include_dirs",
   "//build/config/compiler:runtime_library",
   "//build/config:no_rtti",
+  "//build/config:symbol_visibility_hidden",
 ]
 if (is_win) {
   _native_compiler_configs += [
@@ -426,7 +427,6 @@ if (is_win) {
 if (is_posix) {
   _native_compiler_configs += [
     "//build/config/gcc:no_exceptions",
-    "//build/config:symbol_visibility_hidden",
   ]
 }
 


### PR DESCRIPTION
Follow-up to https://github.com/flutter/buildroot/pull/150.

The ICU target expects to be able to always remove the `//build/config:symbol_visibility_hidden,` config. However, previously it wasn't added on Windows and the removal would fail. This adds a dummy `//build/config:symbol_visibility_hidden,` config when we are on Windows, which can then be removed by the ICU target without errors.