### PR TITLE
Revert "Add compiler flags suggested by security review (#4368) (#177)"

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -96,7 +96,7 @@ config("compiler") {
     cflags_objcc += common_flags
 
     # Stack protection.
-    if (is_mac || is_android) {
+    if (is_mac) {
       cflags += [ "-fstack-protector-all" ]
     } else if (is_linux) {
       cflags += [
@@ -338,10 +338,12 @@ config("compiler") {
   # ---------------------------------
   if (is_linux || is_android) {
     cflags += [
+      "-fPIC",
       "-pipe",  # Use pipes for communicating between sub-processes. Faster.
     ]
 
     ldflags += [
+      "-fPIC",
       "-Wl,-z,noexecstack",
       "-Wl,-z,now",
       "-Wl,-z,relro",
@@ -354,14 +356,8 @@ config("compiler") {
   # Linux-specific compiler flags setup.
   # ------------------------------------
   if (is_linux) {
-    cflags += [
-      "-pthread",
-      "-fPIC"
-    ]
-    ldflags += [
-      "-pthread",
-      "-fPIC"
-    ]
+    cflags += [ "-pthread" ]
+    ldflags += [ "-pthread" ]
 
     if (current_cpu == "arm64") {
       cflags += [ "--target=aarch64-linux-gnu" ]
@@ -395,32 +391,14 @@ config("compiler") {
   cflags_cc += cc_std
   cflags_objcc += cc_std
 
-  # iOS-specific flags setup.
-  # -----------------------------
-  if (is_ios) {
-    cflags += [
-      "-fPIE"
-    ]
-    ldflags += [
-      "-pie"
-    ]
-  }
-
   # Android-specific flags setup.
   # -----------------------------
   if (is_android) {
     cflags += [
-      "-fPIE",
       "-ffunction-sections",
       "-funwind-tables",
       "-fno-short-enums",
       "-nostdinc++",
-
-      # TODO(kf6gpe): -Wa,--noexecstack is not supported by the Mac toolchain
-      # with targeting Android. https://github.com/flutter/flutter/issues/23606
-      # "-Wa,--noexecstack",
-      "-Wformat",
-      "-Wformat-security",
     ]
     if (!is_clang) {
       # Clang doesn't support these flags.
@@ -447,12 +425,9 @@ config("compiler") {
     }
 
     ldflags += [
-      "-pie",
       "-Wl,--no-undefined",
       "-Wl,--exclude-libs,ALL",
-      "-Wl,-z,relro,-z,now",
       "-fuse-ld=lld",
-
       # Enable identical code folding to reduce size.
       "-Wl,--icf=all",
     ]
@@ -674,7 +649,7 @@ config("chromium_code") {
       "__STDC_FORMAT_MACROS",
     ]
 
-    if (is_ios || is_android || (!using_sanitizer && (!is_linux || !is_clang))) {
+    if (!using_sanitizer && (!is_linux || !is_clang)) {
       # _FORTIFY_SOURCE isn't really supported by Clang now, see
       # http://llvm.org/bugs/show_bug.cgi?id=16821.
       # It seems to work fine with Ubuntu 12 headers though, so use it in


### PR DESCRIPTION
This reverts commit 9bbd43537961a12b1a4f164cb0dc2c52e5ee6d31.

This caused major regressions, see https://github.com/flutter/flutter/issues/23678.

In the future, we can check the flags individually to see which we can add without regressing our benchmarks. 