### PR TITLE
Use buildtools ar when building Android

### DIFF
--- a/build/toolchain/android/BUILD.gn
+++ b/build/toolchain/android/BUILD.gn
@@ -65,7 +65,9 @@ template("android_gcc_toolchain") {
       cxx = compiler_prefix + tool_prefix + "g++"
     }
 
-    ar = tool_prefix + "ar"
+    # The NDK shipped ar utility is out of date, and using it will cause linker
+    # failures for version inconsistencies.
+    ar = "ar"
     ld = cxx
     readelf = compiler_prefix + tool_prefix + "readelf"
     nm = compiler_prefix + tool_prefix + "nm"

--- a/build/toolchain/android/BUILD.gn
+++ b/build/toolchain/android/BUILD.gn
@@ -60,14 +60,13 @@ template("android_gcc_toolchain") {
 
       cc = compiler_prefix + prefix + "/clang"
       cxx = compiler_prefix + prefix + "/clang++"
+      ar = prefix + "ar"
     } else {
       cc = compiler_prefix + tool_prefix + "gcc"
       cxx = compiler_prefix + tool_prefix + "g++"
+      ar = tool_prefix + "llvm-ar"
     }
 
-    # The NDK shipped ar utility is out of date, and using it will cause linker
-    # failures for version inconsistencies.
-    ar = "ar"
     ld = cxx
     readelf = compiler_prefix + tool_prefix + "readelf"
     nm = compiler_prefix + tool_prefix + "nm"

--- a/build/toolchain/android/BUILD.gn
+++ b/build/toolchain/android/BUILD.gn
@@ -60,11 +60,11 @@ template("android_gcc_toolchain") {
 
       cc = compiler_prefix + prefix + "/clang"
       cxx = compiler_prefix + prefix + "/clang++"
-      ar = prefix + "ar"
+      ar = prefix + "/llvm-ar"
     } else {
       cc = compiler_prefix + tool_prefix + "gcc"
       cxx = compiler_prefix + tool_prefix + "g++"
-      ar = tool_prefix + "llvm-ar"
+      ar = tool_prefix + "ar"
     }
 
     ld = cxx


### PR DESCRIPTION
See comment - the mistmatch between ar versions (in particular, the NDK's ar being as old as it is) causes linker failures later.

@jason-simmons @chinmaygarde 