### PR TITLE
Add shims for Chromium Khronos compatibility

### DIFF
--- a/gpu/GLES2/gl2chromium.h
+++ b/gpu/GLES2/gl2chromium.h
@@ -1,0 +1,5 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// No content needed. See //gpu/README.md.

--- a/gpu/README.md
+++ b/gpu/README.md
@@ -1,0 +1,11 @@
+This directory exists solely to hold shims for compatibility with the Chromium 
+reposository of Khronos headers. That repo is significantly easier to use than
+the upstream verions, since:
+- The upstream headers are spread over two repositories.
+- The upstream repositories are large, due to files that aren't
+  relevant for building (see
+  https://github.com/KhronosGroup/OpenGL-Registry#there-sure-is-a-lot-of-stuff-in-here).
+- The Chromium version already has a BUILD.gn file.
+
+However, it contains slight forking to add Chromium-specific headers, so this
+folder provides dummy versions of those headers.

--- a/gpu/command_buffer/client/gles2_c_lib_export.h
+++ b/gpu/command_buffer/client/gles2_c_lib_export.h
@@ -1,0 +1,11 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// See //gpu/README.md.
+
+#if defined(_WIN32)
+#define GLES2_C_LIB_EXPORT __declspec(dllimport)
+#else
+#define GLES2_C_LIB_EXPORT
+#endif


### PR DESCRIPTION
This makes the buildroot compatible with the Chromium
Khronos repo, allowing it to be added as a third_party dependency of the
engine.

Needed for https://github.com/flutter/flutter/issues/30729