### PR TITLE
Remove the Java compile time dependency on rt.jar

### DIFF
--- a/build/android/gyp/javac.py
+++ b/build/android/gyp/javac.py
@@ -92,21 +92,7 @@ def DoJavac(
       '-classpath', ':'.join(classpath),
       '-d', classes_dir]
 
-  def GetJavaHome():
-    # Android's boot jar doesn't contain all java 8 classes.
-    # See: https://github.com/evant/gradle-retrolambda/issues/23.
-    # Get the path of the jdk folder by searching for the 'jar' executable. We
-    # cannot search for the 'javac' executable because goma provides a custom
-    # version of 'javac'.
-    # Can't use jar path for macOS though.
-    if sys.platform == 'darwin':
-      return subprocess.check_output(['/usr/libexec/java_home', '-v', '1.8']).strip()
-    jar_path = os.path.realpath(distutils.spawn.find_executable('jar'))
-    return os.path.dirname(os.path.dirname(jar_path))
-
   if bootclasspath:
-    rt_jar = os.path.join(GetJavaHome(), 'jre', 'lib', 'rt.jar')
-    bootclasspath.append(rt_jar)
     javac_args.extend([
         '-bootclasspath', ':'.join(bootclasspath),
         '-source', '1.8',


### PR DESCRIPTION
rt.jar is not provided by recent versions of the JDK