### PR TITLE
Disable global static thread safety analysis and enable RTTI in libcxx.

### DIFF
--- a/build/config/clang/BUILD.gn
+++ b/build/config/clang/BUILD.gn
@@ -2,8 +2,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("clang.gni")
 import("//build/toolchain/clang.gni")
+import("clang.gni")
 
 # Enables some extra Clang-specific warnings. Some third-party code won't
 # compile with these so may want to remove this config.
@@ -13,21 +13,12 @@ config("extra_warnings") {
 
     # Warns when a const char[] is converted to bool.
     "-Wstring-conversion",
+
     # Warns when a source file doesn't have a newline at end-of-file.
     # This is to match Fuchsia, which enables this warning.
     "-Wnewline-eof",
   ]
-  if (use_xcode) {
-    # Xcode clang throws up warnings about the way we do mutexes.
-    cflags += [
-      "-Wno-thread-safety",
-      "-Wno-thread-safety-analysis",
-    ]
-  } else {
-    cflags += [
-      "-Wthread-safety",
-    ]
-  }
+
   if (is_fuchsia) {
     cflags += [ "-Wno-implicit-int-float-conversion" ]
   }

--- a/build/secondary/third_party/libcxx/BUILD.gn
+++ b/build/secondary/third_party/libcxx/BUILD.gn
@@ -65,6 +65,12 @@ source_set("libcxx") {
     "LIBCXX_BUILDING_LIBCXXABI",
   ]
 
+  # While no translation units in Flutter engine enable RTTI, it may be enabled
+  # in one of the third party dependencies. This mirrors the configuration in
+  # libcxxabi.
+  configs -= [ "//build/config/compiler:no_rtti" ]
+  configs += [ "//build/config/compiler:rtti" ]
+
   if (is_clang) {
     # shared_mutex.cpp and debug.cpp are purposefully in violation.
     cflags_cc = [ "-Wno-thread-safety-analysis" ]


### PR DESCRIPTION
Unblocks https://github.com/flutter/engine/pull/13123

* We should only enable static thread safety checks for Flutter translation units. Not all third party code is correctly annotated for static checks. This will be enabled seprately in //flutter.
* Allow third party users of libcxx to use RTTI (used by ICU).