### PR TITLE
Fix create_updated_flutter_deps to handle repos at different paths.

### DIFF
--- a/tools/dart/create_updated_flutter_deps.py
+++ b/tools/dart/create_updated_flutter_deps.py
@@ -111,9 +111,9 @@ def Main(argv):
                 updated_value = dart_v.replace(new_vars["dart_git"], "Var('dart_git') + '/")
                 updated_value = updated_value.replace(old_vars["chromium_git"], "Var('chromium_git') + '")
 
-                plain_v = dart_v[dart_v.rfind('/')+1:dart_v.rfind('@')]
-                if plain_v.rfind('.git') != -1:
-                  plain_v = plain_v[:plain_v.rfind('.git')]
+                plain_v = dart_k[dart_k.rfind('/') + 1:]
+                if plain_v == "quiver":
+                  plain_v = "quiver-dart"
                 if ('dart_' + plain_v + '_tag' in updated_vars):
                   updated_value = updated_value[:updated_value.rfind('@')] + "' + '@' + Var('dart_" + plain_v + "_tag')"
                 elif ('dart_' + plain_v + '_rev' in updated_vars):

--- a/tools/dart/create_updated_flutter_deps.py
+++ b/tools/dart/create_updated_flutter_deps.py
@@ -112,6 +112,8 @@ def Main(argv):
                 updated_value = updated_value.replace(old_vars["chromium_git"], "Var('chromium_git') + '")
 
                 plain_v = dart_k[dart_k.rfind('/') + 1:]
+                # This dependency has to be special-cased here because the
+                # repository name is not the same as the directory name.
                 if plain_v == "quiver":
                   plain_v = "quiver-dart"
                 if ('dart_' + plain_v + '_tag' in updated_vars):


### PR DESCRIPTION
We can't rely on the repo name to identify what version tag it should use, so we use the folder name instead. Unfortunately the folder name is incorrect for "quiver-dart", so we special case it.