### PR TITLE
Remove spurious include of GNI in //flutter.

### DIFF
--- a/build/secondary/third_party/libcxxabi/BUILD.gn
+++ b/build/secondary/third_party/libcxxabi/BUILD.gn
@@ -2,8 +2,6 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("$flutter_root/common/config.gni")
-
 config("libcxxabi_config") {
   include_dirs = [ "include" ]
 }


### PR DESCRIPTION
The buildroot may no include targets from the engine repo. Besides, this one
was unused.