### PR TITLE
Disable warnings no longer present in Fuchsia Clang.

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -659,13 +659,6 @@ if (is_win) {
     default_warning_flags += [ "-Wunguarded-availability" ]
   }
 
-  if (is_fuchsia) {
-    default_warning_flags += [
-      "-Wno-c99-designator",
-      "-Wno-reorder-init-list",
-    ]
-  }
-
   if (allow_deprecated_api_calls) {
     default_warning_flags += [ "-Wno-deprecated-declarations" ]
   }


### PR DESCRIPTION
These warnings were present for a short duration on LLVM/Clang. The latest rolls
no longer have the same. This is causing toolchain autorollers to fail on
the specification of the unknown flag.

We should figure out if it makes sense to slow down the cadence of these rolls.