### PR TITLE
Fix OCMock static_library target

### DIFF
--- a/build/secondary/third_party/ocmock/BUILD.gn
+++ b/build/secondary/third_party/ocmock/BUILD.gn
@@ -9,13 +9,18 @@ config("ocmock_config") {
   include_dirs = [ "$ocmock_path" ]
 }
 
-source_set("ocmock_src") {
+static_library("ocmock") {
   configs -= [ "//build/config/compiler:chromium_code" ]
   all_dependent_configs = [ ":ocmock_config" ]
   cflags = [
     "-fvisibility=default",
     "-Wno-misleading-indentation",
   ]
+  if (is_ios) {
+    cflags += [
+      "-mios-simulator-version-min=$ios_testing_deployment_target",
+    ]
+  }
   sources = [
     "$ocmock_path/OCMock/NSInvocation+OCMAdditions.h",
     "$ocmock_path/OCMock/NSInvocation+OCMAdditions.m",
@@ -89,17 +94,5 @@ source_set("ocmock_src") {
     "$ocmock_path/OCMock/OCPartialMockObject.m",
     "$ocmock_path/OCMock/OCProtocolMockObject.h",
     "$ocmock_path/OCMock/OCProtocolMockObject.m",
-  ]
-}
-
-# This is a static library so it can be used by xcode's build system too.
-static_library("ocmock") {
-  if (is_ios) {
-    cflags = [
-      "-mios-simulator-version-min=$ios_testing_deployment_target",
-    ]
-  }
-  public_deps = [
-    ":ocmock_src",
   ]
 }


### PR DESCRIPTION
In flutter/buildroot#399, the static_library target was split into a
source_set and static_library target, but this resulted in libocmock
being built as an empty 88-byte library. We never caught the issue since
this buildroot change was never rolled to the engine.

This reverts things back to match how we build other static libraries
such as libzip and libxml.

This reverts 940dcf6e85301c049576da58b193cf2d903539a2.