### PR TITLE
Update default builds to use the C++ 17 standard.

### DIFF
--- a/build/config/BUILDCONFIG.gn
+++ b/build/config/BUILDCONFIG.gn
@@ -302,6 +302,7 @@ if (!is_clang && (is_asan || is_lsan || is_tsan || is_msan)) {
 _native_compiler_configs = [
   "//build/config:feature_flags",
   "//build/config/compiler:compiler",
+  "//build/config/compiler:cxx_version_default",
   "//build/config/compiler:compiler_arm_fpu",
   "//build/config/compiler:chromium_code",
   "//build/config/compiler:default_include_dirs",

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -387,15 +387,6 @@ config("compiler") {
 
   # C++ compiler flags setup.
   # -------------------------
-  if (is_win) {
-    cc_std = [ "/std:c++14" ]
-  } else if (is_fuchsia) {
-    cc_std = [ "-std=c++17" ]
-  } else {
-    cc_std = [ "-std=c++14" ]
-  }
-  cflags_cc += cc_std
-  cflags_objcc += cc_std
 
   # Android-specific flags setup.
   # -----------------------------
@@ -457,6 +448,46 @@ config("compiler") {
   }
 
   asmflags = cflags
+}
+
+config("cxx_version_default") {
+  if (is_win) {
+    cc_std = [ "/std:c++17" ]
+  } else {
+    cc_std = [ "-std=c++17" ]
+  }
+  cflags_cc = cc_std
+  cflags_objcc = cc_std
+}
+
+config("cxx_version_11") {
+  if (is_win) {
+    cc_std = [ "/std:c++11" ]
+  } else {
+    cc_std = [ "-std=c++11" ]
+  }
+  cflags_cc = cc_std
+  cflags_objcc = cc_std
+}
+
+config("cxx_version_14") {
+  if (is_win) {
+    cc_std = [ "/std:c++14" ]
+  } else {
+    cc_std = [ "-std=c++14" ]
+  }
+  cflags_cc = cc_std
+  cflags_objcc = cc_std
+}
+
+config("cxx_version_17") {
+  if (is_win) {
+    cc_std = [ "/std:c++17" ]
+  } else {
+    cc_std = [ "-std=c++17" ]
+  }
+  cflags_cc = cc_std
+  cflags_objcc = cc_std
 }
 
 config("compiler_arm_fpu") {

--- a/build/secondary/third_party/libcxxabi/BUILD.gn
+++ b/build/secondary/third_party/libcxxabi/BUILD.gn
@@ -42,6 +42,11 @@ source_set("libcxxabi") {
   # https://github.com/flutter/flutter/issues/24535.
   configs -= [ "//build/config/compiler:no_rtti" ]
 
+  # Compile libcxx ABI using an older standard. This replicates the rule in the
+  # CMakeLists on the "cxx_abiobjects" target.
+  configs -= [ "//build/config/compiler:cxx_version_default" ]
+  configs += [ "//build/config/compiler:cxx_version_11" ]
+
   configs += [
     "//build/config/compiler:rtti",
     "//third_party/libcxx:libcxx_config",

--- a/build/secondary/third_party/swiftshader_flutter/BUILD.gn
+++ b/build/secondary/third_party/swiftshader_flutter/BUILD.gn
@@ -52,6 +52,8 @@ source_set("compiler") {
   public = []
 
   configs += [ ":internal_config" ]
+  configs -= [ "//build/config/compiler:cxx_version_default" ]
+  configs += [ "//build/config/compiler:cxx_version_14" ]
 
   if (is_win) {
     configs -= [ "//build/config/win:unicode" ]
@@ -87,6 +89,8 @@ source_set("subzero") {
   public = []
 
   configs += [ ":internal_config" ]
+  configs -= [ "//build/config/compiler:cxx_version_default" ]
+  configs += [ "//build/config/compiler:cxx_version_14" ]
 
   if (is_win) {
     configs -= [ "//build/config/win:unicode" ]
@@ -236,6 +240,8 @@ source_set("subzero") {
 
 source_set("reactor") {
   configs += [ ":internal_config" ]
+  configs -= [ "//build/config/compiler:cxx_version_default" ]
+  configs += [ "//build/config/compiler:cxx_version_14" ]
 
   if (is_win) {
     configs -= [ "//build/config/win:unicode" ]
@@ -257,6 +263,8 @@ source_set("renderer") {
   public = []
 
   configs += [ ":internal_config" ]
+  configs -= [ "//build/config/compiler:cxx_version_default" ]
+  configs += [ "//build/config/compiler:cxx_version_14" ]
 
   if (is_win) {
     configs -= [ "//build/config/win:unicode" ]
@@ -291,6 +299,8 @@ source_set("opengl_common") {
   public = []
 
   configs += [ ":internal_config" ]
+  configs -= [ "//build/config/compiler:cxx_version_default" ]
+  configs += [ "//build/config/compiler:cxx_version_14" ]
 
   if (is_win) {
     configs -= [ "//build/config/win:unicode" ]
@@ -309,6 +319,8 @@ source_set("common") {
   public = []
 
   configs += [ ":internal_config" ]
+  configs -= [ "//build/config/compiler:cxx_version_default" ]
+  configs += [ "//build/config/compiler:cxx_version_14" ]
 
   if (is_win) {
     configs -= [ "//build/config/win:unicode" ]
@@ -332,6 +344,8 @@ source_set("preprocessor") {
   public = []
 
   configs += [ ":internal_config" ]
+  configs -= [ "//build/config/compiler:cxx_version_default" ]
+  configs += [ "//build/config/compiler:cxx_version_14" ]
 
   if (is_win) {
     configs -= [ "//build/config/win:unicode" ]
@@ -350,6 +364,8 @@ source_set("opengl_preprocessor") {
   public = []
 
   configs += [ ":internal_config" ]
+  configs -= [ "//build/config/compiler:cxx_version_default" ]
+  configs += [ "//build/config/compiler:cxx_version_14" ]
 
   if (is_win) {
     configs -= [ "//build/config/win:unicode" ]
@@ -374,6 +390,8 @@ source_set("opengl_compiler") {
   public = []
 
   configs += [ ":internal_config" ]
+  configs -= [ "//build/config/compiler:cxx_version_default" ]
+  configs += [ "//build/config/compiler:cxx_version_14" ]
 
   if (is_win) {
     configs -= [ "//build/config/win:unicode" ]
@@ -419,6 +437,8 @@ source_set("shader") {
   public = []
 
   configs += [ ":internal_config" ]
+  configs -= [ "//build/config/compiler:cxx_version_default" ]
+  configs += [ "//build/config/compiler:cxx_version_14" ]
 
   if (is_win) {
     configs -= [ "//build/config/win:unicode" ]
@@ -449,6 +469,8 @@ source_set("system") {
   public = []
 
   configs += [ ":internal_config" ]
+  configs -= [ "//build/config/compiler:cxx_version_default" ]
+  configs += [ "//build/config/compiler:cxx_version_14" ]
 
   if (is_win) {
     configs -= [ "//build/config/win:unicode" ]
@@ -481,6 +503,8 @@ source_set("device") {
   public = []
 
   configs += [ ":internal_config" ]
+  configs -= [ "//build/config/compiler:cxx_version_default" ]
+  configs += [ "//build/config/compiler:cxx_version_14" ]
 
   if (is_win) {
     configs -= [ "//build/config/win:unicode" ]
@@ -528,6 +552,8 @@ source_set("main") {
   public = []
 
   configs += [ ":internal_config" ]
+  configs -= [ "//build/config/compiler:cxx_version_default" ]
+  configs += [ "//build/config/compiler:cxx_version_14" ]
 
   if (is_win) {
     configs -= [ "//build/config/win:unicode" ]
@@ -569,6 +595,8 @@ shared_library("egl") {
   public = []
 
   configs += [ ":internal_config" ]
+  configs -= [ "//build/config/compiler:cxx_version_default" ]
+  configs += [ "//build/config/compiler:cxx_version_14" ]
 
   if (is_win) {
     configs -= [ "//build/config/win:unicode" ]
@@ -623,6 +651,8 @@ shared_library("gles") {
   }
 
   configs += [ ":internal_config" ]
+  configs -= [ "//build/config/compiler:cxx_version_default" ]
+  configs += [ "//build/config/compiler:cxx_version_14" ]
 
   if (is_win) {
     configs -= [ "//build/config/win:unicode" ]


### PR DESCRIPTION
C++ Standard version selection has been moved into it's own config. This allows
leaf targets to yank the config from the native compiler configs and specifying
their own opinion. This is better than adding cflags directly because the those
will be added after the default specification. Such invocations fail on some
platforms (Windows) and cause confusion on others where two standards are
defined.

The targets that are not yet ready for C++17 now have their versions pinned.