### PR TITLE
Define dummy shlib_toolchain to allow harfbuzz to build

### DIFF
--- a/build/config/BUILDCONFIG.gn
+++ b/build/config/BUILDCONFIG.gn
@@ -462,6 +462,10 @@ set_defaults("test") {
 # default toolchain.
 import("//build/toolchain/custom/custom.gni")
 
+# Define this to allow Fuchsia's fork of harfbuzz to build.
+# shlib_toolchain is a Fuchsia-specific symbol and not used by Flutter.
+shlib_toolchain = false
+
 if (custom_toolchain != "") {
   assert(custom_sysroot != "")
   assert(custom_target_triple != "")


### PR DESCRIPTION
Fuchsia's fork of harfbuzz contains a check for `shlib_toolchain` which only exists in the fuchsia build tree.

We define this here to allow the symbol to exist so that Flutter can build off of that fork as well.