### PR TITLE
Build host Dart binary with -march=core2 on Mac OS X.

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -177,7 +177,7 @@ config("compiler") {
       common_mac_flags += [
         "-arch",
         "x86_64",
-        "-msse2",
+        "-march=core2",
       ]
     } else if (current_cpu == "x86") {
       common_mac_flags += [


### PR DESCRIPTION
This is the right way to disable SSE3 features and above to support
early pre-Penryn iMac-s.

-msse2 which I tried to use before does not actually disable SSE3 and above.

This time I have verified that no pextrb (SSE4.1) instructions are generated
by C++ compiler by disassembling dart binary.

Note: the binary still contains some SSE4.1 instructions because BoringSSL comes
with handwritten assembly - but it check CPU features before using that assembly.

Fixes https://github.com/flutter/flutter/issues/24916

(This time for real)