### PR TITLE
Revert "Switches Android to ThinLTO and optimizes LTO for space"

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -810,7 +810,6 @@ if (is_win) {
 # Default "optimization on" config. On Windows, this favors size over speed.
 config("optimize") {
   lto_flags = []
-  ld_lto_flags = []
   if (is_win) {
     # Favor size over speed, /O1 must be before the common flags. The GYP
     # build also specifies /Os and /GF but these are implied by /O1.
@@ -820,13 +819,12 @@ config("optimize") {
   } else if (is_android) {
     cflags = [ "-Oz" ] + common_optimize_on_cflags  # Favor size over speed.
     if (enable_lto) {
-      lto_flags += [ "-flto=thin" ]
-      ld_lto_flags += [ "-Wl,--lto-O0" ]  # Favor size over speed.
+      lto_flags += [ "-flto" ]
     }
   } else {
     cflags = [ "-O2" ] + common_optimize_on_cflags
   }
-  ldflags = common_optimize_on_ldflags + lto_flags + ld_lto_flags
+  ldflags = common_optimize_on_ldflags + lto_flags
   cflags += lto_flags
 }
 


### PR DESCRIPTION
Reverts flutter/buildroot#179

Reason: The compressed binaries are actually larger with these LTO settings.