### PR TITLE
Remove win "/WX" 'treat warnings as errors' flag from global flags.

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -611,10 +611,6 @@ config("runtime_library") {
 default_warning_flags = []
 default_warning_flags_cc = []
 if (is_win) {
-  if (current_cpu != "x86") {
-    default_warning_flags += [ "/WX" ]  # Treat warnings as errors.
-  }
-
   default_warning_flags += [
     # Permanent.
     "/wd4091",  # typedef warning from dbghelp.h


### PR DESCRIPTION
This will be instead added to flutter_root:config (in harfbuzz PR https://github.com/flutter/engine/pull/13242)

This rule causes harfbuzz to fail to compile on windows