### PR TITLE
Fix Xcode check

### DIFF
--- a/build/toolchain/clang.gni
+++ b/build/toolchain/clang.gni
@@ -23,5 +23,8 @@ declare_args() {
 
 declare_args() {
   # Xcode is required if using bitcode, and Xcode builds cannot use goma.
-  use_xcode = enable_bitcode && !bitcode_marker
+  # TODO(dnfield): We shouldn't need Xcode for bitcode_marker builds, but we do
+  # until libpng and dart have explicitly added LLVM asm sections to their
+  # assembly sources. https://github.com/flutter/flutter/issues/39281
+  use_xcode = enable_bitcode
 }


### PR DESCRIPTION
We can't use clang yet for marker bitcode, until https://github.com/flutter/flutter/issues/39281 is resolved.

This will work because Xcode knows how to build the assembly files even without the sections explicitly in there. Xcode also works as long as I use LTO, which isn't much slower when building for bitcode anyway.