### PR TITLE
Buildroot update for Fuchsia toolchain update.

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -336,6 +336,7 @@ config("compiler") {
       "STRICT=1",
       "-s",
       "WARN_UNALIGNED=1",
+
       # Reduces global namespace pollution.
       "-s",
       "MODULARIZE=1",
@@ -679,6 +680,7 @@ if (is_win) {
     default_warning_flags += [
       # zlib needs this
       "-Wno-shift-negative-value",
+
       # freetype2 needs these two
       "-Wno-unused-function",
       "-Wno-unused-variable",
@@ -708,6 +710,14 @@ if (is_win) {
 
   if (allow_deprecated_api_calls) {
     default_warning_flags += [ "-Wno-deprecated-declarations" ]
+  }
+
+  if (is_fuchsia) {
+    default_warning_flags += [
+      "-Wno-deprecated-copy",  # Multiple
+      "-Wno-psabi",  # Skia
+      "-Wno-non-c-typedef-for-linkage",  # Skia
+    ]
   }
 }
 
@@ -931,8 +941,11 @@ config("no_optimize") {
     }
     ldflags = common_optimize_on_ldflags
   } else if (is_wasm) {
-    cflags = [ "-O0", "-g4" ]
-  } else  {
+    cflags = [
+      "-O0",
+      "-g4",
+    ]
+  } else {
     cflags = [ "-O0" ]
   }
 }

--- a/build/secondary/third_party/swiftshader_flutter/BUILD.gn
+++ b/build/secondary/third_party/swiftshader_flutter/BUILD.gn
@@ -11,8 +11,10 @@ config("internal_config") {
     "$source_root/src/OpenGL",
   ]
 
+  cflags = []
+
   if (is_win) {
-    cflags = [
+    cflags += [
       "/wd4005",
       "/wd4018",
       "/wd4141",
@@ -33,7 +35,7 @@ config("internal_config") {
       "/wd5030",
     ]
   } else {
-    cflags = [
+    cflags += [
       "-Wno-header-hygiene",
       "-Wno-newline-eof",
       "-Wno-nonportable-include-path",
@@ -41,6 +43,10 @@ config("internal_config") {
       "-Wno-undefined-var-template",
       "-Wno-unneeded-internal-declaration",
     ]
+  }
+
+  if (is_fuchsia) {
+    cflags += [ "-Wno-range-loop-construct" ]
   }
 
   defines = [ "NO_SANITIZE_FUNCTION=" ]
@@ -303,15 +309,11 @@ source_set("wsi") {
   }
 
   if (is_win) {
-    sources += [
-      "$source_root/src/WSI/Win32SurfaceKHR.cpp",
-    ]
+    sources += [ "$source_root/src/WSI/Win32SurfaceKHR.cpp" ]
   }
 
   if (is_mac) {
-    sources += [
-      "$source_root/src/WSI/MetalSurface.mm",
-    ]
+    sources += [ "$source_root/src/WSI/MetalSurface.mm" ]
     libs = [
       "Cocoa.framework",
       "QuartzCore.framework",
@@ -341,9 +343,7 @@ source_set("reactor") {
     "$source_root/src/Reactor/Reactor.cpp",
   ]
 
-  deps = [
-    ":subzero",
-  ]
+  deps = [ ":subzero" ]
 }
 
 source_set("renderer") {
@@ -377,9 +377,7 @@ source_set("renderer") {
     "$source_root/src/Renderer/VertexProcessor.cpp",
   ]
 
-  deps = [
-    ":shader",
-  ]
+  deps = [ ":shader" ]
 }
 
 source_set("marl") {
@@ -550,9 +548,7 @@ source_set("opengl_compiler") {
     sources += [ "$source_root/src/OpenGL/compiler/ossource_posix.cpp" ]
   }
 
-  deps = [
-    ":opengl_preprocessor",
-  ]
+  deps = [ ":opengl_preprocessor" ]
 }
 
 source_set("shader") {
@@ -582,9 +578,7 @@ source_set("shader") {
     "$source_root/src/Shader/VertexShader.cpp",
   ]
 
-  deps = [
-    ":main",
-  ]
+  deps = [ ":main" ]
 }
 
 source_set("system") {
@@ -616,11 +610,8 @@ source_set("system") {
   ]
 
   if (is_linux || is_android) {
-    sources += [
-      "$source_root/src/System/Linux/MemFd.cpp",
-    ]
+    sources += [ "$source_root/src/System/Linux/MemFd.cpp" ]
   }
-
 }
 
 source_set("device") {
@@ -634,8 +625,10 @@ source_set("device") {
     configs -= [ "//build/config/win:unicode" ]
   }
 
-  include_dirs = [ "$source_root/third_party/SPIRV-Headers/include",
-  "$source_root/third_party/marl/include", ]
+  include_dirs = [
+    "$source_root/third_party/SPIRV-Headers/include",
+    "$source_root/third_party/marl/include",
+  ]
 
   sources = [
     "$source_root/src/Device/Blitter.cpp",
@@ -688,9 +681,7 @@ source_set("main") {
     ]
   }
 
-  deps = [
-    ":common",
-  ]
+  deps = [ ":common" ]
 }
 
 shared_library("egl") {
@@ -871,17 +862,21 @@ shared_library("vulkan") {
     output_name = "libvk_swiftshader"
   }
 
-  configs += [ ":internal_config",
-               ":swiftshader_libvulkan_private_config", ]
+  configs += [
+    ":internal_config",
+    ":swiftshader_libvulkan_private_config",
+  ]
   configs -= [ "//build/config/compiler:cxx_version_default" ]
   configs += [ "//build/config/compiler:cxx_version_14" ]
 
   public_configs = [ ":swiftshader_config" ]
 
-  include_dirs = [ "$source_root/src/Vulkan",
-                   "$source_root/third_party/marl/include",
-    "$source_root/third_party/SPIRV-Headers/include", 
-    "$source_root/third_party/SPIRV-Tools/include",]
+  include_dirs = [
+    "$source_root/src/Vulkan",
+    "$source_root/third_party/marl/include",
+    "$source_root/third_party/SPIRV-Headers/include",
+    "$source_root/third_party/SPIRV-Tools/include",
+  ]
 
   public = []
 
@@ -922,13 +917,13 @@ shared_library("vulkan") {
   ]
 
   deps = [
-    ":marl",
+    ":SPIRV-Tools",
     ":device",
+    ":marl",
     ":pipeline",
     ":reactor",
-    ":wsi",
     ":system",
-    ":SPIRV-Tools",
+    ":wsi",
   ]
 
   libs = []
@@ -938,14 +933,14 @@ shared_library("vulkan") {
     ldflags = [
       "-Wl,-install_name,@rpath/libvk_swiftshader.dylib",
       "-Wl,-exported_symbols_list," +
-          rebase_path("$source_root/src/Vulkan/vk_swiftshader.exports", root_build_dir),
+          rebase_path("$source_root/src/Vulkan/vk_swiftshader.exports",
+                      root_build_dir),
     ]
   } else if (is_linux || is_fuchsia) {
-    inputs = [
-      "$source_root/src/Vulkan/vk_swiftshader.lds",
-    ]
+    inputs = [ "$source_root/src/Vulkan/vk_swiftshader.lds" ]
     ldflags = [ "-Wl,--version-script=" +
-                rebase_path("$source_root/src/Vulkan/vk_swiftshader.lds", root_build_dir) ]
+                rebase_path("$source_root/src/Vulkan/vk_swiftshader.lds",
+                            root_build_dir) ]
   }
 }
 
@@ -965,9 +960,7 @@ group("swiftshader_gl") {
 }
 
 group("swiftshader_vulkan") {
-  deps = [
-    ":vulkan",
-  ]
+  deps = [ ":vulkan" ]
 }
 
 spirv_headers = "//third_party/swiftshader/third_party/SPIRV-Headers"
@@ -987,9 +980,7 @@ template("spvtools_core_tables") {
     operand_kinds_file = "${target_gen_dir}/operand.kinds-$version.inc"
     extinst_file = "$spirv_tools/source/extinst.debuginfo.grammar.json"
 
-    sources = [
-      core_json_file,
-    ]
+    sources = [ core_json_file ]
     outputs = [
       core_insts_file,
       operand_kinds_file,
@@ -1031,9 +1022,7 @@ template("spvtools_core_enums") {
       "--enum-string-mapping-output",
       rebase_path(extension_map_file, root_build_dir),
     ]
-    inputs = [
-      core_json_file,
-    ]
+    inputs = [ core_json_file ]
     outputs = [
       extension_enum_file,
       extension_map_file,
@@ -1069,9 +1058,7 @@ template("spvtools_glsl_tables") {
       core_json_file,
       glsl_json_file,
     ]
-    outputs = [
-      glsl_insts_file,
-    ]
+    outputs = [ glsl_insts_file ]
   }
 }
 
@@ -1103,9 +1090,7 @@ template("spvtools_opencl_tables") {
       core_json_file,
       opengl_json_file,
     ]
-    outputs = [
-      opencl_insts_file,
-    ]
+    outputs = [ opencl_insts_file ]
   }
 }
 
@@ -1127,12 +1112,8 @@ template("spvtools_language_header") {
       "--extinst-output-base",
       rebase_path(extinst_output_base, root_build_dir),
     ]
-    inputs = [
-      debug_insts_file,
-    ]
-    outputs = [
-      "${extinst_output_base}.h",
-    ]
+    inputs = [ debug_insts_file ]
+    outputs = [ "${extinst_output_base}.h" ]
   }
 }
 
@@ -1152,12 +1133,8 @@ template("spvtools_vendor_table") {
       "--vendor-insts-output",
       rebase_path(extinst_file, root_build_dir),
     ]
-    inputs = [
-      extinst_vendor_grammar,
-    ]
-    outputs = [
-      extinst_file,
-    ]
+    inputs = [ extinst_vendor_grammar ]
+    outputs = [ extinst_file ]
   }
 }
 
@@ -1168,12 +1145,8 @@ action("spvtools_generators_inc") {
   xml_file = "${spirv_headers}/include/spirv/spir-v.xml"
   inc_file = "${target_gen_dir}/generators.inc"
 
-  sources = [
-    xml_file,
-  ]
-  outputs = [
-    inc_file,
-  ]
+  sources = [ xml_file ]
+  outputs = [ inc_file ]
   args = [
     "--xml",
     rebase_path(xml_file, root_build_dir),
@@ -1188,9 +1161,7 @@ action("spvtools_build_version") {
   src_dir = "."
   inc_file = "${target_gen_dir}/build-version.inc"
 
-  outputs = [
-    inc_file,
-  ]
+  outputs = [ inc_file ]
   args = [
     rebase_path(src_dir, root_build_dir),
     rebase_path(inc_file, root_build_dir),
@@ -1241,8 +1212,14 @@ config("spvtools_internal_config") {
   configs = [ ":spvtools_public_config" ]
 
   if (is_clang) {
-    cflags = [ "-Wno-implicit-fallthrough",
-    "-Wno-newline-eof" ]
+    cflags = [
+      "-Wno-implicit-fallthrough",
+      "-Wno-newline-eof",
+    ]
+  }
+
+  if (is_fuchsia) {
+    cflags += [ "-Wno-range-loop-construct" ]
   }
 }
 
@@ -1317,9 +1294,7 @@ source_set("spvtools") {
     "$spirv_tools/source/util/timer.h",
   ]
 
-  public_deps = [
-    ":spvtools_core_enums_unified1",
-  ]
+  public_deps = [ ":spvtools_core_enums_unified1" ]
 
   configs += [ ":spvtools_internal_config" ]
 }
@@ -1370,9 +1345,7 @@ source_set("spvtools_val") {
     "$spirv_tools/source/val/validation_state.cpp",
   ]
 
-  deps = [
-    ":spvtools",
-  ]
+  deps = [ ":spvtools" ]
   configs += [ ":spvtools_internal_config" ]
 }
 
@@ -1596,9 +1569,7 @@ source_set("spvtools_opt") {
 }
 
 source_set("spvtools_link") {
-  sources = [
-    "$spirv_tools/source/link/linker.cpp",
-  ]
+  sources = [ "$spirv_tools/source/link/linker.cpp" ]
   deps = [
     ":spvtools",
     ":spvtools_opt",


### PR DESCRIPTION
This paves the way for updating the Fuchsia toolchain to git_revision:3520297039d69381cb5776235209fc08863b9095.

The build breaks are from the introduction of new warnings that trip on translation units in our dependencies. These dependencies cannot be directly patched because they also build targets for Fuchsia but with their own toolchain versions specified in their respective buildroots. This unblocks Flutter.

There seems to have been a GN update since the last time the files I touched were formatted. So this PR contains updates to the formats of those files.

Towards fixing https://github.com/flutter/flutter/issues/63581