### PR TITLE
Let .ignore files also be git ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 .gdb_history
 .gdbinit
 .idea
+.ignore
 .landmines
 .packages
 .project


### PR DESCRIPTION
Since this is the parent directory to other repos which are gitignored and since many tools like ag/rg reference .gitignore for filtering its own search, our .gitignores (for the purposes of 'submodules') isn't a very good hint for how search tools should filter. 

Most search tools use the same override file `.ignore`. Let people create those files locally and not git dirty. 