### PR TITLE
Wire up thread sanitizer.

### DIFF
--- a/build/config/BUILD.gn
+++ b/build/config/BUILD.gn
@@ -46,12 +46,6 @@ config("feature_flags") {
   if (use_allocator != "tcmalloc") {
     defines += [ "NO_TCMALLOC" ]
   }
-  if (is_asan || is_lsan || is_tsan || is_msan || is_ios) {
-    defines += [
-      "MEMORY_TOOL_REPLACES_ALLOCATOR",
-      "MEMORY_SANITIZER_INITIAL_SIZE",
-    ]
-  }
   if (is_asan) {
     defines += [ "ADDRESS_SANITIZER" ]
   }

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -122,12 +122,8 @@ config("compiler") {
       cflags += [ "-fsanitize=leak" ]
     }
     if (is_tsan) {
-      tsan_blacklist_path =
-          rebase_path("//tools/memory/tsan_v2/ignores.txt", root_build_dir)
-      cflags += [
-        "-fsanitize=thread",
-        "-fsanitize-blacklist=$tsan_blacklist_path",
-      ]
+      cflags += [ "-fsanitize=thread" ]
+      ldflags += [ "-fsanitize=thread" ]
     }
     if (is_msan) {
       msan_blacklist_path =

--- a/build/config/sanitizers/sanitizers.gni
+++ b/build/config/sanitizers/sanitizers.gni
@@ -5,8 +5,7 @@
 declare_args() {
   # Use libc++ (buildtools/third_party/libc++ and
   # buildtools/third_party/libc++abi) instead of stdlibc++ as standard library.
-  # This is intended to be used for instrumented builds.
-  use_custom_libcxx = (is_asan && is_linux) || is_tsan || is_msan
+  use_custom_libcxx = false
 
   # Track where uninitialized memory originates from. From fastest to slowest:
   # 0 - no tracking, 1 - track only the initial allocation site, 2 - track the


### PR DESCRIPTION
TSAN instrumented builds fail currently because of un-annotated routines in Dart VM (though I am positive there are issues in the engine as well). I will work will @a-siva and @rmacnak-google on creating a blacklist of false positives.