### PR TITLE
Compile and statically link in our own libcxx on Linux.

### DIFF
--- a/build/config/BUILDCONFIG.gn
+++ b/build/config/BUILDCONFIG.gn
@@ -535,7 +535,7 @@ if (custom_toolchain != "") {
 #
 # Variables
 #   no_default_deps: If true, no standard dependencies will be added.
-if (is_android) {
+if (is_android || (is_linux && current_cpu != "x86")) {
   foreach(_target_type,
           [
             "executable",

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -603,20 +603,15 @@ config("runtime_library") {
     }
   }
 
-  # Linux standard liburary setup.
-  # TODO(chinmaygarde): We are only using C++14 on x64 hosts (with a static
-  # libcxx and libcxxabi from buildtools) because the static libraries
-  # in buildtools are not compatible with x86. This will be rectified soon
-  # with libcxx and libcxxabi providing their own GN files. The "current_cpu"
-  # check can then be removed. So far, the only target that need x86 don't
-  # also require C++14.
-  # Tracked in https://fuchsia.atlassian.net/browse/TO-61
+  # Linux standard library setup.
+  # We compile our own libc++ on all Linux targets except i386 (for
+  # gen_snapshot) where this is not supported.
   if (is_linux) {
     if (current_cpu != "x86") {
-      cflags_cc += [ "-stdlib=libc++" ]
-      ldflags += [
-        "-stdlib=libc++",
-        "-static-libstdc++",
+      cflags_cc += [ "-nostdinc++" ]
+      include_dirs = [
+        "//third_party/libcxx/include",
+        "//third_party/libcxxabi/include",
       ]
     } else {
       cflags_cc += [ "-stdlib=libstdc++" ]


### PR DESCRIPTION
This does not apply to i386 Linux builds. We cannot build libcxx for
that. Besides that target is going away anyway as after the gen_snapshot
migration is complete.