### PR TITLE
Switch Windows to VS 2019 toolchain

### DIFF
--- a/build/vs_toolchain.py
+++ b/build/vs_toolchain.py
@@ -35,8 +35,8 @@ sys.path.insert(0, os.path.join(script_dir, '..', 'tools'))
 
 # VS versions are listed in descending order of priority (highest first).
 MSVS_VERSIONS = collections.OrderedDict([
-  ('2017', '15.0'),
   ('2019', '16.0'),
+  ('2017', '15.0'),
 ])
 
 
@@ -416,17 +416,14 @@ def _CopyDebugger(target_dir, target_cpu):
 def _GetDesiredVsToolchainHashes():
   """Load a list of SHA1s corresponding to the toolchains that we want installed
   to build with."""
-  env_version = GetVisualStudioVersion()
-  if env_version == '2017':
-    # VS 2017 Update 9 (15.9.12) with 10.0.18362 SDK, 10.0.17763 version of
-    # Debuggers, and 10.0.17134 version of d3dcompiler_47.dll, with ARM64
-    # libraries.
-    toolchain_hash = '418b3076791776573a815eb298c8aa590307af63'
-    # Third parties that do not have access to the canonical toolchain can map
-    # canonical toolchain version to their own toolchain versions.
-    toolchain_hash_mapping_key = 'GYP_MSVS_HASH_%s' % toolchain_hash
-    return [os.environ.get(toolchain_hash_mapping_key, toolchain_hash)]
-  raise Exception('Unsupported VS version %s' % env_version)
+  #XXX VS 2017 Update 9 (15.9.12) with 10.0.18362 SDK, 10.0.17763 version of
+  # Debuggers, and 10.0.17134 version of d3dcompiler_47.dll, with ARM64
+  # libraries.
+  toolchain_hash = '8f58c55897a3282ed617055775a77ec3db771b88'
+  # Third parties that do not have access to the canonical toolchain can map
+  # canonical toolchain version to their own toolchain versions.
+  toolchain_hash_mapping_key = 'GYP_MSVS_HASH_%s' % toolchain_hash
+  return [os.environ.get(toolchain_hash_mapping_key, toolchain_hash)]
 
 
 def ShouldUpdateToolchain():

--- a/build/vs_toolchain.py
+++ b/build/vs_toolchain.py
@@ -416,7 +416,7 @@ def _CopyDebugger(target_dir, target_cpu):
 def _GetDesiredVsToolchainHashes():
   """Load a list of SHA1s corresponding to the toolchains that we want installed
   to build with."""
-  #XXX VS 2017 Update 9 (15.9.12) with 10.0.18362 SDK, 10.0.17763 version of
+  # VS 2019 Update 9 (16.3.29324.140) with 10.0.18362 SDK, 10.0.17763 version of
   # Debuggers, and 10.0.17134 version of d3dcompiler_47.dll, with ARM64
   # libraries.
   toolchain_hash = '8f58c55897a3282ed617055775a77ec3db771b88'

--- a/build_overrides/angle.gni
+++ b/build_overrides/angle.gni
@@ -7,6 +7,8 @@
 
 angle_root = "//third_party/angle"
 
+angle_has_build = true
+
 angle_googletest_dir = "//third_party/googletest/src"
 angle_libpng_dir = "//third_party/libpng"
 # Note: This path doesn't actually exist; see


### PR DESCRIPTION
Mirrors the change from https://chromium.googlesource.com/chromium/src/+/8e82c6ab1bc2223fa25f1a127b65071d2d58ae36%5E%21/

Also adds a new variable needed to build ToT ANGLE and rolls ANGLE. The toolchain change is unfortunately linked to rolling ANGLE at the same time, since the current ANGLE pull has build errors under VS 2017, but ToT hits internal compiler errors with the old toolchain, so they need to be updated in lockstep.

Part of fix for https://github.com/flutter/flutter/issues/48831