### PR TITLE
Remove default sources assignment filters.

### DIFF
--- a/build/config/BUILDCONFIG.gn
+++ b/build/config/BUILDCONFIG.gn
@@ -275,119 +275,6 @@ if (current_os == "win") {
 default_library_type = "static_library"
 
 # =============================================================================
-# SOURCES FILTERS
-# =============================================================================
-#
-# These patterns filter out platform-specific files when assigning to the
-# sources variable. The magic variable |sources_assignment_filter| is applied
-# to each assignment or appending to the sources variable and matches are
-# automatcally removed.
-#
-# Note that the patterns are NOT regular expressions. Only "*" and "\b" (path
-# boundary = end of string or slash) are supported, and the entire string
-# muct match the pattern (so you need "*.cc" to match all .cc files, for
-# example).
-
-# DO NOT ADD MORE PATTERNS TO THIS LIST, see set_sources_assignment_filter call
-# below.
-sources_assignment_filter = []
-if (!is_posix) {
-  sources_assignment_filter += [
-    "*_posix.h",
-    "*_posix.cc",
-    "*_posix_unittest.h",
-    "*_posix_unittest.cc",
-    "*\bposix/*",
-  ]
-}
-if (!is_win) {
-  sources_assignment_filter += [
-    "*_win.cc",
-    "*_win.h",
-    "*_win_unittest.cc",
-    "*\bwin/*",
-    "*.def",
-    "*.rc",
-  ]
-}
-if (!is_mac) {
-  sources_assignment_filter += [
-    "*_mac.h",
-    "*_mac.cc",
-    "*_mac.mm",
-    "*_mac_unittest.h",
-    "*_mac_unittest.cc",
-    "*_mac_unittest.mm",
-    "*\bmac/*",
-    "*_cocoa.h",
-    "*_cocoa.cc",
-    "*_cocoa.mm",
-    "*_cocoa_unittest.h",
-    "*_cocoa_unittest.cc",
-    "*_cocoa_unittest.mm",
-    "*\bcocoa/*",
-  ]
-}
-if (!is_ios) {
-  sources_assignment_filter += [
-    "*_ios.h",
-    "*_ios.cc",
-    "*_ios.mm",
-    "*_ios_unittest.h",
-    "*_ios_unittest.cc",
-    "*_ios_unittest.mm",
-    "*\bios/*",
-  ]
-}
-if (!is_mac && !is_ios) {
-  sources_assignment_filter += [ "*.mm" ]
-}
-if (!is_linux) {
-  sources_assignment_filter += [
-    "*_linux.h",
-    "*_linux.cc",
-    "*_linux_unittest.h",
-    "*_linux_unittest.cc",
-    "*\blinux/*",
-  ]
-}
-if (!is_android) {
-  sources_assignment_filter += [
-    "*_android.h",
-    "*_android.cc",
-    "*_android_unittest.h",
-    "*_android_unittest.cc",
-    "*\bandroid/*",
-  ]
-}
-if (!is_chromeos) {
-  sources_assignment_filter += [
-    "*_chromeos.h",
-    "*_chromeos.cc",
-    "*_chromeos_unittest.h",
-    "*_chromeos_unittest.cc",
-    "*\bchromeos/*",
-  ]
-}
-
-# DO NOT ADD MORE PATTERNS TO THIS LIST, see set_sources_assignment_filter call
-# below.
-
-# Actually save this list.
-#
-# These patterns are executed for every file in the source tree of every run.
-# Therefore, adding more patterns slows down the build for everybody. We should
-# only add automatic patterns for configurations affecting hundreds of files
-# across many projects in the tree.
-#
-# Therefore, we only add rules to this list corresponding to platforms on the
-# Chromium waterfall.  This is not for non-officially-supported platforms
-# (FreeBSD, etc.) toolkits, (X11, GTK, etc.), or features. For these cases,
-# write a conditional in the target to remove the file(s) from the list when
-# your platform/toolkit/feature doesn't apply.
-set_sources_assignment_filter(sources_assignment_filter)
-
-# =============================================================================
 # BUILD OPTIONS
 # =============================================================================
 
@@ -678,11 +565,6 @@ template("component") {
       configs = []  # Prevent list overwriting warning.
       configs = invoker.configs
 
-      # The sources assignment filter will have already been applied when the
-      # code was originally executed. We don't want to apply it again, since
-      # the original target may have override it for some assignments.
-      set_sources_assignment_filter([])
-
       if (defined(invoker.all_dependent_configs)) {
         all_dependent_configs = invoker.all_dependent_configs
       }
@@ -777,9 +659,6 @@ template("component") {
       # See above.
       configs = []  # Prevent list overwriting warning.
       configs = invoker.configs
-
-      # See above call.
-      set_sources_assignment_filter([])
 
       if (defined(invoker.all_dependent_configs)) {
         all_dependent_configs = invoker.all_dependent_configs

--- a/build/config/android/internal_rules.gni
+++ b/build/config/android/internal_rules.gni
@@ -16,7 +16,6 @@ rebased_android_sdk_jar = rebase_path(android_sdk_jar, root_build_dir)
 android_aapt_path = "$rebased_android_sdk_build_tools/aapt"
 
 template("android_lint") {
-  set_sources_assignment_filter([])
   if (defined(invoker.testonly)) {
     testonly = invoker.testonly
   }
@@ -120,7 +119,6 @@ template("findbugs") {
 }
 
 template("dex") {
-  set_sources_assignment_filter([])
   if (defined(invoker.testonly)) {
     testonly = invoker.testonly
   }
@@ -172,7 +170,6 @@ template("dex") {
 # Creates a zip archive of the inputs.
 # If base_dir is provided, the archive paths will be relative to it.
 template("zip") {
-  set_sources_assignment_filter([])
   if (defined(invoker.testonly)) {
     testonly = invoker.testonly
   }
@@ -229,7 +226,6 @@ template("zip") {
 # See build/android/gyp/write_build_config.py and
 # build/android/gyp/util/build_utils.py:ExpandFileArgs
 template("write_build_config") {
-  set_sources_assignment_filter([])
   if (defined(invoker.testonly)) {
     testonly = invoker.testonly
   }
@@ -390,7 +386,6 @@ template("write_build_config") {
 }
 
 template("process_java_prebuilt") {
-  set_sources_assignment_filter([])
   if (defined(invoker.testonly)) {
     testonly = invoker.testonly
   }
@@ -498,8 +493,8 @@ template("process_java_prebuilt") {
       visibility = invoker.visibility
     }
     public_deps = [
-      ":${target_name}__jar_toc",
       ":$_output_jar_target",
+      ":${target_name}__jar_toc",
     ]
   }
 }
@@ -565,7 +560,6 @@ template("finalize_apk") {
 # Packages resources, assets, dex, and native libraries into an apk. Signs and
 # zipaligns the apk.
 template("create_apk") {
-  set_sources_assignment_filter([])
   if (defined(invoker.testonly)) {
     testonly = invoker.testonly
   }
@@ -819,7 +813,6 @@ template("create_apk") {
 }
 
 template("java_prebuilt_impl") {
-  set_sources_assignment_filter([])
   if (defined(invoker.testonly)) {
     testonly = invoker.testonly
   }
@@ -922,7 +915,6 @@ template("java_prebuilt_impl") {
 #   jar_path: Use this to explicitly set the output jar path. Defaults to
 #     "${target_gen_dir}/${target_name}.jar.
 template("compile_java") {
-  set_sources_assignment_filter([])
   if (defined(invoker.testonly)) {
     testonly = invoker.testonly
   }
@@ -1066,7 +1058,6 @@ template("compile_java") {
 }
 
 template("java_library_impl") {
-  set_sources_assignment_filter([])
   if (defined(invoker.testonly)) {
     testonly = invoker.testonly
   }
@@ -1292,7 +1283,6 @@ template("java_library_impl") {
 
 # Runs process_resources.py
 template("process_resources") {
-  set_sources_assignment_filter([])
   if (defined(invoker.testonly)) {
     testonly = invoker.testonly
   }
@@ -1400,7 +1390,6 @@ template("process_resources") {
 }
 
 template("copy_ex") {
-  set_sources_assignment_filter([])
   if (defined(invoker.testonly)) {
     testonly = invoker.testonly
   }
@@ -1452,7 +1441,6 @@ template("copy_ex") {
 
 # Produces a single .dex.jar out of a set of Java dependencies.
 template("deps_dex") {
-  set_sources_assignment_filter([])
   build_config = "$target_gen_dir/${target_name}.build_config"
   build_config_target_name = "${target_name}__build_config"
 

--- a/build/config/android/rules.gni
+++ b/build/config/android/rules.gni
@@ -27,7 +27,6 @@ assert(is_android)
 #     jni_package = "foo"
 #   }
 template("generate_jni") {
-  set_sources_assignment_filter([])
   if (defined(invoker.testonly)) {
     testonly = invoker.testonly
   }
@@ -124,7 +123,6 @@ template("generate_jni") {
 #     jni_package = "foo"
 #   }
 template("generate_jar_jni") {
-  set_sources_assignment_filter([])
   if (defined(invoker.testonly)) {
     testonly = invoker.testonly
   }
@@ -236,7 +234,6 @@ template("generate_jar_jni") {
 #     include_path = "android/java/templates"
 #   }
 template("java_cpp_template") {
-  set_sources_assignment_filter([])
   if (defined(invoker.testonly)) {
     testonly = invoker.testonly
   }
@@ -355,7 +352,6 @@ template("java_cpp_template") {
 #     ]
 #   }
 template("java_cpp_enum") {
-  set_sources_assignment_filter([])
   if (defined(invoker.testonly)) {
     testonly = invoker.testonly
   }
@@ -436,7 +432,6 @@ template("java_cpp_enum") {
 #     variables = ["color=red"]
 #   }
 template("jinja_template_resources") {
-  set_sources_assignment_filter([])
   if (defined(invoker.testonly)) {
     testonly = invoker.testonly
   }
@@ -506,7 +501,6 @@ template("jinja_template_resources") {
 #     sources = [ "path/en-US.pak", "path/fr.pak", ... ]
 #   }
 template("locale_pak_resources") {
-  set_sources_assignment_filter([])
   assert(defined(invoker.sources))
 
   _base_path = "$target_gen_dir/$target_name"
@@ -582,7 +576,6 @@ template("locale_pak_resources") {
 #     custom_package = "org.chromium.foo"
 #   }
 template("android_resources") {
-  set_sources_assignment_filter([])
   if (defined(invoker.testonly)) {
     testonly = invoker.testonly
   }
@@ -673,7 +666,6 @@ template("android_resources") {
 #    grd_file = "foo_strings.grd"
 #  }
 template("java_strings_grd") {
-  set_sources_assignment_filter([])
   if (defined(invoker.testonly)) {
     testonly = invoker.testonly
   }
@@ -743,7 +735,6 @@ template("java_strings_grd") {
 #    ]
 #  }
 template("java_strings_grd_prebuilt") {
-  set_sources_assignment_filter([])
   if (defined(invoker.testonly)) {
     testonly = invoker.testonly
   }
@@ -816,8 +807,6 @@ template("java_strings_grd_prebuilt") {
 #     main_class = "org.chromium.foo.FooMain"
 #   }
 template("java_binary") {
-  set_sources_assignment_filter([])
-
   # TODO(cjhopman): This should not act like a java_library for dependents (i.e.
   # dependents shouldn't get the jar in their classpath, etc.).
   java_library_impl(target_name) {
@@ -880,8 +869,6 @@ template("java_binary") {
 #     deps = [ ":bar_java" ]
 #   }
 template("junit_binary") {
-  set_sources_assignment_filter([])
-
   java_binary(target_name) {
     bypass_platform_checks = true
     main_class = "org.chromium.testing.local.JunitTestMain"
@@ -967,7 +954,6 @@ template("junit_binary") {
 #     ]
 #   }
 template("java_library") {
-  set_sources_assignment_filter([])
   java_library_impl(target_name) {
     if (defined(invoker.DEPRECATED_java_in_dir)) {
       DEPRECATED_java_in_dir = invoker.DEPRECATED_java_in_dir
@@ -1038,7 +1024,6 @@ template("java_library") {
 #     ]
 #   }
 template("java_prebuilt") {
-  set_sources_assignment_filter([])
   java_prebuilt_impl(target_name) {
     jar_path = invoker.jar_path
     if (defined(invoker.jar_dep)) {
@@ -1116,7 +1101,6 @@ template("java_prebuilt") {
 #     ]
 #   }
 template("android_library") {
-  set_sources_assignment_filter([])
   assert(!defined(invoker.jar_path),
          "android_library does not support a custom jar path")
   java_library_impl(target_name) {
@@ -1189,7 +1173,6 @@ template("android_library") {
 #     will be packaged into the resulting .dex.jar file.
 #   dex_path: location at which the output file will be put
 template("android_standalone_library") {
-  set_sources_assignment_filter([])
   deps_dex(target_name) {
     deps = invoker.deps
     dex_path = invoker.dex_path
@@ -1222,7 +1205,6 @@ template("android_standalone_library") {
 #     ]
 #   }
 template("android_java_prebuilt") {
-  set_sources_assignment_filter([])
   java_prebuilt_impl(target_name) {
     jar_path = invoker.jar_path
     supports_android = true
@@ -1299,7 +1281,6 @@ template("android_java_prebuilt") {
 #     ]
 #   }
 template("android_apk") {
-  set_sources_assignment_filter([])
   if (defined(invoker.testonly)) {
     testonly = invoker.testonly
   }
@@ -1691,7 +1672,6 @@ template("android_apk") {
 #     ]
 #   }
 template("instrumentation_test_apk") {
-  set_sources_assignment_filter([])
   testonly = true
   _template_name = target_name
 
@@ -1779,7 +1759,6 @@ template("instrumentation_test_apk") {
 #     unittests_dep = ":foo_unittests"
 #   }
 template("unittest_apk") {
-  set_sources_assignment_filter([])
   testonly = true
 
   assert(defined(invoker.unittests_dep), "Need unittests_dep for $target_name")
@@ -1856,7 +1835,6 @@ template("unittest_apk") {
 #     ]
 #   }
 template("android_aidl") {
-  set_sources_assignment_filter([])
   if (defined(invoker.testonly)) {
     testonly = invoker.testonly
   }
@@ -1933,7 +1911,6 @@ template("android_aidl") {
 #     deps = [ ":the_thing_that_makes_foo" ]
 #   }
 template("create_native_executable_dist") {
-  set_sources_assignment_filter([])
   if (defined(invoker.testonly)) {
     testonly = invoker.testonly
   }
@@ -2028,7 +2005,6 @@ template("create_native_executable_dist") {
 #    sources = [ "$proto_path/foo.proto" ]
 #  }
 template("proto_java_library") {
-  set_sources_assignment_filter([])
   _protoc_dep = "//third_party/android_protobuf:android_protoc($host_toolchain)"
   _protoc_out_dir = get_label_info(_protoc_dep, "root_out_dir")
   _protoc_bin = "$_protoc_out_dir/android_protoc"
@@ -2071,7 +2047,6 @@ template("proto_java_library") {
 
 # TODO(GYP): implement this.
 template("uiautomator_test") {
-  set_sources_assignment_filter([])
   if (defined(invoker.testonly)) {
     testonly = invoker.testonly
   }

--- a/build/config/mac/rules.gni
+++ b/build/config/mac/rules.gni
@@ -50,7 +50,6 @@ template("resource_copy_mac") {
   _resources = invoker.resources
 
   copy(target_name) {
-    set_sources_assignment_filter([])
     sources = _resources
     outputs = [
       "$root_build_dir/$_app_name.app/$_bundle_directory/Contents/Resources/{{source_file_part}}",

--- a/build/config/templates/templates.gni
+++ b/build/config/templates/templates.gni
@@ -17,31 +17,32 @@
 #     variables = "app_name=chrome_shell app_version=1"
 #   }
 template("file_template") {
-  set_sources_assignment_filter([])
-
   if (defined(invoker.testonly)) {
     testonly = invoker.testonly
   }
 
-  assert(defined(invoker.input),
-      "The input file must be specified")
-  assert(defined(invoker.output),
-      "The output file must be specified")
+  assert(defined(invoker.input), "The input file must be specified")
+  assert(defined(invoker.output), "The output file must be specified")
   assert(defined(invoker.variables),
-      "The variable used for substitution in templates must be specified")
+         "The variable used for substitution in templates must be specified")
 
   variables = invoker.variables
 
   action(target_name) {
-    if(defined(invoker.visibility)) {
+    if (defined(invoker.visibility)) {
       visibility = invoker.visibility
     }
 
     script = "//build/android/gyp/jinja_template.py"
     depfile = "$target_gen_dir/$target_name.d"
 
-    sources = [ invoker.input ]
-    outputs = [ invoker.output, depfile ]
+    sources = [
+      invoker.input,
+    ]
+    outputs = [
+      invoker.output,
+      depfile,
+    ]
 
     args = [
       "--inputs",
@@ -50,7 +51,7 @@ template("file_template") {
       rebase_path(invoker.output, root_build_dir),
       "--depfile",
       rebase_path(depfile, root_build_dir),
-      "--variables=${variables}"
+      "--variables=${variables}",
     ]
   }
 }

--- a/build/fuchsia/sdk.gni
+++ b/build/fuchsia/sdk.gni
@@ -115,7 +115,6 @@ template("_fuchsia_fidl_library") {
   source_set(target_name) {
     public_configs = [ ":$config_name" ]
 
-    set_sources_assignment_filter([])
     sources = get_target_outputs(":$fidl_gen_target_name")
 
     deps = [
@@ -169,7 +168,6 @@ template("_fuchsia_cc_source_library") {
   source_set(target_name) {
     output_name = _output_name
     public = _public_headers
-    set_sources_assignment_filter([])
     sources = _sources
     public_configs = [ ":$config_name" ]
     public_deps = _deps


### PR DESCRIPTION
This was a pattern used by GYP and has since been abandoned in favor of conditionally adding the right sources and dependencies to GN targets. The assignment filter makes debugging linker issues due to filtered source files or dependencies extremely hard to isolate. All uses of this “feature” in the Flutter buildroot and engine have been to disable the same. Dependencies already assume that no filters are present as other buildroots (Fuchsia) don’t define these either.