### PR TITLE
Add missing android_only_explicit_jni_exports.lst

### DIFF
--- a/build/android/android_only_explicit_jni_exports.lst
+++ b/build/android/android_only_explicit_jni_exports.lst
@@ -1,0 +1,14 @@
+# Copyright 2017 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# Linker script that exports only JNI_OnLoad.
+# Should be used for libraries that do explicit JNI registration.
+
+{
+  global:
+    JNI_OnLoad;
+  local:
+    *;
+};
+


### PR DESCRIPTION
Was supposed to be part of https://github.com/flutter/buildroot/pull/167.