### PR TITLE
Define skia_using_fuchsia_sdk in sdk.gni.

### DIFF
--- a/build/fuchsia/sdk.gni
+++ b/build/fuchsia/sdk.gni
@@ -14,6 +14,12 @@ declare_args() {
   fuchsia_toolchain_path = "//fuchsia/toolchain/$host_os"
 }
 
+declare_args() {
+  # The Skia buildroot uses this flag to decide if it should be using the
+  # Fuchsia SDK to build its translation units.
+  skia_using_fuchsia_sdk = using_fuchsia_sdk
+}
+
 _fuchsia_sdk_path = "//fuchsia/sdk/$host_os"
 
 template("_fuchsia_sysroot") {


### PR DESCRIPTION
This new flag will be used by Skia GN rules to determine if it should be built
using the Fuchsia SDK. This is to support standalone builds of Skia using the
Fuchsia SDK (it could previously only be built with the Fuchsia SDK as part
of Flutter).