### PR TITLE
GN Build rule updates for an upcoming SwiftShader roll.

### DIFF
--- a/build/secondary/third_party/swiftshader_flutter/BUILD.gn
+++ b/build/secondary/third_party/swiftshader_flutter/BUILD.gn
@@ -252,7 +252,6 @@ source_set("reactor") {
     "$source_root/src/Reactor/Debug.cpp",
     "$source_root/src/Reactor/ExecutableMemory.cpp",
     "$source_root/src/Reactor/Reactor.cpp",
-    "$source_root/src/Reactor/Routine.cpp",
   ]
 
   deps = [


### PR DESCRIPTION
SwiftShader is being rolled to 5d1e8540407c138f47028d64684f3da599430aa4.