### PR TITLE
Fix WEBP_EXTERN signature for Fuchsia.

### DIFF
--- a/build/secondary/third_party/libwebp/BUILD.gn
+++ b/build/secondary/third_party/libwebp/BUILD.gn
@@ -14,7 +14,7 @@ config("libwebp_defines") {
     # This makes WebP decode to BGR_565 when we ask for RGB_565.
     # (It also swaps the color order for 4444, but we don't care today.)
     "WEBP_SWAP_16BIT_CSP",
-    "WEBP_EXTERN(x)=x",
+    "WEBP_EXTERN(x)= extern x",
   ]
 }
 


### PR DESCRIPTION
The WEBP_EXTERN macro is overriden by Flutter because the default implementation sets symbol visibility to default instead of hidden.