### PR TITLE
Added --delete_removed_deps flag to create_updated_flutter_deps.py

### DIFF
--- a/tools/dart/dart_roll_helper.py
+++ b/tools/dart/dart_roll_helper.py
@@ -91,7 +91,8 @@ def get_deps():
 
 def update_deps():
   print_status('Updating Dart dependencies')
-  p = subprocess.Popen([update_dart_deps_path()], cwd=ENGINE_HOME)
+  p = subprocess.Popen([update_dart_deps_path(), '--delete_removed_deps'],
+                       cwd=ENGINE_HOME)
   p.wait()
 
 


### PR DESCRIPTION
Added --delete_removed_deps flag to create_updated_flutter_deps.py to allow for dependencies removed in the Dart SDK to be automatically removed from flutter/DEPS.