### PR TITLE
Enable LTO for Android

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -17,6 +17,7 @@ if (is_win) {
 }
 
 import("//build/toolchain/ccache.gni")
+import("//build/toolchain/clang.gni")
 import("//build/config/profiler.gni")
 import("//build/config/sanitizers/sanitizers.gni")
 
@@ -797,7 +798,7 @@ if (is_win) {
     common_optimize_on_ldflags += [
       # Specifically tell the linker to perform optimizations.
       # See http://lwn.net/Articles/192624/ .
-      "-Wl,-O1",
+      "-Wl,-O2",
       "-Wl,--gc-sections",
     ]
 
@@ -812,16 +813,23 @@ if (is_win) {
 
 # Default "optimization on" config. On Windows, this favors size over speed.
 config("optimize") {
+  lto_flags = []
   if (is_win) {
     # Favor size over speed, /O1 must be before the common flags. The GYP
     # build also specifies /Os and /GF but these are implied by /O1.
     cflags = [ "/O1" ] + common_optimize_on_cflags + [ "/Oi" ]
-  } else if (is_android || is_ios) {
+  } else if (is_ios) {
     cflags = [ "-Os" ] + common_optimize_on_cflags  # Favor size over speed.
+  } else if (is_android) {
+    cflags = [ "-Oz" ] + common_optimize_on_cflags  # Favor size over speed.
+    if (enable_lto) {
+      lto_flags += [ "-flto" ]
+    }
   } else {
     cflags = [ "-O2" ] + common_optimize_on_cflags
   }
-  ldflags = common_optimize_on_ldflags
+  ldflags = common_optimize_on_ldflags + lto_flags
+  cflags += lto_flags
 }
 
 # Turn off optimizations.


### PR DESCRIPTION
Size reductions of libflutter.so:
* uncompressed: -412KB (from 6MB to 5.6MB)
* compressed: -243KB (from 3.3MB to 3MB)

Fixes https://github.com/flutter/flutter/issues/16538.