### PR TITLE
Revert "Switch to VS 2019"

### DIFF
--- a/build/vs_toolchain.py
+++ b/build/vs_toolchain.py
@@ -35,8 +35,8 @@ sys.path.insert(0, os.path.join(script_dir, '..', 'tools'))
 
 # VS versions are listed in descending order of priority (highest first).
 MSVS_VERSIONS = collections.OrderedDict([
-  ('2019', '16.0'),
   ('2017', '15.0'),
+  ('2019', '16.0'),
 ])
 
 
@@ -416,14 +416,17 @@ def _CopyDebugger(target_dir, target_cpu):
 def _GetDesiredVsToolchainHashes():
   """Load a list of SHA1s corresponding to the toolchains that we want installed
   to build with."""
-  # VS 2019 Update 9 (16.3.29324.140) with 10.0.18362 SDK, 10.0.17763 version of
-  # Debuggers, and 10.0.17134 version of d3dcompiler_47.dll, with ARM64
-  # libraries.
-  toolchain_hash = '8f58c55897a3282ed617055775a77ec3db771b88'
-  # Third parties that do not have access to the canonical toolchain can map
-  # canonical toolchain version to their own toolchain versions.
-  toolchain_hash_mapping_key = 'GYP_MSVS_HASH_%s' % toolchain_hash
-  return [os.environ.get(toolchain_hash_mapping_key, toolchain_hash)]
+  env_version = GetVisualStudioVersion()
+  if env_version == '2017':
+    # VS 2017 Update 9 (15.9.12) with 10.0.18362 SDK, 10.0.17763 version of
+    # Debuggers, and 10.0.17134 version of d3dcompiler_47.dll, with ARM64
+    # libraries.
+    toolchain_hash = '418b3076791776573a815eb298c8aa590307af63'
+    # Third parties that do not have access to the canonical toolchain can map
+    # canonical toolchain version to their own toolchain versions.
+    toolchain_hash_mapping_key = 'GYP_MSVS_HASH_%s' % toolchain_hash
+    return [os.environ.get(toolchain_hash_mapping_key, toolchain_hash)]
+  raise Exception('Unsupported VS version %s' % env_version)
 
 
 def ShouldUpdateToolchain():


### PR DESCRIPTION
Reverts flutter/buildroot#392

Temporarily revert so that changes in https://github.com/flutter/buildroot/pull/395 can be rolled.

This seems to cause https://ci.chromium.org/p/flutter/builders/try/Windows%20Host%20Engine/11969? which is part of https://github.com/flutter/engine/pull/20479