### PR TITLE
Add a GN arg to allow passing -fnew-alignment=N option to clang.

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -316,7 +316,10 @@ config("compiler") {
   }
 
   if (operator_new_alignment != "default" && is_clang) {
-    cflags += [ "-fnew-alignment=$operator_new_alignment" ]
+    cflags += [
+      "-faligned-allocation",
+      "-fnew-alignment=$operator_new_alignment",
+    ]
   }
 
   if (enable_profiling && !is_debug) {

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -25,6 +25,10 @@ declare_args() {
   # Normally, Android builds are lightly optimized, even for debug builds, to
   # keep binary size down. Setting this flag to true disables such optimization
   android_full_debug = false
+
+  # Set this flag when linking with custom allocators that don't satisfy
+  # default ::operator new(size_t) alignment guarantees.
+  operator_new_alignment = "default"
 }
 
 # default_include_dirs ---------------------------------------------------------
@@ -309,6 +313,10 @@ config("compiler") {
         "_LARGEFILE64_SOURCE",
       ]
     }
+  }
+
+  if (operator_new_alignment != "default" && is_clang) {
+    cflags += [ "-fnew-alignment=$operator_new_alignment" ]
   }
 
   if (enable_profiling && !is_debug) {


### PR DESCRIPTION
Some allocators (tcmalloc) don't provide alignment guarantees that
match clang's default expectations, which causes crashes when using
clang compiled binary with such allocators.

For example clang can produce movaps instructions to initialize newly
allocated object - which would crash if result of ::operator new() is
not 16 bytes aligned.