### PR TITLE
Add support of cross-building  the engine for ARM64 Linux Host

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@
 Google Inc.
 Jim Simon <jim.j.simon@gmail.com>
 The Fuchsia Authors
+Hidenori Matsubayashi <Hidenori.Matsubayashi@sony.com>

--- a/build/config/sysroot.gni
+++ b/build/config/sysroot.gni
@@ -27,8 +27,12 @@ if (current_toolchain == default_toolchain && target_sysroot != "") {
 } else if (is_linux && !is_chromeos) {
   if (current_cpu == "mipsel") {
     sysroot = rebase_path("//mipsel-sysroot/sysroot")
-  } else if (use_default_linux_sysroot && !is_fuchsia && current_cpu == "x64") {
-    sysroot = rebase_path("//build/linux/debian_sid_amd64-sysroot")
+  } else if (use_default_linux_sysroot && !is_fuchsia) {
+    if (current_cpu == "x64") {
+      sysroot = rebase_path("//build/linux/debian_sid_amd64-sysroot")
+    } else {
+      sysroot = rebase_path("//build/linux/debian_sid_arm64-sysroot")
+    }
     assert(
         exec_script("//build/dir_exists.py", [ sysroot ], "string") == "True",
         "Missing sysroot ($sysroot). To fix, run: build/linux/sysroot_scripts/install-sysroot.py --arch=$current_cpu")

--- a/build/toolchain/gcc_toolchain.gni
+++ b/build/toolchain/gcc_toolchain.gni
@@ -172,7 +172,7 @@ template("gcc_toolchain") {
       tocfile = sofile + ".TOC"
       temporary_tocname = sofile + ".tmp"
       link_command = "$ld -shared {{ldflags}} $coverage_flags -o $sofile -Wl,--build-id=sha1 -Wl,-soname=$soname @$rspfile"
-      toc_command = "{ $readelf -d $sofile | grep SONAME ; $nm -gD -f p $sofile | cut -f1-2 -d' '; } > $temporary_tocname"
+      toc_command = "{ $readelf -d $sofile | grep SONAME ; $nm -gD -f posix $sofile | cut -f1-2 -d' '; } > $temporary_tocname"
       replace_command = "if ! cmp -s $temporary_tocname $tocfile; then mv $temporary_tocname $tocfile; fi"
 
       command = "$link_command && $toc_command && $replace_command"

--- a/build/toolchain/gcc_toolchain.gni
+++ b/build/toolchain/gcc_toolchain.gni
@@ -45,6 +45,9 @@ analyzer_wrapper =
 #      Location of the strip executable. When specified, strip will be run on
 #      all shared libraries and executables as they are built. The pre-stripped
 #      artifacts will be put in lib.stripped/ and exe.stripped/.
+#  - llvm_objcopy
+#      Location of the llvm-objcopy executable. Used as strip instead of strip
+#      when specified.
 template("gcc_toolchain") {
   toolchain(target_name) {
     assert(defined(invoker.cc), "gcc_toolchain() must specify a \"cc\" value")
@@ -214,7 +217,7 @@ template("gcc_toolchain") {
       rspfile = "$outfile.rsp"
       unstripped_outfile = outfile
 
-      if (defined(invoker.strip)) {
+      if (defined(invoker.strip) || defined(invoker.llvm_objcopy)) {
         unstripped_outfile = "{{root_out_dir}}/exe.unstripped/$exename"
       }
 
@@ -223,6 +226,10 @@ template("gcc_toolchain") {
         strip = invoker.strip
         strip_command =
             "${strip} --strip-unneeded -o $outfile $unstripped_outfile"
+        command += " && " + strip_command
+      } else if (defined(invoker.llvm_objcopy)) {
+        strip = invoker.llvm_objcopy
+        strip_command = "${strip} --strip-all $unstripped_outfile $outfile"
         command += " && " + strip_command
       }
       if (defined(invoker.postlink)) {

--- a/build/toolchain/linux/BUILD.gn
+++ b/build/toolchain/linux/BUILD.gn
@@ -100,7 +100,7 @@ gcc_toolchain("clang_arm64") {
   nm = "nm"
   ar = "ar"
   ld = cxx
-  strip = "${compiler_prefix}$prefix/llvm-strip"
+  llvm_objcopy = "${prefix}/llvm-objcopy"
 
   toolchain_cpu = "arm64"
   toolchain_os = "linux"

--- a/build/toolchain/linux/BUILD.gn
+++ b/build/toolchain/linux/BUILD.gn
@@ -98,7 +98,7 @@ gcc_toolchain("clang_arm64") {
 
   readelf = "readelf"
   nm = "nm"
-  ar = "ar"
+  ar = "${prefix}/llvm-ar"
   ld = cxx
   llvm_objcopy = "${prefix}/llvm-objcopy"
 

--- a/build/toolchain/linux/BUILD.gn
+++ b/build/toolchain/linux/BUILD.gn
@@ -100,7 +100,6 @@ gcc_toolchain("clang_arm64") {
   nm = "nm"
   ar = "ar"
   ld = cxx
-  strip = "strip"
 
   toolchain_cpu = "arm64"
   toolchain_os = "linux"

--- a/build/toolchain/linux/BUILD.gn
+++ b/build/toolchain/linux/BUILD.gn
@@ -100,6 +100,7 @@ gcc_toolchain("clang_arm64") {
   nm = "nm"
   ar = "ar"
   ld = cxx
+  strip = "${compiler_prefix}$prefix/llvm-strip"
 
   toolchain_cpu = "arm64"
   toolchain_os = "linux"

--- a/build/toolchain/linux/BUILD.gn
+++ b/build/toolchain/linux/BUILD.gn
@@ -97,7 +97,7 @@ gcc_toolchain("clang_arm64") {
   cxx = "${compiler_prefix}$prefix/clang++"
 
   readelf = "readelf"
-  nm = "nm"
+  nm = "${prefix}/llvm-nm"
   ar = "${prefix}/llvm-ar"
   ld = cxx
   llvm_objcopy = "${prefix}/llvm-objcopy"


### PR DESCRIPTION
## Description

Added cross-building Flutter Engine for ARM64 Linux platforms. This PR is part of ARM64 Linux support in the Flutter SDK.

## Related PRs
 - [ ] https://github.com/flutter/flutter/pull/61221
 - [x] https://github.com/flutter/engine/pull/20254

## Related Issues
* https://github.com/flutter/flutter/issues/56992
* https://github.com/flutter/flutter/issues/60678

## Tests
### 1. Build Test
First, I confirmed that Flutter Engine can be built for x64 and arm64. The procedure is as follows. All are operations on x64 Linux Host.

Get source code and setup build enviroment.

```
create .gclient file.
$ gclient sync
$ cd src
````

Cross-build for ARM64 Linux

```
$ ./flutter/tools/gn --target-os linux --linux-cpu arm64 --runtime-mode release
$ ninja -C out/linux_release_arm64
-> Passed!

$ ./flutter/tools/gn --target-os linux --linux-cpu arm64 --runtime-mode debug
$ ninja -C out/linux_debug_arm64
-> Passed!
```

Build for x64 Linux and Regression test.

```
$ ./flutter/tools/gn --unoptimized
$ ninja -C out/host_debug_unopt
-> Passed!

$ ./flutter/testing/run_tests.sh
-> All Tests Passed!
```

### 2. Run Flutter SDK and app on ARM64 Linux (Jetson Nano)

Second, using the artifacts for ARM64 built by the above procedure, I have confirmed that the Flutter SDK and Flutter app can work fine on Jetson Nano (ARM64 CPU).

All are operations on ARM64 Linux Host (Jetson Nano).

```
$ git clone https://github.com/flutter/flutter.git
$ export PATH=$PATH:{your working dir path}/flutter/bin
$ flutter doctor
   ... Error happened.
```

Copy `dart-sdk` which was locally built to `${your installpath}/bin/cache/`.

```
$ flutter doctor
$ flutter config --enable-linux-desktop
$ flutter create sample
$ cd sample
$ flutter build linux
   ... Error happened.
```

Copy the Flutter SDK artifacts (build data) to `${your installpath}/bin/cache/artifacts/engine` directory manually.

 -  `out/linux_debug_arm64/flutter_patched_sdk` to `${your installpath}/bin/cache/artifacts/engine/common/flutter_patched_sdk`
 -  `out/linux_debug_arm64/flutter_linux, gen/const_finder.dart.snapshot, flutter_tester, font-subset, gen/frontend_server.dart.snapshot, icudtl.dat, libflutter_linux_gtk.so, gen/flutter/lib/snapshot/isolate_snapshot.bin, gen/flutter/lib/snapshot/vm_isolate_snapshot.bin` to `${your installpath}/bin/cache/artifacts/engine/artifacts/engine/linux-x64`

-  `out/linux_release_arm64/flutter_patched_sdk` to `${your installpath}/bin/cache/artifacts/engine/common/flutter_patched_sdk_product`
 -  `out/linux_release_arm64/flutter_linux, libflutter_linux_gtk.so` to `${your installpath}/bin/cache/artifacts/engine/artifacts/engine/linux-x64-release`
 -  `out/linux_release_arm64/clang_x64/gen_snapshot` to `${your installpath}/bin/cache/artifacts/engine/artifacts/engine/linux-x64-release`

* For simple operation check, `${your installpath}/bin/cache/artifacts/engine/artifacts/engine/linux-x64-profile` is omitted.

```
( $ flutter build linux --verbose )
$ flutter run -d linux
```

![Screenshot from 2020-08-05 12-52-42](https://user-images.githubusercontent.com/62131389/89372186-729c6980-d720-11ea-861d-1de1cbc57e08.png)