### PR TITLE
Specify -object_path_lto to enable dsym generation

### DIFF
--- a/build/toolchain/mac/BUILD.gn
+++ b/build/toolchain/mac/BUILD.gn
@@ -145,8 +145,10 @@ template("mac_toolchain") {
       tocname = dylib + ".TOC"
       temporary_tocname = dylib + ".tmp"
 
+      lto_object_file = "{{root_out_dir}}/lto_{{target_output_name}}.o"
+
       does_reexport_command = "[ ! -e $dylib -o ! -e $tocname ] || otool -l $dylib | grep -q LC_REEXPORT_DYLIB"
-      link_command = "$ld -shared $sysroot_flags $toolchain_flags $lto_flags {{ldflags}} -o $dylib -Wl,-filelist,$rspfile {{solibs}} {{libs}}"
+      link_command = "$ld -shared $sysroot_flags $toolchain_flags $lto_flags -Wl,-object_path_lto,$lto_object_file {{ldflags}} -o $dylib -Wl,-filelist,$rspfile {{solibs}} {{libs}}"
       replace_command = "if ! cmp -s $temporary_tocname $tocname; then mv $temporary_tocname $tocname"
       extract_toc_command = "{ otool -l $dylib | grep LC_ID_DYLIB -A 5; nm -gP $dylib | cut -f1-2 -d' ' | grep -v U\$\$; true; }"
 


### PR DESCRIPTION
Without this option the linker generates /tmp/lto.o and deletes it once the link is done. However, dsymutil needs this file to properly generate .dSYM files. The option keeps the file around.

Fixes the following error during the dsymutil run reported in https://github.com/flutter/flutter/issues/12012#issuecomment-335254085.

```
/tmp/lto.o unable to open object file: No such file or directory
```