### PR TITLE
Don't assume anything above SSE2 when compiling X64 code (e.g. dart binary)

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -177,6 +177,7 @@ config("compiler") {
       common_mac_flags += [
         "-arch",
         "x86_64",
+        "-msse2",
       ]
     } else if (current_cpu == "x86") {
       common_mac_flags += [


### PR DESCRIPTION
Allows users to run flutter tools on old Mac's.

Fixes https://github.com/flutter/flutter/issues/24916