### PR TITLE
Drop -Oz for Linux

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -882,7 +882,7 @@ config("optimize") {
     cflags = [ "/O1" ] + common_optimize_on_cflags + [ "/Oi" ]
   } else if (is_ios) {
     cflags = [ "-Os" ] + common_optimize_on_cflags  # Favor size over speed.
-  } else if (is_android || is_fuchsia || is_linux) {
+  } else if (is_android || is_fuchsia) {
     cflags = [ "-Oz" ] + common_optimize_on_cflags  # Favor size over speed.
     if (enable_lto) {
       lto_flags += [ "-flto" ]


### PR DESCRIPTION
This has vastly increased the time to build host_debug on CI - from about 5 minutes (https://ci.chromium.org/p/flutter/builders/prod/Linux%20Host%20Engine/5236) to about 45 minutes (https://ci.chromium.org/p/flutter/builders/prod/Linux%20Host%20Engine/5237), and it is impacting the time it takes to do the HHH build significantly.

If we want this back, we should consider what benefits we're getting from it, and whether it should be targetted only at host_release builds.

@chinmaygarde @stuartmorgan @jason-simmons 