### PR TITLE
Wire up the standalone leak sanitizer.

### DIFF
--- a/build/config/BUILD.gn
+++ b/build/config/BUILD.gn
@@ -43,17 +43,11 @@ config("feature_flags") {
   if (use_nss_certs) {
     defines += [ "USE_NSS_CERTS=1" ]
   }
-  if (use_allocator != "tcmalloc") {
-    defines += [ "NO_TCMALLOC" ]
-  }
   if (is_asan) {
     defines += [ "ADDRESS_SANITIZER" ]
   }
   if (is_lsan) {
-    defines += [
-      "LEAK_SANITIZER",
-      "WTF_USE_LEAK_SANITIZER=1",
-    ]
+    defines += [ "LEAK_SANITIZER" ]
   }
   if (is_tsan) {
     defines += [

--- a/build/config/allocator.gni
+++ b/build/config/allocator.gni
@@ -2,15 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-# TODO(GYP): Make tcmalloc work on win.
-if (is_android || current_cpu == "mipsel" || is_mac || is_ios || is_asan ||
-    is_lsan || is_tsan || is_msan || is_win) {
-  _default_allocator = "none"
-} else {
-  _default_allocator = "tcmalloc"
-}
-
 declare_args() {
   # Memory allocator to use. Set to "none" to use default allocator.
-  use_allocator = _default_allocator
+  use_allocator = "none"
 }

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -120,6 +120,7 @@ config("compiler") {
     }
     if (is_lsan) {
       cflags += [ "-fsanitize=leak" ]
+      ldflags += [ "-fsanitize=leak" ]
     }
     if (is_tsan) {
       cflags += [ "-fsanitize=thread" ]


### PR DESCRIPTION
By default, address sanitizer enabled builds can detect leaks if the `ASAN_OPTIONS=detect_leaks=1` environment option is specified. If only leaks need to detected, this standalone option may be used.