### PR TITLE
For Fuchsia targets allow c99-designator warnings

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -659,6 +659,10 @@ if (is_win) {
     default_warning_flags += [ "-Wunguarded-availability" ]
   }
 
+  if (is_fuchsia) {
+    default_warning_flags += [ "-Wno-c99-designator" ]
+  }
+
   if (allow_deprecated_api_calls) {
     default_warning_flags += [ "-Wno-deprecated-declarations" ]
   }


### PR DESCRIPTION
This is to unblock the auto-roller as seen in:
https://cirrus-ci.com/task/5486455142481920?command=compile_fuchsia#L176