### PR TITLE
Re-split ocmock into source set and static lib

### DIFF
--- a/build/secondary/third_party/ocmock/BUILD.gn
+++ b/build/secondary/third_party/ocmock/BUILD.gn
@@ -9,18 +9,15 @@ config("ocmock_config") {
   include_dirs = [ "$ocmock_path" ]
 }
 
-static_library("ocmock") {
+# Target that compiles all sources to .o files but does not produce a static
+# library for use in macOS desktop tests.
+source_set("ocmock_src") {
   configs -= [ "//build/config/compiler:chromium_code" ]
   all_dependent_configs = [ ":ocmock_config" ]
   cflags = [
     "-fvisibility=default",
     "-Wno-misleading-indentation",
   ]
-  if (is_ios) {
-    cflags += [
-      "-mios-simulator-version-min=$ios_testing_deployment_target",
-    ]
-  }
   sources = [
     "$ocmock_path/OCMock/NSInvocation+OCMAdditions.h",
     "$ocmock_path/OCMock/NSInvocation+OCMAdditions.m",
@@ -94,5 +91,19 @@ static_library("ocmock") {
     "$ocmock_path/OCMock/OCPartialMockObject.m",
     "$ocmock_path/OCMock/OCProtocolMockObject.h",
     "$ocmock_path/OCMock/OCProtocolMockObject.m",
+  ]
+}
+
+# Generates a static library, used in iOS unit test targets
+static_library("ocmock") {
+  # Force the static lib to include code from dependencies
+  complete_static_lib = true
+  if (is_ios) {
+    cflags = [
+      "-mios-simulator-version-min=$ios_testing_deployment_target",
+    ]
+  }
+  public_deps = [
+    ":ocmock_src",
   ]
 }


### PR DESCRIPTION
This re-lands #399 with complete_static_lib=true in the static library
target.

static_library does not includes sources from its dependencies, and
since this target had no (direct) sources of its own, was being built
empty in the original version of this split. The complete_static_lib
forces the library to include sources from its dependencies.