### PR TITLE
 Reland "Compile libcxx and libcxxabi (#190)"

### DIFF
--- a/build/config/BUILDCONFIG.gn
+++ b/build/config/BUILDCONFIG.gn
@@ -632,6 +632,31 @@ if (custom_toolchain != "") {
   }
 }
 
+# Sets default dependencies for executable and shared_library targets.
+#
+# Variables
+#   no_default_deps: If true, no standard dependencies will be added.
+if (is_android) {
+  foreach(_target_type,
+          [
+            "executable",
+            "loadable_module",
+            "shared_library",
+          ]) {
+    template(_target_type) {
+      target(_target_type, target_name) {
+        forward_variables_from(invoker, "*", [ "no_default_deps" ])
+        if (!defined(deps)) {
+          deps = []
+        }
+        if (!defined(invoker.no_default_deps) || !invoker.no_default_deps) {
+          deps += [ "//third_party/libcxx" ]
+        }
+      }
+    }
+  }
+}
+
 # ==============================================================================
 # COMPONENT SETUP
 # ==============================================================================

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -520,10 +520,6 @@ config("runtime_library") {
     # strange errors. The include ordering here is important; change with
     # caution.
     cflags += [
-      "-isystem" + rebase_path("$android_libcpp_root/include", root_build_dir),
-      "-isystem" + rebase_path(
-              "$android_ndk_root/sources/cxx-stl/llvm-libc++abi/include",
-              root_build_dir),
       "-isystem" +
           rebase_path("$android_ndk_root/sources/android/support/include",
                       root_build_dir),
@@ -533,12 +529,13 @@ config("runtime_library") {
       "-D__ANDROID_API__=$android_api_level",
     ]
 
-    lib_dirs += [ "$android_libcpp_root/libs/$android_app_abi" ]
-
-    libs += [
-      "$android_libcpp_library",
-      "c++abi",
+    include_dirs = [
+      "//third_party/libcxx/include",
+      "//third_party/libcxxabi/include",
     ]
+
+    # libunwind and libandroid_support also live in $android_libcpp_root.
+    lib_dirs += [ "$android_libcpp_root/libs/$android_app_abi" ]
 
     if (android_api_level < 21) {
       libs += [ "android_support" ]

--- a/build/secondary/third_party/libcxx/BUILD.gn
+++ b/build/secondary/third_party/libcxx/BUILD.gn
@@ -1,0 +1,63 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+config("libcxx_config") {
+  include_dirs = [ "include" ]
+}
+
+source_set("libcxx") {
+  sources = [
+    "src/algorithm.cpp",
+    "src/any.cpp",
+    "src/bind.cpp",
+    "src/chrono.cpp",
+    "src/condition_variable.cpp",
+    "src/debug.cpp",
+    "src/exception.cpp",
+    "src/functional.cpp",
+    "src/future.cpp",
+    "src/hash.cpp",
+    "src/ios.cpp",
+    "src/iostream.cpp",
+    "src/locale.cpp",
+    "src/memory.cpp",
+    "src/mutex.cpp",
+    "src/new.cpp",
+    "src/optional.cpp",
+    "src/random.cpp",
+    "src/regex.cpp",
+    "src/shared_mutex.cpp",
+    "src/stdexcept.cpp",
+    "src/string.cpp",
+    "src/strstream.cpp",
+    "src/system_error.cpp",
+    "src/thread.cpp",
+    "src/typeinfo.cpp",
+    "src/utility.cpp",
+    "src/valarray.cpp",
+    "src/variant.cpp",
+    "src/vector.cpp",
+  ]
+
+  deps = [
+    "//third_party/libcxxabi",
+  ]
+
+  public_configs = [
+    ":libcxx_config",
+    "//third_party/libcxxabi:libcxxabi_config",
+  ]
+
+  defines = [
+    "_LIBCPP_NO_EXCEPTIONS",
+    "_LIBCPP_NO_RTTI",
+    "_LIBCPP_BUILDING_LIBRARY",
+    "LIBCXX_BUILDING_LIBCXXABI",
+  ]
+
+  if (is_clang) {
+    # shared_mutex.cpp and debug.cpp are purposefully in violation.
+    cflags_cc = [ "-Wno-thread-safety-analysis" ]
+  }
+}

--- a/build/secondary/third_party/libcxx/BUILD.gn
+++ b/build/secondary/third_party/libcxx/BUILD.gn
@@ -44,6 +44,12 @@ source_set("libcxx") {
     "//third_party/libcxxabi",
   ]
 
+  # TODO(goderbauer): remove when all sources build with LTO for android_arm64.
+  if (is_android && current_cpu == "arm64") {
+    sources -= [ "src/new.cpp" ]
+    deps += [ ":libcxx_nolto" ]
+  }
+
   public_configs = [
     ":libcxx_config",
     "//third_party/libcxxabi:libcxxabi_config",
@@ -60,4 +66,30 @@ source_set("libcxx") {
     # shared_mutex.cpp and debug.cpp are purposefully in violation.
     cflags_cc = [ "-Wno-thread-safety-analysis" ]
   }
+}
+
+source_set("libcxx_nolto") {
+  visibility = [ ":*" ]
+
+  sources = [
+    "src/new.cpp",
+  ]
+
+  cflags_cc = [ "-fno-lto" ]
+
+  deps = [
+    "//third_party/libcxxabi",
+  ]
+
+  public_configs = [
+    ":libcxx_config",
+    "//third_party/libcxxabi:libcxxabi_config",
+  ]
+
+  defines = [
+    "_LIBCPP_NO_EXCEPTIONS",
+    "_LIBCPP_NO_RTTI",
+    "_LIBCPP_BUILDING_LIBRARY",
+    "LIBCXX_BUILDING_LIBCXXABI",
+  ]
 }

--- a/build/secondary/third_party/libcxxabi/BUILD.gn
+++ b/build/secondary/third_party/libcxxabi/BUILD.gn
@@ -9,7 +9,7 @@ config("libcxxabi_config") {
 }
 
 source_set("libcxxabi") {
-  visibility = [ "../libcxx" ]
+  visibility = [ "../libcxx:*" ]
 
   sources = [
     "src/abort_message.cpp",

--- a/build/secondary/third_party/libcxxabi/BUILD.gn
+++ b/build/secondary/third_party/libcxxabi/BUILD.gn
@@ -1,0 +1,55 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("$flutter_root/common/config.gni")
+
+config("libcxxabi_config") {
+  include_dirs = [ "include" ]
+}
+
+source_set("libcxxabi") {
+  visibility = [ "../libcxx" ]
+
+  sources = [
+    "src/abort_message.cpp",
+    "src/cxa_aux_runtime.cpp",
+    "src/cxa_default_handlers.cpp",
+    "src/cxa_exception_storage.cpp",
+    "src/cxa_guard.cpp",
+    "src/cxa_handlers.cpp",
+    "src/cxa_noexception.cpp",
+    "src/cxa_unexpected.cpp",
+    "src/cxa_vector.cpp",
+    "src/cxa_virtual.cpp",
+    "src/fallback_malloc.cpp",
+    "src/private_typeinfo.cpp",
+    "src/stdlib_exception.cpp",
+    "src/stdlib_stdexcept.cpp",
+    "src/stdlib_typeinfo.cpp",
+  ]
+
+  # TODO(goderbauer): Remove this and add cxa_demangle.cpp to the regular source
+  # list above when https://dart-review.googlesource.com/c/sdk/+/84831 has been
+  # rolled into the engine.
+  if (!is_android || flutter_runtime_mode != "release") {
+    sources += [ "src/cxa_demangle.cpp" ]
+  }
+
+  public_configs = [ ":libcxxabi_config" ]
+
+  defines = [
+    "_LIBCXXABI_NO_EXCEPTIONS",
+    "_LIBCXXABI_BUILDING_LIBRARY",
+    "LIBCXXABI_SILENT_TERMINATE",
+  ]
+
+  # ICU uses RTTI, so we need to build libcxxabi with support for it,
+  # https://github.com/flutter/flutter/issues/24535.
+  configs -= [ "//build/config/compiler:no_rtti" ]
+
+  configs += [
+    "//build/config/compiler:rtti",
+    "//third_party/libcxx:libcxx_config",
+  ]
+}


### PR DESCRIPTION
This reverts commit f6b7397.
Adds workaround for LTO builds targeting android_arm64.