### PR TITLE
Enable support for is_clang on Windows

### DIFF
--- a/build/config/BUILDCONFIG.gn
+++ b/build/config/BUILDCONFIG.gn
@@ -337,6 +337,7 @@ if (is_linux) {
 
 if (is_clang) {
   _native_compiler_configs += [ "//build/config/clang:extra_warnings" ]
+  _native_compiler_configs += [ "//build/config/clang:find_bad_constructs" ]
 }
 
 # Optimizations and debug checking.
@@ -469,8 +470,13 @@ if (custom_toolchain != "") {
   host_toolchain = "//build/toolchain/linux:clang_$host_cpu"
   set_default_toolchain("//build/toolchain/custom")
 } else if (is_win) {
+  if (is_clang) {
+    host_toolchain = "//build/toolchain/win:clang_$current_cpu"
+  } else {
+    host_toolchain = "//build/toolchain/win:$current_cpu"
+  }
+
   # On windows we use the same toolchain for host and target by default.
-  host_toolchain = "//build/toolchain/win:$current_cpu"
   set_default_toolchain("$host_toolchain")
 } else if (is_android) {
   if (host_os == "linux") {

--- a/build/config/clang/BUILD.gn
+++ b/build/config/clang/BUILD.gn
@@ -5,6 +5,10 @@
 import("//build/toolchain/clang.gni")
 import("clang.gni")
 
+# Empty entry to satisfy ANGLE build, which tries to remove this config.
+config("find_bad_constructs") {
+}
+
 # Enables some extra Clang-specific warnings. Some third-party code won't
 # compile with these so may want to remove this config.
 config("extra_warnings") {


### PR DESCRIPTION
The clang build will currently fail, but this adds the necessary build
plumbing to allow trying it if is_clang is set manually (no support yet
in the GN wrapper script, since it doesn't work yet).

Part of https://github.com/flutter/flutter/issues/16256