### PR TITLE
Upgrade android sdk version to 30r2

### DIFF
--- a/build/config/android/config.gni
+++ b/build/config/android/config.gni
@@ -16,8 +16,8 @@ if (is_android) {
 
   if (!defined(default_android_sdk_root)) {
     default_android_sdk_root = "//third_party/android_tools/sdk"
-    default_android_sdk_version = "29"
-    default_android_sdk_build_tools_version = "29.0.1"
+    default_android_sdk_version = "30"
+    default_android_sdk_build_tools_version = "30.0.1"
   }
 
   declare_args() {


### PR DESCRIPTION
This updates the buildroot to use Android 30r2 and build-tools 30.0.1.

Rolls into engine with https://github.com/flutter/engine/pull/20479