### PR TITLE
-Oz for Fuchsia, Linux

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -882,7 +882,7 @@ config("optimize") {
     cflags = [ "/O1" ] + common_optimize_on_cflags + [ "/Oi" ]
   } else if (is_ios) {
     cflags = [ "-Os" ] + common_optimize_on_cflags  # Favor size over speed.
-  } else if (is_android) {
+  } else if (is_android || is_fuchsia || is_linux) {
     cflags = [ "-Oz" ] + common_optimize_on_cflags  # Favor size over speed.
     if (enable_lto) {
       lto_flags += [ "-flto" ]


### PR DESCRIPTION
This reduces the size of the Flutter runner for arm64 significantly. I expect there will be some performance reductions related to it. Some of that may be mitigated by https://dart-review.googlesource.com/c/sdk/+/135791, which applies `-O3` to certain parts of Dart that are more performance critical.

/cc @nathanrogersgoogle @fmeawad
/cc @a-siva @rmacnak-google 

Before this patch:

```
48568   out/fuchsia_release_arm64/flutter_aot_product_runner-0.far
73192   out/fuchsia_release_arm64/flutter_jit_product_runner-0.far
```

After:

```
45064   out/fuchsia_release_arm64/flutter_aot_product_runner-0.far
69640   out/fuchsia_release_arm64/flutter_jit_product_runner-0.far
```

Those are 512k blocks, so AOT product runner goes from 24.87MB to 23.07MB, JIT from 37.47MB to 35.66MB.