### PR TITLE
Revert "Remove explicit whitelists for GN check. All our targets pass checks."

### DIFF
--- a/.gn
+++ b/.gn
@@ -8,3 +8,15 @@ buildconfig = "//build/config/BUILDCONFIG.gn"
 # GN build files are placed when they can not be placed directly
 # in the source tree, e.g. for third party source trees.
 secondary_source = "//build/secondary/"
+
+# The set of targets known to pass 'gn check'. When all targets pass, remove
+# this.
+check_targets = [
+  "//dart/*",
+  "//flow/*",
+  "//flutter/*",
+  "//glue/*",
+  "//mojo/*",
+  "//skia/*",
+  "//sky/*",
+]


### PR DESCRIPTION
Reverts flutter/buildroot#157

This breaks the engine on Windows: https://uberchromegw.corp.google.com/i/client.flutter/builders/Windows%20Engine/builds/2504.