### PR TITLE
Differentiate clang invocation when targeting x86 vs x64 on Windows.

### DIFF
--- a/build/toolchain/win/BUILD.gn
+++ b/build/toolchain/win/BUILD.gn
@@ -78,7 +78,7 @@ template("msvc_toolchain") {
       #precompiled_header_type = "msvc"
       pdbname = "{{target_out_dir}}/{{target_output_name}}_c.pdb"
       flags = ""
-      if (invoker.current_cpu == "x86") {
+      if (is_clang && invoker.current_cpu == "x86") {
         flags = "-m32"
       }
       command = "ninja -t msvc -e $env -- $cl $flags /nologo /showIncludes /FC @$rspfile /c {{source}} /Fo{{output}} /Fd$pdbname"
@@ -99,7 +99,7 @@ template("msvc_toolchain") {
       # The PDB name needs to be different between C and C++ compiled files.
       pdbname = "{{target_out_dir}}/{{target_output_name}}_cc.pdb"
       flags = ""
-      if (invoker.current_cpu == "x86") {
+      if (is_clang && invoker.current_cpu == "x86") {
         flags = "-m32"
       }
       command = "ninja -t msvc -e $env -- $cl $flags /nologo /showIncludes /FC @$rspfile /c {{source}} /Fo{{output}} /Fd$pdbname"

--- a/build/toolchain/win/BUILD.gn
+++ b/build/toolchain/win/BUILD.gn
@@ -77,7 +77,11 @@ template("msvc_toolchain") {
       # TODO(brettw) enable this when GN support in the binary has been rolled.
       #precompiled_header_type = "msvc"
       pdbname = "{{target_out_dir}}/{{target_output_name}}_c.pdb"
-      command = "ninja -t msvc -e $env -- $cl /nologo /showIncludes /FC @$rspfile /c {{source}} /Fo{{output}} /Fd$pdbname"
+      flags = ""
+      if (invoker.current_cpu == "x86") {
+        flags = "-m32"
+      }
+      command = "ninja -t msvc -e $env -- $cl $flags /nologo /showIncludes /FC @$rspfile /c {{source}} /Fo{{output}} /Fd$pdbname"
       depsformat = "msvc"
       description = "CC {{output}}"
       outputs = [
@@ -94,7 +98,11 @@ template("msvc_toolchain") {
 
       # The PDB name needs to be different between C and C++ compiled files.
       pdbname = "{{target_out_dir}}/{{target_output_name}}_cc.pdb"
-      command = "ninja -t msvc -e $env -- $cl /nologo /showIncludes /FC @$rspfile /c {{source}} /Fo{{output}} /Fd$pdbname"
+      flags = ""
+      if (invoker.current_cpu == "x86") {
+        flags = "-m32"
+      }
+      command = "ninja -t msvc -e $env -- $cl $flags /nologo /showIncludes /FC @$rspfile /c {{source}} /Fo{{output}} /Fd$pdbname"
       depsformat = "msvc"
       description = "CXX {{output}}"
       outputs = [


### PR DESCRIPTION
This fixes building of android gen_snapshot with clang.

This is along the same lines that were done in dart sdk https://dart-review.googlesource.com/c/sdk/+/142704