### PR TITLE
Add support for ANGLE using upstream build rules

### DIFF
--- a/build/config/BUILD.gn
+++ b/build/config/BUILD.gn
@@ -6,15 +6,13 @@ import("//build/config/allocator.gni")
 import("//build/config/crypto.gni")
 import("//build/config/features.gni")
 import("//build/config/ui.gni")
+import("//build/config/dcheck_always_on.gni")
 
 declare_args() {
   # When set, turns off the (normally-on) iterator debugging and related stuff
   # that is normally turned on for Debug builds. These are generally useful for
   # catching bugs but in some cases may cause conflicts or excessive slowness.
   disable_iterator_debugging = false
-
-  # Set to true to enable dcheck in Release builds.
-  dcheck_always_on = false
 
   # Set to true to compile with the OpenGL ES 2.0 conformance tests.
   internal_gles2_conform_tests = false

--- a/build/config/dcheck_always_on.gni
+++ b/build/config/dcheck_always_on.gni
@@ -1,0 +1,11 @@
+# Copyright (c) 2016 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# Needed for ANGLE build.
+dcheck_is_configurable = false
+
+declare_args() {
+  # Set to true to enable dcheck in Release builds.
+  dcheck_always_on = false
+}

--- a/build/config/sanitizers/sanitizers.gni
+++ b/build/config/sanitizers/sanitizers.gni
@@ -18,3 +18,5 @@ declare_args() {
   # GCS.
   use_prebuilt_instrumented_libraries = false
 }
+
+use_fuzzing_engine = false

--- a/build/config/ui.gni
+++ b/build/config/ui.gni
@@ -18,3 +18,9 @@ declare_args() {
   # window system events and input.
   use_glfw = false
 }
+
+# For ANGLE build. It's a build option there, but hard-coded here.
+use_x11 = false
+
+# For ANGLE build. It's a build option there, but hard-coded here.
+use_ozone = false

--- a/build/secondary/testing/libfuzzer/fuzzer_test.gni
+++ b/build/secondary/testing/libfuzzer/fuzzer_test.gni
@@ -1,0 +1,11 @@
+# Copyright 2019 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# This is a dummy implementation to satisfy the ANGLE build, using the no-op
+# implementation from the real (Chromium) fuzzer_test.gni.
+template("fuzzer_test") {
+  not_needed(invoker, "*")
+  group(target_name) {
+  }
+}

--- a/build/secondary/testing/test.gni
+++ b/build/secondary/testing/test.gni
@@ -1,0 +1,6 @@
+# Copyright 2019 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# This is a dummy file to satisfy the ANGLE build. Flutter's use of ANGLE
+# doesn't actually require any of the real content.

--- a/build/secondary/third_party/jsoncpp/BUILD.gn
+++ b/build/secondary/third_party/jsoncpp/BUILD.gn
@@ -1,0 +1,11 @@
+# Copyright 2019 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# The ANGLE build rules have a target that depends on jsoncpp, but the Flutter
+# engine never actually builds that target, so just this provides empty dummy
+# dependencies to satisfy the generation-time resolution.
+config("jsoncpp_config") {
+}
+group("jsoncpp") {
+}

--- a/build/secondary/third_party/swiftshader_flutter/BUILD.gn
+++ b/build/secondary/third_party/swiftshader_flutter/BUILD.gn
@@ -587,7 +587,7 @@ source_set("main") {
 
 shared_library("egl") {
   if (is_win) {
-    output_name = "libEGL"
+    output_name = "libEGL64_translator"
   } else {
     output_name = "EGL"
   }
@@ -645,7 +645,7 @@ shared_library("egl") {
 
 shared_library("gles") {
   if (is_win) {
-    output_name = "libGLESv2"
+    output_name = "lib64GLES_V2_translator"
   } else {
     output_name = "GLESv2"
   }

--- a/build/secondary/ui/ozone/ozone.gni
+++ b/build/secondary/ui/ozone/ozone.gni
@@ -1,0 +1,7 @@
+# Copyright 2019 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# ANGLE requires this variable, but it doesn't need to be configurable for
+# Flutter so just unconditionally set it to false.
+ozone_platform_gbm = false

--- a/build_overrides/angle.gni
+++ b/build_overrides/angle.gni
@@ -1,0 +1,12 @@
+# Copyright 2019 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# The ANGLE build requires this file to point to the location of third-party
+# dependencies.
+
+angle_googletest_dir = "//third_party/googletest/src"
+angle_libpng_dir = "//third_party/libpng"
+# Note: This path doesn't actually exist; see
+# //build/secondary/third_party/jsoncpp/BUILD.gn
+angle_jsoncpp_dir = "//third_party/jsoncpp"

--- a/build_overrides/build.gni
+++ b/build_overrides/build.gni
@@ -1,0 +1,8 @@
+# Copyright 2019 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# Set for ANGLE. This buildroot is close enough to Chromium's buildroot
+# (with the addition of some dummy files) to allow building in this mode; the
+# non-Chromium build mode for ANGLE is far too different.
+build_with_chromium = true


### PR DESCRIPTION
Reland of fe3b82877ee9dc7de7c345b8e1da1b0dd75f1a0a (#276)

This adds minimial (in some cases dummy) files sufficient to allow
building ANGLE in this buildroot using the build_with_chromium option.