### PR TITLE
Upgrade compiler to Clang 9 and fix use of system vended libcxx.

### DIFF
--- a/build/config/BUILDCONFIG.gn
+++ b/build/config/BUILDCONFIG.gn
@@ -283,6 +283,8 @@ if (!is_clang && (is_asan || is_lsan || is_tsan || is_msan)) {
   is_clang = true
 }
 
+use_flutter_cxx = is_clang && (is_linux || is_android)
+
 if (is_msan && !is_linux) {
   assert(false, "Memory sanitizer is only available on Linux.")
 }
@@ -529,7 +531,7 @@ if (custom_toolchain != "") {
 #
 # Variables
 #   no_default_deps: If true, no standard dependencies will be added.
-if (is_android || (is_linux && current_cpu != "x86")) {
+if (use_flutter_cxx) {
   foreach(_target_type,
           [
             "executable",

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -163,7 +163,6 @@ config("compiler") {
       common_mac_flags += [
         "-arch",
         "x86_64",
-        "-march=core2",
       ]
     } else if (current_cpu == "x86") {
       common_mac_flags += [
@@ -210,10 +209,6 @@ config("compiler") {
       ldflags += [ "-m32" ]
       if (is_clang) {
         cflags += [
-          # Else building libyuv gives clang's register allocator issues,
-          # see llvm.org/PR15798 / crbug.com/233709
-          "-momit-leaf-frame-pointer",
-
           # Align the stack on 16-byte boundaries, http://crbug.com/418554.
           "-mstack-alignment=16",
           "-mstackrealign",
@@ -500,6 +495,7 @@ config("compiler_arm_fpu") {
 config("runtime_library") {
   cflags = []
   cflags_cc = []
+  cflags_objcc = []
   defines = []
   ldflags = []
   lib_dirs = []
@@ -521,6 +517,20 @@ config("runtime_library") {
     ]
   }
 
+  if (use_flutter_cxx) {
+    cflags_cc += [ "-nostdinc++" ]
+    cflags_objcc += [ "-nostdinc++" ]
+
+    # Unwind seemes to be in these libraries in Linux.
+    if (!is_linux) {
+      ldflags += [ "-nostdlib++" ]
+    }
+    include_dirs = [
+      "//third_party/libcxx/include",
+      "//third_party/libcxxabi/include",
+    ]
+  }
+
   # Android standard library setup.
   if (is_android) {
     if (is_clang) {
@@ -530,8 +540,6 @@ config("runtime_library") {
         "nan=__builtin_nan",
       ]
     }
-
-    defines += [ "__GNU_SOURCE=1" ]  # Necessary for clone().
 
     # TODO(jdduke) Re-enable on mips after resolving linking
     # issues with libc++ (crbug.com/456380).
@@ -554,11 +562,6 @@ config("runtime_library") {
               "$android_ndk_root/sysroot/usr/include/$android_target_triple",
               root_build_dir),
       "-D__ANDROID_API__=$android_api_level",
-    ]
-
-    include_dirs = [
-      "//third_party/libcxx/include",
-      "//third_party/libcxxabi/include",
     ]
 
     # libunwind and libandroid_support also live in $android_libcpp_root.
@@ -589,13 +592,7 @@ config("runtime_library") {
   # We compile our own libc++ on all Linux targets except i386 (for
   # gen_snapshot) where this is not supported.
   if (is_linux) {
-    if (current_cpu != "x86") {
-      cflags_cc += [ "-nostdinc++" ]
-      include_dirs = [
-        "//third_party/libcxx/include",
-        "//third_party/libcxxabi/include",
-      ]
-    } else {
+    if (!use_flutter_cxx) {
       cflags_cc += [ "-stdlib=libstdc++" ]
       ldflags += [ "-stdlib=libstdc++" ]
       libs += [ "gcc" ]
@@ -638,6 +635,9 @@ if (is_win) {
     # Disables.
     "-Wno-missing-field-initializers",  # "struct foo f = {0};"
     "-Wno-unused-parameter",  # Unused function parameters.
+    "-Wno-implicit-int-float-conversion",
+    "-Wno-reorder-init-list",
+    "-Wno-c99-designator",
   ]
 
   if (is_mac || is_ios) {

--- a/build/config/ios/BUILD.gn
+++ b/build/config/ios/BUILD.gn
@@ -2,12 +2,21 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//build/config/sysroot.gni")
 import("//build/config/ios/ios_sdk.gni")
+import("//build/config/sysroot.gni")
 
 config("sdk") {
   common_flags = [ "-stdlib=libc++" ]
 
   cflags = common_flags
   ldflags = common_flags
+
+  common_ccflags = [
+    "-nostdinc++",
+    "-isystem",
+    "$xcode_toolchain/usr/include/c++/v1",
+  ]
+
+  cflags_cc = common_ccflags
+  cflags_objcc = common_ccflags
 }

--- a/build/config/mac/BUILD.gn
+++ b/build/config/mac/BUILD.gn
@@ -9,6 +9,15 @@ config("sdk") {
 
   cflags = common_flags
   ldflags = common_flags
+
+  common_ccflags = [
+    "-nostdinc++",
+    "-isystem",
+    "$xcode_toolchain/usr/include/c++/v1",
+  ]
+
+  cflags_cc = common_ccflags
+  cflags_objcc = common_ccflags
 }
 
 # On Mac, this is used for everything except static libraries.

--- a/build/config/mac/xcode_toolchain.py
+++ b/build/config/mac/xcode_toolchain.py
@@ -1,0 +1,17 @@
+#!/usr/bin/python
+# Copyright (c) 2015 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import sys
+import os
+import subprocess
+
+def Main():
+  path = subprocess.check_output(['/usr/bin/env', 'xcode-select', '-p']).strip();
+  path = os.path.join(path, "Toolchains", "XcodeDefault.xctoolchain")
+  assert os.path.exists(path)
+  print path
+
+if __name__ == '__main__':
+  sys.exit(Main())

--- a/build/config/sysroot.gni
+++ b/build/config/sysroot.gni
@@ -9,6 +9,10 @@ declare_args() {
   # The absolute path of the sysroot that is applied when compiling using
   # the target toolchain.
   target_sysroot = ""
+
+  # The absolute path to the Xcode toolchain. This is used to look for headers
+  # that usually ship with the toolchain like c++/v1.
+  xcode_toolchain = ""
 }
 
 if (current_toolchain == default_toolchain && target_sysroot != "") {
@@ -30,4 +34,11 @@ if (current_toolchain == default_toolchain && target_sysroot != "") {
   sysroot = ios_sdk_path
 } else {
   sysroot = ""
+}
+
+if ((is_mac || is_ios) && xcode_toolchain == "") {
+  xcode_toolchain = exec_script("//build/config/mac/xcode_toolchain.py",
+                                [],
+                                "trim string",
+                                [])
 }

--- a/build/secondary/third_party/libcxxabi/BUILD.gn
+++ b/build/secondary/third_party/libcxxabi/BUILD.gn
@@ -5,30 +5,16 @@
 import("$flutter_root/common/config.gni")
 
 config("libcxxabi_config") {
+  common_cc_flags = [ "-nostdinc++" ]
+
+  cflags_cc = common_cc_flags
+  cflags_objcc = common_cc_flags
+
   include_dirs = [ "include" ]
 }
 
 source_set("libcxxabi") {
   visibility = [ "../libcxx:*" ]
-
-  sources = [
-    "src/abort_message.cpp",
-    "src/cxa_aux_runtime.cpp",
-    "src/cxa_default_handlers.cpp",
-    "src/cxa_demangle.cpp",
-    "src/cxa_exception_storage.cpp",
-    "src/cxa_guard.cpp",
-    "src/cxa_handlers.cpp",
-    "src/cxa_noexception.cpp",
-    "src/cxa_unexpected.cpp",
-    "src/cxa_vector.cpp",
-    "src/cxa_virtual.cpp",
-    "src/fallback_malloc.cpp",
-    "src/private_typeinfo.cpp",
-    "src/stdlib_exception.cpp",
-    "src/stdlib_stdexcept.cpp",
-    "src/stdlib_typeinfo.cpp",
-  ]
 
   public_configs = [ ":libcxxabi_config" ]
 
@@ -38,17 +24,48 @@ source_set("libcxxabi") {
     "LIBCXXABI_SILENT_TERMINATE",
   ]
 
-  # ICU uses RTTI, so we need to build libcxxabi with support for it,
-  # https://github.com/flutter/flutter/issues/24535.
-  configs -= [ "//build/config/compiler:no_rtti" ]
+  sources = []
 
-  # Compile libcxx ABI using an older standard. This replicates the rule in the
+  # Compile libcxx ABI using C++11. This replicates the rule in the
   # CMakeLists on the "cxx_abiobjects" target.
   configs -= [ "//build/config/compiler:cxx_version_default" ]
   configs += [ "//build/config/compiler:cxx_version_11" ]
 
-  configs += [
-    "//build/config/compiler:rtti",
-    "//third_party/libcxx:libcxx_config",
+  configs += [ "../libcxx:libcxx_config" ]
+
+  # No translation units in the engine are built with exceptions. But, using
+  # Objective-C exceptions requires some infrastructure setup for exceptions.
+  # Build support for the same in cxxabi on Darwin.
+  if (is_mac || is_ios) {
+    configs -= [ "//build/config/gcc:no_exceptions" ]
+    sources += [
+      "src/cxa_exception.cpp",
+      "src/cxa_personality.cpp",
+    ]
+  } else {
+    sources += [ "src/cxa_noexception.cpp" ]
+  }
+
+  # Third party dependencies may depend on RTTI. Add support for the same in
+  # cxxabi.
+  configs -= [ "//build/config/compiler:no_rtti" ]
+  configs += [ "//build/config/compiler:rtti" ]
+
+  sources += [
+    "src/abort_message.cpp",
+    "src/cxa_aux_runtime.cpp",
+    "src/cxa_default_handlers.cpp",
+    "src/cxa_demangle.cpp",
+    "src/cxa_exception_storage.cpp",
+    "src/cxa_guard.cpp",
+    "src/cxa_handlers.cpp",
+    "src/cxa_unexpected.cpp",
+    "src/cxa_vector.cpp",
+    "src/cxa_virtual.cpp",
+    "src/fallback_malloc.cpp",
+    "src/private_typeinfo.cpp",
+    "src/stdlib_exception.cpp",
+    "src/stdlib_stdexcept.cpp",
+    "src/stdlib_typeinfo.cpp",
   ]
 }


### PR DESCRIPTION
On Darwin platforms, we were using libcxx headers from //third_party but linking against the system libcxx. This happened to work earlier because the ABIs matched. This has now been patched so that the consistent set of headers and libraries are used throughout. I have also patched the build rules so that we can use engine vended libcxx on Darwin as well. But I will only make the switch once the compiler is upgraded.