### PR TITLE
Update pkg-config scripts from Chromium

### DIFF
--- a/build/config/linux/pkg-config.py
+++ b/build/config/linux/pkg-config.py
@@ -1,6 +1,9 @@
+#!/usr/bin/env python
 # Copyright (c) 2013 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
+
+from __future__ import print_function
 
 import json
 import os
@@ -26,50 +29,48 @@ from optparse import OptionParser
 # When using a sysroot, you must also specify the architecture via
 # "-a <arch>" where arch is either "x86" or "x64".
 #
+# CrOS systemroots place pkgconfig files at <systemroot>/usr/share/pkgconfig
+# and one of <systemroot>/usr/lib/pkgconfig or <systemroot>/usr/lib64/pkgconfig
+# depending on whether the systemroot is for a 32 or 64 bit architecture. They
+# specify the 'lib' or 'lib64' of the pkgconfig path by defining the
+# 'system_libdir' variable in the args.gn file. pkg_config.gni communicates this
+# variable to this script with the "--system_libdir <system_libdir>" flag. If no
+# flag is provided, then pkgconfig files are assumed to come from
+# <systemroot>/usr/lib/pkgconfig.
+#
 # Additionally, you can specify the option --atleast-version. This will skip
 # the normal outputting of a dictionary and instead print true or false,
 # depending on the return value of pkg-config for the given package.
 
-# If this is run on non-Linux platforms, just return nothing and indicate
-# success. This allows us to "kind of emulate" a Linux build from other
-# platforms.
-if sys.platform.find("linux") == -1:
-  print "[[],[],[],[],[]]"
-  sys.exit(0)
-
 
 def SetConfigPath(options):
-  """Set the PKG_CONFIG_PATH environment variable.
+  """Set the PKG_CONFIG_LIBDIR environment variable.
+
   This takes into account any sysroot and architecture specification from the
-  options on the given command line."""
+  options on the given command line.
+  """
 
   sysroot = options.sysroot
-  if not sysroot:
-    sysroot = ""
+  assert sysroot
 
   # Compute the library path name based on the architecture.
   arch = options.arch
   if sysroot and not arch:
-    print "You must specify an architecture via -a if using a sysroot."
+    print("You must specify an architecture via -a if using a sysroot.")
     sys.exit(1)
-  if arch == 'x64':
-    libpath = 'lib64'
-  else:
-    libpath = 'lib'
 
-  # Add the sysroot path to the environment's PKG_CONFIG_PATH
-  config_path = sysroot + '/usr/' + libpath + '/pkgconfig'
-  config_path += ':' + sysroot + '/usr/share/pkgconfig'
-  if 'PKG_CONFIG_PATH' in os.environ:
-    os.environ['PKG_CONFIG_PATH'] += ':' + config_path
-  else:
-    os.environ['PKG_CONFIG_PATH'] = config_path
+  libdir = sysroot + '/usr/' + options.system_libdir + '/pkgconfig'
+  libdir += ':' + sysroot + '/usr/share/pkgconfig'
+  os.environ['PKG_CONFIG_LIBDIR'] = libdir
+  return libdir
 
 
-def GetPkgConfigPrefixToStrip(args):
+def GetPkgConfigPrefixToStrip(options, args):
   """Returns the prefix from pkg-config where packages are installed.
+
   This returned prefix is the one that should be stripped from the beginning of
-  directory names to take into account sysroots."""
+  directory names to take into account sysroots.
+  """
   # Some sysroots, like the Chromium OS ones, may generate paths that are not
   # relative to the sysroot. For example,
   # /path/to/chroot/build/x86-generic/usr/lib/pkgconfig/pkg.pc may have all
@@ -77,8 +78,8 @@ def GetPkgConfigPrefixToStrip(args):
   # instead of relative to /path/to/chroot/build/x86-generic (i.e prefix=/usr).
   # To support this correctly, it's necessary to extract the prefix to strip
   # from pkg-config's |prefix| variable.
-  prefix = subprocess.check_output(["pkg-config", "--variable=prefix"] + args,
-      env=os.environ)
+  prefix = subprocess.check_output([options.pkg_config,
+      "--variable=prefix"] + args, env=os.environ).decode('utf-8')
   if prefix[-4] == '/usr':
     return prefix[4:]
   return prefix
@@ -104,97 +105,144 @@ def RewritePath(path, strip_prefix, sysroot):
     return path
 
 
-parser = OptionParser()
-parser.add_option('-p', action='store', dest='pkg_config', type='string',
-                  default='pkg-config')
-parser.add_option('-v', action='append', dest='strip_out', type='string')
-parser.add_option('-s', action='store', dest='sysroot', type='string')
-parser.add_option('-a', action='store', dest='arch', type='string')
-parser.add_option('--atleast-version', action='store',
-                  dest='atleast_version', type='string')
-parser.add_option('--libdir', action='store_true', dest='libdir')
-(options, args) = parser.parse_args()
+def main():
+  # If this is run on non-Linux platforms, just return nothing and indicate
+  # success. This allows us to "kind of emulate" a Linux build from other
+  # platforms.
+  if "linux" not in sys.platform:
+    print("[[],[],[],[],[]]")
+    return 0
 
-# Make a list of regular expressions to strip out.
-strip_out = []
-if options.strip_out != None:
-  for regexp in options.strip_out:
-    strip_out.append(re.compile(regexp))
+  parser = OptionParser()
+  parser.add_option('-d', '--debug', action='store_true')
+  parser.add_option('-p', action='store', dest='pkg_config', type='string',
+                    default='pkg-config')
+  parser.add_option('-v', action='append', dest='strip_out', type='string')
+  parser.add_option('-s', action='store', dest='sysroot', type='string')
+  parser.add_option('-a', action='store', dest='arch', type='string')
+  parser.add_option('--system_libdir', action='store', dest='system_libdir',
+                    type='string', default='lib')
+  parser.add_option('--atleast-version', action='store',
+                    dest='atleast_version', type='string')
+  parser.add_option('--libdir', action='store_true', dest='libdir')
+  parser.add_option('--dridriverdir', action='store_true', dest='dridriverdir')
+  parser.add_option('--version-as-components', action='store_true',
+                    dest='version_as_components')
+  (options, args) = parser.parse_args()
 
-SetConfigPath(options)
-if options.sysroot:
-  prefix = GetPkgConfigPrefixToStrip(args)
-else:
-  prefix = ''
+  # Make a list of regular expressions to strip out.
+  strip_out = []
+  if options.strip_out != None:
+    for regexp in options.strip_out:
+      strip_out.append(re.compile(regexp))
 
-if options.atleast_version:
-  # When asking for the return value, just run pkg-config and print the return
-  # value, no need to do other work.
-  if not subprocess.call([options.pkg_config,
-                          "--atleast-version=" + options.atleast_version] +
-                          args,
-                         env=os.environ):
-    print "true"
+  if options.sysroot:
+    libdir = SetConfigPath(options)
+    if options.debug:
+      sys.stderr.write('PKG_CONFIG_LIBDIR=%s\n' % libdir)
+    prefix = GetPkgConfigPrefixToStrip(options, args)
   else:
-    print "false"
-  sys.exit(0)
+    prefix = ''
 
-if options.libdir:
+  if options.atleast_version:
+    # When asking for the return value, just run pkg-config and print the return
+    # value, no need to do other work.
+    if not subprocess.call([options.pkg_config,
+                            "--atleast-version=" + options.atleast_version] +
+                            args):
+      print("true")
+    else:
+      print("false")
+    return 0
+
+  if options.version_as_components:
+    cmd = [options.pkg_config, "--modversion"] + args
+    try:
+      version_string = subprocess.check_output(cmd).decode('utf-8')
+    except:
+      sys.stderr.write('Error from pkg-config.\n')
+      return 1
+    print(json.dumps(list(map(int, version_string.strip().split(".")))))
+    return 0
+
+
+  if options.libdir:
+    cmd = [options.pkg_config, "--variable=libdir"] + args
+    if options.debug:
+      sys.stderr.write('Running: %s\n' % cmd)
+    try:
+      libdir = subprocess.check_output(cmd).decode('utf-8')
+    except:
+      print("Error from pkg-config.")
+      return 1
+    sys.stdout.write(libdir.strip())
+    return 0
+
+  if options.dridriverdir:
+    cmd = [options.pkg_config, "--variable=dridriverdir"] + args
+    if options.debug:
+      sys.stderr.write('Running: %s\n' % cmd)
+    try:
+      dridriverdir = subprocess.check_output(cmd).decode('utf-8')
+    except:
+      print("Error from pkg-config.")
+      return 1
+    sys.stdout.write(dridriverdir.strip())
+    return
+
+  cmd = [options.pkg_config, "--cflags", "--libs"] + args
+  if options.debug:
+    sys.stderr.write('Running: %s\n' % ' '.join(cmd))
+
   try:
-    libdir = subprocess.check_output([options.pkg_config,
-                                      "--variable=libdir"] +
-                                     args,
-                                     env=os.environ)
+    flag_string = subprocess.check_output(cmd).decode('utf-8')
   except:
-    print "Error from pkg-config."
-    sys.exit(1)
-  sys.stdout.write(libdir.strip())
-  sys.exit(0)
+    sys.stderr.write('Could not run pkg-config.\n')
+    return 1
 
-try:
-  flag_string = subprocess.check_output(
-      [ options.pkg_config, "--cflags", "--libs-only-l", "--libs-only-L" ] +
-      args, env=os.environ)
   # For now just split on spaces to get the args out. This will break if
   # pkgconfig returns quoted things with spaces in them, but that doesn't seem
   # to happen in practice.
   all_flags = flag_string.strip().split(' ')
-except:
-  print "Could not run pkg-config."
-  sys.exit(1)
 
 
-sysroot = options.sysroot
-if not sysroot:
-  sysroot = ''
+  sysroot = options.sysroot
+  if not sysroot:
+    sysroot = ''
 
-includes = []
-cflags = []
-libs = []
-lib_dirs = []
-ldflags = []
+  includes = []
+  cflags = []
+  libs = []
+  lib_dirs = []
 
-for flag in all_flags[:]:
-  if len(flag) == 0 or MatchesAnyRegexp(flag, strip_out):
-    continue;
+  for flag in all_flags[:]:
+    if len(flag) == 0 or MatchesAnyRegexp(flag, strip_out):
+      continue;
 
-  if flag[:2] == '-l':
-    libs.append(RewritePath(flag[2:], prefix, sysroot))
-  elif flag[:2] == '-L':
-    lib_dirs.append(RewritePath(flag[2:], prefix, sysroot))
-  elif flag[:2] == '-I':
-    includes.append(RewritePath(flag[2:], prefix, sysroot))
-  elif flag[:3] == '-Wl':
-    ldflags.append(flag)
-  elif flag == '-pthread':
-    # Many libs specify "-pthread" which we don't need since we always include
-    # this anyway. Removing it here prevents a bunch of duplicate inclusions on
-    # the command line.
-    pass
-  else:
-    cflags.append(flag)
+    if flag[:2] == '-l':
+      libs.append(RewritePath(flag[2:], prefix, sysroot))
+    elif flag[:2] == '-L':
+      lib_dirs.append(RewritePath(flag[2:], prefix, sysroot))
+    elif flag[:2] == '-I':
+      includes.append(RewritePath(flag[2:], prefix, sysroot))
+    elif flag[:3] == '-Wl':
+      # Don't allow libraries to control ld flags.  These should be specified
+      # only in build files.
+      pass
+    elif flag == '-pthread':
+      # Many libs specify "-pthread" which we don't need since we always include
+      # this anyway. Removing it here prevents a bunch of duplicate inclusions
+      # on the command line.
+      pass
+    else:
+      cflags.append(flag)
 
-# Output a GN array, the first one is the cflags, the second are the libs. The
-# JSON formatter prints GN compatible lists when everything is a list of
-# strings.
-print json.dumps([includes, cflags, libs, lib_dirs, ldflags])
+  # Output a GN array, the first one is the cflags, the second are the libs. The
+  # JSON formatter prints GN compatible lists when everything is a list of
+  # strings.
+  print(json.dumps([includes, cflags, libs, lib_dirs]))
+  return 0
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/build/config/linux/pkg_config.gni
+++ b/build/config/linux/pkg_config.gni
@@ -104,7 +104,7 @@ template("pkg_config") {
     cflags = pkgresult[1]
 
     foreach(include, pkgresult[0]) {
-      if (use_sysroot) {
+      if (sysroot != "") {
         # We want the system include paths to use -isystem instead of -I to
         # suppress warnings in those headers.
         include_relativized = rebase_path(include, root_build_dir)

--- a/build/config/linux/pkg_config.gni
+++ b/build/config/linux/pkg_config.gni
@@ -31,53 +31,98 @@ declare_args() {
   # Leaving it blank defaults to searching PATH for 'pkg-config' and relying on
   # the sysroot mechanism to find the right .pc files.
   pkg_config = ""
+
+  # A optional pkg-config wrapper to use for tools built on the host.
+  host_pkg_config = ""
+
+  # CrOS systemroots place pkgconfig files at <systemroot>/usr/share/pkgconfig
+  # and one of <systemroot>/usr/lib/pkgconfig or <systemroot>/usr/lib64/pkgconfig
+  # depending on whether the systemroot is for a 32 or 64 bit architecture.
+  #
+  # When build under GYP, CrOS board builds specify the 'system_libdir' variable
+  # as part of the GYP_DEFINES provided by the CrOS emerge build or simple
+  # chrome build scheme. This variable permits controlling this for GN builds
+  # in similar fashion by setting the `system_libdir` variable in the build's
+  # args.gn file to 'lib' or 'lib64' as appropriate for the target architecture.
+  system_libdir = "lib"
 }
 
 pkg_config_script = "//build/config/linux/pkg-config.py"
 
 # Define the args we pass to the pkg-config script for other build files that
 # need to invoke it manually.
+pkg_config_args = []
+
 if (sysroot != "") {
   # Pass the sysroot if we're using one (it requires the CPU arch also).
-  pkg_config_args = [
+  pkg_config_args += [
     "-s",
-    sysroot,
+    rebase_path(sysroot),
     "-a",
     current_cpu,
   ]
-} else if (pkg_config != "") {
-  pkg_config_args = [
+}
+
+if (pkg_config != "") {
+  pkg_config_args += [
     "-p",
     pkg_config,
   ]
+}
+
+# Only use the custom libdir when building with the target sysroot.
+if (target_sysroot != "" && sysroot == target_sysroot) {
+  pkg_config_args += [
+    "--system_libdir",
+    system_libdir,
+  ]
+}
+
+if (host_pkg_config != "") {
+  host_pkg_config_args = [
+    "-p",
+    host_pkg_config,
+  ]
 } else {
-  pkg_config_args = []
+  host_pkg_config_args = pkg_config_args
 }
 
 template("pkg_config") {
   assert(defined(invoker.packages),
          "Variable |packages| must be defined to be a list in pkg_config.")
   config(target_name) {
-    args = pkg_config_args + invoker.packages
+    if (host_toolchain == current_toolchain) {
+      args = host_pkg_config_args + invoker.packages
+    } else {
+      args = pkg_config_args + invoker.packages
+    }
     if (defined(invoker.extra_args)) {
       args += invoker.extra_args
     }
 
     pkgresult = exec_script(pkg_config_script, args, "value")
-    include_dirs = pkgresult[0]
     cflags = pkgresult[1]
+
+    foreach(include, pkgresult[0]) {
+      if (use_sysroot) {
+        # We want the system include paths to use -isystem instead of -I to
+        # suppress warnings in those headers.
+        include_relativized = rebase_path(include, root_build_dir)
+        cflags += [ "-isystem$include_relativized" ]
+      } else {
+        cflags += [ "-I$include" ]
+      }
+    }
 
     if (!defined(invoker.ignore_libs) || !invoker.ignore_libs) {
       libs = pkgresult[2]
       lib_dirs = pkgresult[3]
-      ldflags = pkgresult[4]
     }
 
-    if (defined(invoker.defines)) {
-      defines = invoker.defines
-    }
-    if (defined(invoker.visibility)) {
-      visibility = invoker.visibility
-    }
+    forward_variables_from(invoker,
+                           [
+                             "defines",
+                             "visibility",
+                           ])
   }
 }


### PR DESCRIPTION
The pkg-config scripts, inherited from Chromium, know about the sysroot structure. However, when the sysroot scripts were update from recent Chromium copies, the pgk-config scripts weren't, so it was not using the correct pkg-config path.

This updates these scripts from the current Chromium copies, with one minor change in the .gni file to account for a difference in our copy of sysroot.gni.