### PR TITLE
Ignore file case mismatches for Windows goma builds

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -642,6 +642,7 @@ if (is_win) {
     "/wd4311",  # Pointer truncation from PVOID to DWORD.
     "/wd4477",  # Format string requires wchar_t*
   ]
+  import("//build/toolchain/goma.gni")
   if (is_clang && use_goma) {
     # goma compilation doesn't preserve file case, so don't warn about
     # case-mismatches.

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -642,6 +642,14 @@ if (is_win) {
     "/wd4311",  # Pointer truncation from PVOID to DWORD.
     "/wd4477",  # Format string requires wchar_t*
   ]
+  if (is_clang && use_goma) {
+    # goma compilation doesn't preserve file case, so don't warn about
+    # case-mismatches.
+    default_warning_flags += [
+      "-Wno-nonportable-include-path",
+      "-Wno-nonportable-system-include-path",
+    ]
+  }
 } else {
   # Common GCC warning setup.
   default_warning_flags += [


### PR DESCRIPTION
Apparently goma builds don't preserve file case, causing lots of warnings about non-portable include paths. This eliminates ~249,000 warnings for the Windows Host Engine builds, making the log file several orders of magnitude smaller and making it usable when opened in the browser.

Addresses most of https://github.com/flutter/flutter/issues/59199