### PR TITLE
Enable -Wnewline-eof

### DIFF
--- a/build/config/clang/BUILD.gn
+++ b/build/config/clang/BUILD.gn
@@ -13,6 +13,9 @@ config("extra_warnings") {
 
     # Warns when a const char[] is converted to bool.
     "-Wstring-conversion",
+    # Warns when a source file doesn't have a newline at end-of-file.
+    # This is to match Fuchsia, which enables this warning.
+    "-Wnewline-eof",
   ]
   if (use_xcode) {
     # Xcode clang throws up warnings about the way we do mutexes.

--- a/build/secondary/third_party/swiftshader_flutter/BUILD.gn
+++ b/build/secondary/third_party/swiftshader_flutter/BUILD.gn
@@ -35,6 +35,7 @@ config("internal_config") {
   } else {
     cflags = [
       "-Wno-header-hygiene",
+      "-Wno-newline-eof",
       "-Wno-thread-safety-analysis",
       "-Wno-undefined-var-template",
       "-Wno-unneeded-internal-declaration",


### PR DESCRIPTION
Note that as of C++11, the standard specifies that such files shall be
treated as though they include a newline at end-of-file. We add this
warning solely to match Fuchsia's clang warnings and ensure we don't
commit files without newline at EOF that will later break when rolled to
Fuchsia.