### PR TITLE
Add compiler flags suggested by security review (#4368)

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -432,7 +432,7 @@ config("compiler") {
     }
 
     defines += [ "ANDROID" ]
-    
+
     # The NDK has these things, but doesn't define the constants
     # to say that it does. Define them here instead.
     defines += [ "HAVE_SYS_UIO_H" ]
@@ -840,11 +840,9 @@ config("optimize") {
     # build also specifies /Os and /GF but these are implied by /O1.
     cflags = [ "/O1" ] + common_optimize_on_cflags + [ "/Oi" ]
   } else if (is_ios) {
-    # Favor size over speed
-    cflags = [ "-Os" ] + common_optimize_on_cflags 
+    cflags = [ "-Os" ] + common_optimize_on_cflags  # Favor size over speed.
   } else if (is_android) {
-    # Favor size over speed 
-    cflags = [ "-Oz" ] + common_optimize_on_cflags  
+    cflags = [ "-Oz" ] + common_optimize_on_cflags  # Favor size over speed.
     # TODO(goderbauer): re-enable when  https://github.com/flutter/flutter/issues/21686 is fixed
     # if (enable_lto) {
     #   lto_flags += [ "-flto" ]

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -96,7 +96,7 @@ config("compiler") {
     cflags_objcc += common_flags
 
     # Stack protection.
-    if (is_mac) {
+    if (is_mac || is_android) {
       cflags += [ "-fstack-protector-all" ]
     } else if (is_linux) {
       cflags += [
@@ -338,12 +338,10 @@ config("compiler") {
   # ---------------------------------
   if (is_linux || is_android) {
     cflags += [
-      "-fPIC",
       "-pipe",  # Use pipes for communicating between sub-processes. Faster.
     ]
 
     ldflags += [
-      "-fPIC",
       "-Wl,-z,noexecstack",
       "-Wl,-z,now",
       "-Wl,-z,relro",
@@ -356,8 +354,14 @@ config("compiler") {
   # Linux-specific compiler flags setup.
   # ------------------------------------
   if (is_linux) {
-    cflags += [ "-pthread" ]
-    ldflags += [ "-pthread" ]
+    cflags += [
+      "-pthread",
+      "-fPIC"
+    ]
+    ldflags += [
+      "-pthread",
+      "-fPIC"
+    ]
 
     if (current_cpu == "arm64") {
       cflags += [ "--target=aarch64-linux-gnu" ]
@@ -391,14 +395,29 @@ config("compiler") {
   cflags_cc += cc_std
   cflags_objcc += cc_std
 
+  # iOS-specific flags setup.
+  # -----------------------------
+  if (is_ios) {
+    cflags += [
+      "-fPIE"
+    ]
+    ldflags += [
+      "-pie"
+    ]
+  }
+
   # Android-specific flags setup.
   # -----------------------------
   if (is_android) {
     cflags += [
+      "-fPIE",
       "-ffunction-sections",
       "-funwind-tables",
       "-fno-short-enums",
-      "-nostdinc++"
+      "-nostdinc++",
+      "-Wa,--noexecstack",
+      "-Wformat",
+      "-Wformat-security"
     ]
     if (!is_clang) {
       # Clang doesn't support these flags.
@@ -413,7 +432,7 @@ config("compiler") {
     }
 
     defines += [ "ANDROID" ]
-
+    
     # The NDK has these things, but doesn't define the constants
     # to say that it does. Define them here instead.
     defines += [ "HAVE_SYS_UIO_H" ]
@@ -425,9 +444,11 @@ config("compiler") {
     }
 
     ldflags += [
+      "-pie",
       "-Wl,--no-undefined",
       "-Wl,--exclude-libs,ALL",
-      "-fuse-ld=lld",
+      "-Wl,-z,relro,-z,now",
+      "-fuse-ld=lld"
     ]
     if (current_cpu == "arm") {
       ldflags += [
@@ -653,7 +674,7 @@ config("chromium_code") {
       "__STDC_FORMAT_MACROS",
     ]
 
-    if (!using_sanitizer && (!is_linux || !is_clang)) {
+    if (is_ios || is_android || (!using_sanitizer && (!is_linux || !is_clang))) {
       # _FORTIFY_SOURCE isn't really supported by Clang now, see
       # http://llvm.org/bugs/show_bug.cgi?id=16821.
       # It seems to work fine with Ubuntu 12 headers though, so use it in
@@ -819,12 +840,15 @@ config("optimize") {
     # build also specifies /Os and /GF but these are implied by /O1.
     cflags = [ "/O1" ] + common_optimize_on_cflags + [ "/Oi" ]
   } else if (is_ios) {
-    cflags = [ "-Os" ] + common_optimize_on_cflags  # Favor size over speed.
+    # Favor size over speed
+    cflags = [ "-Os" ] + common_optimize_on_cflags 
   } else if (is_android) {
-    cflags = [ "-Oz" ] + common_optimize_on_cflags  # Favor size over speed.
-    if (enable_lto) {
-      lto_flags += [ "-flto" ]
-    }
+    # Favor size over speed 
+    cflags = [ "-Oz" ] + common_optimize_on_cflags  
+    # TODO(goderbauer): re-enable when  https://github.com/flutter/flutter/issues/21686 is fixed
+    # if (enable_lto) {
+    #   lto_flags += [ "-flto" ]
+    # }
   } else {
     cflags = [ "-O2" ] + common_optimize_on_cflags
   }

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -843,10 +843,9 @@ config("optimize") {
     cflags = [ "-Os" ] + common_optimize_on_cflags  # Favor size over speed.
   } else if (is_android) {
     cflags = [ "-Oz" ] + common_optimize_on_cflags  # Favor size over speed.
-    # TODO(goderbauer): re-enable when  https://github.com/flutter/flutter/issues/21686 is fixed
-    # if (enable_lto) {
-    #   lto_flags += [ "-flto" ]
-    # }
+    if (enable_lto) {
+      lto_flags += [ "-flto" ]
+    }
   } else {
     cflags = [ "-O2" ] + common_optimize_on_cflags
   }


### PR DESCRIPTION
In [4368](https://github.com/flutter/flutter/issues/4368) it's recommended that we build binaries with the following flags that provide security benefits:

- stack cookies to prevent stack overflow (`-fstack_protector_all`)
- read-only relocations (`-Wl,z,relro`),
- `BIND_NOW` to protect the global offset table from being overwritten (`-Wl,-z,now`)
- Position independent executable code generation (`-fPIE`, `-pie`).
- `FORTIFY_SOURCE` to protect from common misuse of memory and string functions. There is an existing comment that FORTIFY_SOURCE appears to have problems with clang, but that's with an unused optimization level (`-O1`) that does not appear to be pertinent to this work. However, I left in the comment should we choose to adjust the optimization levels in the future.

(For a more detailed if slightly dated explanation of what these flags do, see [here](http://developer.blackberry.com/playbook/native/documentation/com.qnx.doc.native_sdk.security/topic/using_compiler_linker_defenses.html).)

Due to size constraints, I did not add the suggested optimization flag (`-O2`) listed in the original issue, per discussions with @goderbauer on the issue.

Changes were applied to the Android binary compilation flags, and relevant changes applied to the iOS compilation flags (stack cookies, offset table and read-only relocations are not supported by the iOS tools). Note that iOS generates code in a position-independent executable way by default, but I explicitly add those directives in a new iOS flag block for future reviewers.