### PR TITLE
Use the statically linked libcxx on macOS.

### DIFF
--- a/build/config/BUILDCONFIG.gn
+++ b/build/config/BUILDCONFIG.gn
@@ -280,7 +280,7 @@ if (!is_clang && (is_asan || is_lsan || is_tsan || is_msan)) {
   is_clang = true
 }
 
-use_flutter_cxx = is_clang && (is_linux || is_android)
+use_flutter_cxx = is_clang && (is_linux || is_android || is_mac)
 
 if (is_msan && !is_linux) {
   assert(false, "Memory sanitizer is only available on Linux.")
@@ -307,6 +307,14 @@ _native_compiler_configs = [
   "//build/config/compiler:no_rtti",
   "//build/config/compiler:runtime_library",
 ]
+
+if (use_flutter_cxx) {
+  _native_compiler_configs += [
+    "//third_party/libcxxabi:libcxxabi_config",
+    "//third_party/libcxx:libcxx_config",
+  ]
+}
+
 if (is_win) {
   _native_compiler_configs += [
     "//build/config/win:lean_and_mean",

--- a/build/config/mac/BUILD.gn
+++ b/build/config/mac/BUILD.gn
@@ -9,15 +9,6 @@ config("sdk") {
 
   cflags = common_flags
   ldflags = common_flags
-
-  common_ccflags = [
-    "-nostdinc++",
-    "-isystem",
-    "$xcode_toolchain/usr/include/c++/v1",
-  ]
-
-  cflags_cc = common_ccflags
-  cflags_objcc = common_ccflags
 }
 
 # On Mac, this is used for everything except static libraries.

--- a/build/secondary/third_party/libcxx/BUILD.gn
+++ b/build/secondary/third_party/libcxx/BUILD.gn
@@ -3,7 +3,7 @@
 # found in the LICENSE file.
 
 config("libcxx_config") {
-  include_dirs = [ "include" ]
+  defines = [ "_LIBCPP_DISABLE_AVAILABILITY=1" ]
 }
 
 source_set("libcxx") {
@@ -42,6 +42,7 @@ source_set("libcxx") {
     "src/variant.cpp",
     "src/vector.cpp",
   ]
+
   # filesystem uses statvfs, which requires API level 19+.
   if (!is_android) {
     sources += [

--- a/build/secondary/third_party/libcxxabi/BUILD.gn
+++ b/build/secondary/third_party/libcxxabi/BUILD.gn
@@ -29,8 +29,6 @@ source_set("libcxxabi") {
   configs -= [ "//build/config/compiler:cxx_version_default" ]
   configs += [ "//build/config/compiler:cxx_version_11" ]
 
-  configs += [ "../libcxx:libcxx_config" ]
-
   # No translation units in the engine are built with exceptions. But, using
   # Objective-C exceptions requires some infrastructure setup for exceptions.
   # Build support for the same in cxxabi on Darwin.


### PR DESCRIPTION
Since we are now also not depending on libcxx on the underlying platform, there
is no need to restrict use of APIs that are version specific.