### PR TITLE
Update vcvarsall.bat location with vs2017

### DIFF
--- a/build/toolchain/win/setup_toolchain.py
+++ b/build/toolchain/win/setup_toolchain.py
@@ -66,7 +66,7 @@ def _SetupScript(target_cpu, sdk_dir):
     # TODO(scottmg|dpranke): Non-depot_tools toolchain: need to get Visual
     # Studio install location from registry.
     return [os.path.normpath(os.path.join(os.environ['GYP_MSVS_OVERRIDE_PATH'],
-                                          'VC/vcvarsall.bat')),
+                                          'VC/Auxiliary/Build/vcvarsall.bat')),
             'amd64_x86' if target_cpu == 'x86' else 'amd64']
 
 


### PR DESCRIPTION
This fixes one issue of building engine on non-corp windows machines.

This seems to be a difference between vs2015 and vs2017. See https://social.msdn.microsoft.com/Forums/en-US/1071be0e-2a46-4c30-9546-ea9d7c4755fa/where-is-vcvarsallbat-file?forum=visualstudiogeneral for more details.