### PR TITLE
Turn icf on for all android builds

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -428,13 +428,9 @@ config("compiler") {
       "-Wl,--no-undefined",
       "-Wl,--exclude-libs,ALL",
       "-fuse-ld=lld",
+      # Enable identical code folding to reduce size.
+      "-Wl,--icf=all",
     ]
-    if (current_cpu == "arm") {
-      ldflags += [
-        # Enable identical code folding to reduce size.
-        "-Wl,--icf=all",
-      ]
-    }
 
     if (is_clang) {
       if (current_cpu == "arm") {


### PR DESCRIPTION
Reduces size of arm64 `libflutter.so` by 265,712 Bytes (259.58KB) down to 8,639,624 Bytes (8.24MB).

Unfortunatelly, Apple's `ld` doesn't support icf :(