### PR TITLE
Remove android/x86 workaround

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -385,18 +385,9 @@ config("compiler") {
     cflags += [ "-fcolor-diagnostics" ]
   }
 
-  # C++11 compiler flags setup.
-  # ---------------------------
-  # TODO(chinmaygarde): We are only using C++14 on x64 hosts (with a static
-  # libcxx and libcxxabi from buildtools) because the static libraries
-  # in buildtools are not compatible with x86. This will be rectified soon
-  # with libcxx and libcxxabi providing their own GN files. The "current_cpu"
-  # check can then be removed. So far, the only target that need x86 don't
-  # also require C++14.
-  # Tracked in https://fuchsia.atlassian.net/browse/TO-61
-  if (is_linux && current_cpu == "x86") {
-    cc_std = [ "-std=c++11" ]
-  } else if (is_win) {
+  # C++ compiler flags setup.
+  # -------------------------
+  if (is_win) {
     cc_std = [ "/std:c++14" ]
   } else if (is_fuchsia) {
     cc_std = [ "-std=c++17" ]


### PR DESCRIPTION
We now have BUILD.gn files for libc++ and libc++abi, and the toolchain
includes 32-bit versions of libc++ and libc++abi anyway.