### PR TITLE
Make minimum macOS deployment target 10.11

### DIFF
--- a/build/config/mac/mac_sdk.gni
+++ b/build/config/mac/mac_sdk.gni
@@ -6,6 +6,10 @@ declare_args() {
   # Minimum supported version of the Mac SDK.
   mac_sdk_min = "10.12"
 
+  # The MACOSX_DEPLOYMENT_TARGET variable used when compiling.
+  # Must be of the form x.x.x for Info.plist files.
+  mac_deployment_target = "10.11.0"
+
   # Path to a specific version of the Mac SDKJ, not including a backslash at
   # the end. If empty, the path to the lowest version greater than or equal to
   # mac_sdk_min is used.

--- a/build/toolchain/mac/BUILD.gn
+++ b/build/toolchain/mac/BUILD.gn
@@ -278,5 +278,5 @@ mac_toolchain("clang_x64") {
   }
   ld = cxx
   is_clang = true
-  sysroot_flags = "-isysroot $mac_sdk_path -mmacosx-version-min=$mac_sdk_min"
+  sysroot_flags = "-isysroot $mac_sdk_path -mmacosx-version-min=$mac_deployment_target"
 }


### PR DESCRIPTION
Separates the min SDK version from the min deployment version on macOS
(as it already is on iOS), and lowers it to 10.11.

Using 10.11 as a minimum allows a wider range of hardware support, and
there are currently no issues compiling the engine with a target of
10.11.

Part of https://github.com/flutter/flutter/issues/33200