### PR TITLE
fuchsia: Fix broken unoptimized build

### DIFF
--- a/build/config/BUILD.gn
+++ b/build/config/BUILD.gn
@@ -64,7 +64,10 @@ config("feature_flags") {
 # Debug/release ----------------------------------------------------------------
 
 config("debug") {
-  defines = [ "_DEBUG" ]
+  defines = [
+    "DEBUG",  # Dart uses DEBUG
+    "_DEBUG",  # Swiftshader uses _DEBUG
+  ]
 
   if (is_win) {
     if (disable_iterator_debugging) {


### PR DESCRIPTION
Dart headers require either DEBUG or NDEBUG to be defined, but Flutter
only defines _DEBUG during unoptimized builds.