### PR TITLE
Reland "Update buildroot for ANGLE roll"

### DIFF
--- a/build/config/BUILDCONFIG.gn
+++ b/build/config/BUILDCONFIG.gn
@@ -284,6 +284,11 @@ if (current_os == "win") {
   is_win = false
 }
 
+is_apple = is_ios || is_mac
+
+# Needed for some third_party build files from Chromium.
+is_nacl = false
+
 default_library_type = "static_library"
 
 # =============================================================================

--- a/build/config/c++/c++.gni
+++ b/build/config/c++/c++.gni
@@ -1,0 +1,9 @@
+# Copyright 2015 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+declare_args() {
+  # Use libc++ (buildtools/third_party/libc++ and
+  # buildtools/third_party/libc++abi) instead of stdlibc++ as standard library.
+  use_custom_libcxx = false
+}

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -16,6 +16,7 @@ if (is_win) {
   import("//build/config/win/visual_studio_version.gni")
 }
 
+import("//build/config/c++/c++.gni")
 import("//build/config/profiler.gni")
 import("//build/config/sanitizers/sanitizers.gni")
 import("//build/toolchain/ccache.gni")

--- a/build/config/ozone.gni
+++ b/build/config/ozone.gni
@@ -1,0 +1,9 @@
+# Copyright 2014 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# This file is required by the ANGLE build.
+
+import("//build/config/ui.gni")
+
+ozone_platform_gbm = false

--- a/build/config/sanitizers/BUILD.gn
+++ b/build/config/sanitizers/BUILD.gn
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//build/config/c++/c++.gni")
 import("//build/config/sanitizers/sanitizers.gni")
 
 # Contains the dependencies needed for sanitizers to link into executables and

--- a/build/config/sanitizers/sanitizers.gni
+++ b/build/config/sanitizers/sanitizers.gni
@@ -3,10 +3,6 @@
 # found in the LICENSE file.
 
 declare_args() {
-  # Use libc++ (buildtools/third_party/libc++ and
-  # buildtools/third_party/libc++abi) instead of stdlibc++ as standard library.
-  use_custom_libcxx = false
-
   # Track where uninitialized memory originates from. From fastest to slowest:
   # 0 - no tracking, 1 - track only the initial allocation site, 2 - track the
   # chain of stores leading from allocation site to use site.

--- a/build/secondary/ui/ozone/ozone.gni
+++ b/build/secondary/ui/ozone/ozone.gni
@@ -1,7 +1,0 @@
-# Copyright 2019 The Flutter Authors. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
-
-# ANGLE requires this variable, but it doesn't need to be configurable for
-# Flutter so just unconditionally set it to false.
-ozone_platform_gbm = false

--- a/build/toolchain/toolchain.gni
+++ b/build/toolchain/toolchain.gni
@@ -1,0 +1,5 @@
+# Copyright 2020 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+use_xcode_clang = false

--- a/build_overrides/angle.gni
+++ b/build_overrides/angle.gni
@@ -7,7 +7,8 @@
 
 angle_root = "//third_party/angle"
 
-# Flutter's buildroot looks enough like Chromium to satisfy Angle.
+# Flutter's buildroot looks enough like Chromium to satisfy Angle, and enough
+# to cause GN variable collisions if we don't set this.
 angle_has_build = true
 
 angle_googletest_dir = "//third_party/googletest/src"
@@ -15,3 +16,7 @@ angle_libpng_dir = "//third_party/libpng"
 # Note: This path doesn't actually exist; see
 # //build/secondary/third_party/jsoncpp/BUILD.gn
 angle_jsoncpp_dir = "//third_party/jsoncpp"
+
+# This is a general Chromium flag, but in the Flutter build only ANGLE needs it
+# so it is defined here.
+is_cfi = false

--- a/build_overrides/build.gni
+++ b/build_overrides/build.gni
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-# Set for ANGLE. This buildroot is close enough to Chromium's buildroot
-# (with the addition of some dummy files) to allow building in this mode; the
-# non-Chromium build mode for ANGLE is far too different.
-build_with_chromium = true
+# The engine build uses some Chromium-sourced versions of third-party
+# dependencies (e.g, ANGLE, abseil) to use their GN build files, but we don't
+# want the Chromium-specific parts of the build.
+build_with_chromium = false

--- a/build_overrides/vulkan_headers.gni
+++ b/build_overrides/vulkan_headers.gni
@@ -1,0 +1,6 @@
+# Copyright 2020 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# This file is needed by the vulkan-headers build, but doesn't need to actually
+# set anything.


### PR DESCRIPTION
Relands https://github.com/flutter/buildroot/pull/407

Updates build/ to match the current expectations of an angle_has_build
build.