### PR TITLE
Disable the implicit-int-float-conversion warning added in the latest Fuchsia Clang toolchain

### DIFF
--- a/build/config/clang/BUILD.gn
+++ b/build/config/clang/BUILD.gn
@@ -25,6 +25,9 @@ config("extra_warnings") {
       "-Wthread-safety",
     ]
   }
+  if (is_fuchsia) {
+    cflags += [ "-Wno-implicit-int-float-conversion" ]
+  }
 
   defines = [ "_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS" ]
 }


### PR DESCRIPTION
This warning produces errors when building the current versions of Skia and ICU.