### PR TITLE
Allow building Fuchsia CIPD artifact packages locally and optionally publish and tag them.

### DIFF
--- a/build/fuchsia/fuchsia.cipd.yaml
+++ b/build/fuchsia/fuchsia.cipd.yaml
@@ -1,0 +1,6 @@
+package: flutter/fuchsia
+description: Flutter Fuchsia Artifacts
+install_mode: copy
+data:
+  # Don't modify this! This is where the build script put all bucket artifacts.
+  - dir: flutter/


### PR DESCRIPTION
By default, only a local CIPD package is built. If —upload is specified with CIPD authenticated with an account that has access to the bucket, the package is uploaded and tagged with the `latest` tag. If the CIPD package describes contents that habe not changed, this operation is a no-op.

Packages may be browsed here https://chrome-infra-packages.appspot.com/p/flutter/fuchsia/+/