### PR TITLE
Disable aligned allocations on iOS armv7 targets due to lack of support.

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -189,6 +189,11 @@ config("compiler") {
         "-arch",
         "armv7",
       ]
+
+      # Aligned allocation are only available on iOS 11 or above on armv7.
+      # Till we support older iOS version, disabled aligned allocations for this
+      # target architecture.
+      common_mac_flags += [ "-fno-aligned-allocation" ]
     } else if (current_cpu == "arm64") {
       common_mac_flags += [
         "-arch",


### PR DESCRIPTION
iOS is the only platform where we use `libc++`. It seems like the implementation for aligned allocators and deallocators are only available on iOS 11 and above. Since we support iOS 8, we cannot use this feature on `armv7` targets (`aarch64` iOS is fine).

This is in response to error messages such as the following:
```
aligned deallocation function of type 'void (void *, std::align_val_t) noexcept' is only available on iOS 11 or newer
```