### PR TITLE
Revert "fuchsia: Fix broken unoptimized build"

### DIFF
--- a/build/config/BUILD.gn
+++ b/build/config/BUILD.gn
@@ -64,10 +64,7 @@ config("feature_flags") {
 # Debug/release ----------------------------------------------------------------
 
 config("debug") {
-  defines = [
-    "DEBUG",  # Dart uses DEBUG
-    "_DEBUG",  # Swiftshader uses _DEBUG
-  ]
+  defines = [ "_DEBUG" ]
 
   if (is_win) {
     if (disable_iterator_debugging) {


### PR DESCRIPTION
Reverts flutter/buildroot#370

Unfortunately this breaks other build configurations, and the problem is Fuchsia-specific anyways.  It will be better to fix this in the flutter_runner code (or the dart code that is contributing to this problem).

Context:
https://github.com/flutter/engine/pull/17876
https://github.com/dart-lang/sdk/issues/41523
