### PR TITLE
Migrate from vmo::clone() to vmo::create_child()

### DIFF
--- a/build/fuchsia/pkg/lib/vfs/cpp/vmo_file.cc
+++ b/build/fuchsia/pkg/lib/vfs/cpp/vmo_file.cc
@@ -42,8 +42,8 @@ void VmoFile::Describe(fuchsia::io::NodeInfo* out_info) {
           .vmo = std::move(temp_vmo), .length = length_, .offset = offset_};
       break;
     case Sharing::CLONE_COW:
-      if (vmo_.clone(ZX_VMO_CLONE_COPY_ON_WRITE, offset_, length_, &temp_vmo) !=
-          ZX_OK) {
+      if (vmo_.create_child(ZX_VMO_CLONE_COPY_ON_WRITE, offset_, length_,
+                            &temp_vmo) != ZX_OK) {
         return;
       }
       out_info->vmofile() = fuchsia::io::Vmofile{


### PR DESCRIPTION
The deprecated zx::vmo::clone() was eliminated in
https://fuchsia-review.googlesource.com/c/fuchsia/+/292981. It is
replaced by zx::vmo::create_child().