### PR TITLE
Enable ARC by default in all Objective-C TUs in the engine.

### DIFF
--- a/build/config/BUILDCONFIG.gn
+++ b/build/config/BUILDCONFIG.gn
@@ -303,6 +303,7 @@ _native_compiler_configs = [
   "//build/config:feature_flags",
   "//build/config/compiler:compiler",
   "//build/config/compiler:cxx_version_default",
+  "//build/config/compiler:objc_arc",
   "//build/config/compiler:compiler_arm_fpu",
   "//build/config/compiler:chromium_code",
   "//build/config/compiler:default_include_dirs",

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -493,6 +493,14 @@ config("cxx_version_17") {
   cflags_objcc = cc_std
 }
 
+config("objc_arc") {
+  if (is_mac || is_ios) {
+    arc_flags = [ "-fobjc-arc" ]
+    cflags_objc = arc_flags
+    cflags_objcc = arc_flags
+  }
+}
+
 config("compiler_arm_fpu") {
   if (current_cpu == "arm" && !is_ios) {
     cflags = [ "-mfpu=$arm_fpu" ]
@@ -645,7 +653,7 @@ if (is_win) {
   default_warning_flags += [
     # Enables.
     "-Wendif-labels",  # Weird old-style text after an #endif.
-    "-Werror", # Warnings as errors.
+    "-Werror",  # Warnings as errors.
 
     # Disables.
     "-Wno-missing-field-initializers",  # "struct foo f = {0};"

--- a/build/secondary/third_party/swiftshader_flutter/BUILD.gn
+++ b/build/secondary/third_party/swiftshader_flutter/BUILD.gn
@@ -52,7 +52,10 @@ source_set("compiler") {
   public = []
 
   configs += [ ":internal_config" ]
-  configs -= [ "//build/config/compiler:cxx_version_default" ]
+  configs -= [
+    "//build/config/compiler:cxx_version_default",
+    "//build/config/compiler:objc_arc",
+  ]
   configs += [ "//build/config/compiler:cxx_version_14" ]
 
   if (is_win) {
@@ -89,7 +92,10 @@ source_set("subzero") {
   public = []
 
   configs += [ ":internal_config" ]
-  configs -= [ "//build/config/compiler:cxx_version_default" ]
+  configs -= [
+    "//build/config/compiler:cxx_version_default",
+    "//build/config/compiler:objc_arc",
+  ]
   configs += [ "//build/config/compiler:cxx_version_14" ]
 
   if (is_win) {
@@ -240,7 +246,10 @@ source_set("subzero") {
 
 source_set("reactor") {
   configs += [ ":internal_config" ]
-  configs -= [ "//build/config/compiler:cxx_version_default" ]
+  configs -= [
+    "//build/config/compiler:cxx_version_default",
+    "//build/config/compiler:objc_arc",
+  ]
   configs += [ "//build/config/compiler:cxx_version_14" ]
 
   if (is_win) {
@@ -263,7 +272,10 @@ source_set("renderer") {
   public = []
 
   configs += [ ":internal_config" ]
-  configs -= [ "//build/config/compiler:cxx_version_default" ]
+  configs -= [
+    "//build/config/compiler:cxx_version_default",
+    "//build/config/compiler:objc_arc",
+  ]
   configs += [ "//build/config/compiler:cxx_version_14" ]
 
   if (is_win) {
@@ -299,7 +311,10 @@ source_set("opengl_common") {
   public = []
 
   configs += [ ":internal_config" ]
-  configs -= [ "//build/config/compiler:cxx_version_default" ]
+  configs -= [
+    "//build/config/compiler:cxx_version_default",
+    "//build/config/compiler:objc_arc",
+  ]
   configs += [ "//build/config/compiler:cxx_version_14" ]
 
   if (is_win) {
@@ -319,7 +334,10 @@ source_set("common") {
   public = []
 
   configs += [ ":internal_config" ]
-  configs -= [ "//build/config/compiler:cxx_version_default" ]
+  configs -= [
+    "//build/config/compiler:cxx_version_default",
+    "//build/config/compiler:objc_arc",
+  ]
   configs += [ "//build/config/compiler:cxx_version_14" ]
 
   if (is_win) {
@@ -344,7 +362,10 @@ source_set("preprocessor") {
   public = []
 
   configs += [ ":internal_config" ]
-  configs -= [ "//build/config/compiler:cxx_version_default" ]
+  configs -= [
+    "//build/config/compiler:cxx_version_default",
+    "//build/config/compiler:objc_arc",
+  ]
   configs += [ "//build/config/compiler:cxx_version_14" ]
 
   if (is_win) {
@@ -364,7 +385,10 @@ source_set("opengl_preprocessor") {
   public = []
 
   configs += [ ":internal_config" ]
-  configs -= [ "//build/config/compiler:cxx_version_default" ]
+  configs -= [
+    "//build/config/compiler:cxx_version_default",
+    "//build/config/compiler:objc_arc",
+  ]
   configs += [ "//build/config/compiler:cxx_version_14" ]
 
   if (is_win) {
@@ -390,7 +414,10 @@ source_set("opengl_compiler") {
   public = []
 
   configs += [ ":internal_config" ]
-  configs -= [ "//build/config/compiler:cxx_version_default" ]
+  configs -= [
+    "//build/config/compiler:cxx_version_default",
+    "//build/config/compiler:objc_arc",
+  ]
   configs += [ "//build/config/compiler:cxx_version_14" ]
 
   if (is_win) {
@@ -437,7 +464,10 @@ source_set("shader") {
   public = []
 
   configs += [ ":internal_config" ]
-  configs -= [ "//build/config/compiler:cxx_version_default" ]
+  configs -= [
+    "//build/config/compiler:cxx_version_default",
+    "//build/config/compiler:objc_arc",
+  ]
   configs += [ "//build/config/compiler:cxx_version_14" ]
 
   if (is_win) {
@@ -469,7 +499,10 @@ source_set("system") {
   public = []
 
   configs += [ ":internal_config" ]
-  configs -= [ "//build/config/compiler:cxx_version_default" ]
+  configs -= [
+    "//build/config/compiler:cxx_version_default",
+    "//build/config/compiler:objc_arc",
+  ]
   configs += [ "//build/config/compiler:cxx_version_14" ]
 
   if (is_win) {
@@ -503,7 +536,10 @@ source_set("device") {
   public = []
 
   configs += [ ":internal_config" ]
-  configs -= [ "//build/config/compiler:cxx_version_default" ]
+  configs -= [
+    "//build/config/compiler:cxx_version_default",
+    "//build/config/compiler:objc_arc",
+  ]
   configs += [ "//build/config/compiler:cxx_version_14" ]
 
   if (is_win) {
@@ -552,7 +588,10 @@ source_set("main") {
   public = []
 
   configs += [ ":internal_config" ]
-  configs -= [ "//build/config/compiler:cxx_version_default" ]
+  configs -= [
+    "//build/config/compiler:cxx_version_default",
+    "//build/config/compiler:objc_arc",
+  ]
   configs += [ "//build/config/compiler:cxx_version_14" ]
 
   if (is_win) {
@@ -595,7 +634,10 @@ shared_library("egl") {
   public = []
 
   configs += [ ":internal_config" ]
-  configs -= [ "//build/config/compiler:cxx_version_default" ]
+  configs -= [
+    "//build/config/compiler:cxx_version_default",
+    "//build/config/compiler:objc_arc",
+  ]
   configs += [ "//build/config/compiler:cxx_version_14" ]
 
   if (is_win) {
@@ -651,7 +693,10 @@ shared_library("gles") {
   }
 
   configs += [ ":internal_config" ]
-  configs -= [ "//build/config/compiler:cxx_version_default" ]
+  configs -= [
+    "//build/config/compiler:cxx_version_default",
+    "//build/config/compiler:objc_arc",
+  ]
   configs += [ "//build/config/compiler:cxx_version_14" ]
 
   if (is_win) {


### PR DESCRIPTION
And disable the same on target that are not ARC ready. Needed for https://github.com/flutter/engine/pull/11245