### PR TITLE
Prepare for new clang version

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -397,6 +397,7 @@ config("compiler") {
       "-ffunction-sections",
       "-funwind-tables",
       "-fno-short-enums",
+      "-nostdinc++"
     ]
     if (!is_clang) {
       # Clang doesn't support these flags.


### PR DESCRIPTION
Working towards enabling LTO on Android.

Without this flag, the new clang implicitly adds `buildtools/mac-x64/clang/lib/clang/8.0.0/include/c++/v1` or `buildtools/mac-x64/clang/include/c++/v1` as an include directory, which clashes with headers provided by the Android NDK.

Related issue https://github.com/android-ndk/ndk/issues/564.