### PR TITLE
Fix up using bitcode marker

### DIFF
--- a/build/config/clang/BUILD.gn
+++ b/build/config/clang/BUILD.gn
@@ -14,7 +14,7 @@ config("extra_warnings") {
     # Warns when a const char[] is converted to bool.
     "-Wstring-conversion",
   ]
-  if (enable_bitcode) {
+  if (use_xcode) {
     # Xcode clang throws up warnings about the way we do mutexes.
     cflags += [
       "-Wno-thread-safety",

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -163,7 +163,7 @@ config("compiler") {
     common_mac_flags = []
 
     if (enable_bitcode) {
-      if (is_debug) {
+      if (bitcode_marker) {
         common_mac_flags += [ "-fembed-bitcode-marker" ]
       } else {
         common_mac_flags += [ "-fembed-bitcode" ]
@@ -799,7 +799,7 @@ if (is_win) {
     "-fno-ident",
   ]
 
-  if (!enable_bitcode) {
+  if (!enable_bitcode || bitcode_marker) {
     common_optimize_on_cflags += [
       # Put data and code in their own sections, so that unused symbols
       # can be removed at link time with --gc-sections.

--- a/build/toolchain/clang.gni
+++ b/build/toolchain/clang.gni
@@ -16,4 +16,12 @@ declare_args() {
 
   # Set this flag to enable bitcode. Only valid for iOS ARM builds.
   enable_bitcode = false
+
+  # Set this flag to cause bitcode to be marker only.
+  bitcode_marker = false
+}
+
+declare_args() {
+  # Xcode is required if using bitcode, and Xcode builds cannot use goma.
+  use_xcode = enable_bitcode && !bitcode_marker
 }

--- a/build/toolchain/mac/BUILD.gn
+++ b/build/toolchain/mac/BUILD.gn
@@ -18,6 +18,7 @@ import("//build/toolchain/clang_static_analyzer.gni")
 import("//build/toolchain/goma.gni")
 
 assert(!enable_bitcode || !use_ios_simulator)
+assert(!enable_bitcode || (use_xcode || bitcode_marker))
 
 if (use_goma) {
   goma_prefix = "$goma_dir/gomacc "
@@ -234,7 +235,7 @@ llvm_bin_path = "//buildtools/mac-x64/clang/bin"
 mac_toolchain("ios_clang_arm") {
   toolchain_cpu = "arm"
   toolchain_os = "mac"
-  if (!enable_bitcode) {
+  if (!use_xcode) {
     prefix = rebase_path(llvm_bin_path, root_build_dir)
     ar = "$prefix/llvm-ar"
     cc = "$prefix/clang"
@@ -266,7 +267,7 @@ mac_toolchain("ios_clang_x64") {
 mac_toolchain("clang_x64") {
   toolchain_cpu = "x64"
   toolchain_os = "mac"
-  if (!enable_bitcode) {
+  if (!use_xcode) {
     prefix = rebase_path(llvm_bin_path, root_build_dir)
     ar = "$prefix/llvm-ar"
     cc = "$prefix/clang"


### PR DESCRIPTION
This will help with https://github.com/flutter/flutter/issues/37952 and https://github.com/flutter/flutter/issues/39257

For debug builds, we should just use `-fembed-bitcode-marker` to speed things up. This is how Apple does it anyway in Xcode. I incorrectly believed that `is_debug` would control this, but that's only for `unopt` builds.  

This will help with the linked issues because, for some reason (and on CI only), bitcode enabled builds of ios_debug_arm are failing when using bitcode. As much as I'd love to figure out why (it doesn't reproduce locally), we really don't need bitcode there anyway.

I'll have a companion PR to this in the engine that rolls it and adds some changes to the gn script.