### PR TITLE
Disable LTO

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -822,9 +822,10 @@ config("optimize") {
     cflags = [ "-Os" ] + common_optimize_on_cflags  # Favor size over speed.
   } else if (is_android) {
     cflags = [ "-Oz" ] + common_optimize_on_cflags  # Favor size over speed.
-    if (enable_lto) {
-      lto_flags += [ "-flto" ]
-    }
+    # TODO(goderbauer): re-enable when  https://github.com/flutter/flutter/issues/21686 is fixed
+    # if (enable_lto) {
+    #   lto_flags += [ "-flto" ]
+    # }
   } else {
     cflags = [ "-O2" ] + common_optimize_on_cflags
   }


### PR DESCRIPTION
It's causing the buildbots to hang while generating treemaps, see https://github.com/flutter/flutter/issues/21686.