### PR TITLE
Fix buildbots by not adding unsupported flags when building on Mac.

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -415,9 +415,12 @@ config("compiler") {
       "-funwind-tables",
       "-fno-short-enums",
       "-nostdinc++",
-      "-Wa,--noexecstack",
+
+      # TODO(kf6gpe): -Wa,--noexecstack is not supported by the Mac toolchain
+      # with targeting Android. https://github.com/flutter/flutter/issues/23606
+      # "-Wa,--noexecstack",
       "-Wformat",
-      "-Wformat-security"
+      "-Wformat-security",
     ]
     if (!is_clang) {
       # Clang doesn't support these flags.


### PR DESCRIPTION
Fixes buildbots. Flag added as part of https://github.com/flutter/buildroot/pull/177. Issue filed to track reapplication https://github.com/flutter/flutter/issues/23606.