### PR TITLE
Fix toolchain for linux x86_64

### DIFF
--- a/build/toolchain/linux/BUILD.gn
+++ b/build/toolchain/linux/BUILD.gn
@@ -40,6 +40,7 @@ gcc_toolchain("clang_x86") {
   }
   cc = "${compiler_prefix}$prefix/clang"
   cxx = "${compiler_prefix}$prefix/clang++"
+
   readelf = "${prefix}/llvm-readelf"
   nm = "${prefix}/llvm-nm"
   ar = "${prefix}/llvm-ar"

--- a/build/toolchain/linux/BUILD.gn
+++ b/build/toolchain/linux/BUILD.gn
@@ -40,11 +40,11 @@ gcc_toolchain("clang_x86") {
   }
   cc = "${compiler_prefix}$prefix/clang"
   cxx = "${compiler_prefix}$prefix/clang++"
-  readelf = "readelf"
-  nm = "nm"
-  ar = "ar"
+  readelf = "${prefix}/llvm-readelf"
+  nm = "${prefix}/llvm-nm"
+  ar = "${prefix}/llvm-ar"
   ld = cxx
-  strip = "strip"
+  llvm_objcopy = "${prefix}/llvm-objcopy"
 
   toolchain_cpu = "x86"
   toolchain_os = "linux"
@@ -52,13 +52,15 @@ gcc_toolchain("clang_x86") {
 }
 
 gcc_toolchain("x86") {
-  cc = "${compiler_prefix}gcc"
-  cxx = "${compiler_prefix}g++"
+  prefix = ""
+  cc = "${compiler_prefix}${prefix}gcc"
+  cxx = "${compiler_prefix}${prefix}g++"
 
-  readelf = "readelf"
-  nm = "nm"
-  ar = "ar"
+  readelf = "${prefix}readelf"
+  nm = "${prefix}nm"
+  ar = "${prefix}ar"
   ld = cxx
+  strip = "${prefix}strip"
 
   toolchain_cpu = "x86"
   toolchain_os = "linux"
@@ -75,11 +77,11 @@ gcc_toolchain("clang_x64") {
   cc = "${compiler_prefix}$prefix/clang"
   cxx = "${compiler_prefix}$prefix/clang++"
 
-  readelf = "readelf"
-  nm = "nm"
-  ar = "ar"
+  readelf = "${prefix}/llvm-readelf"
+  nm = "${prefix}/llvm-nm"
+  ar = "${prefix}/llvm-ar"
   ld = cxx
-  strip = "strip"
+  llvm_objcopy = "${prefix}/llvm-objcopy"
 
   toolchain_cpu = "x64"
   toolchain_os = "linux"
@@ -108,13 +110,15 @@ gcc_toolchain("clang_arm64") {
 }
 
 gcc_toolchain("x64") {
-  cc = "${compiler_prefix}gcc"
-  cxx = "${compiler_prefix}g++"
+  prefix = ""
+  cc = "${compiler_prefix}${prefix}gcc"
+  cxx = "${compiler_prefix}${prefix}g++"
 
-  readelf = "readelf"
-  nm = "nm"
-  ar = "ar"
+  readelf = "${prefix}readelf"
+  nm = "${prefix}nm"
+  ar = "${prefix}ar"
   ld = cxx
+  strip = "${prefix}strip"
 
   toolchain_cpu = "x64"
   toolchain_os = "linux"


### PR DESCRIPTION
## Background

In the `clang_x86` and `clang_x64` building, `buildroot` has been using readelf/nm/ar/strip commands of a host that executes the build without using the toolchain's. However, it is odd to use gcc in the host environment even though it uses clang / llvm.

> It looks like Dart is using llvm-objcopy for clang_x64 as well, so we should investigate whether to unify that at some point on our side, but limiting the changes to just arm64 here is the safer option.

https://github.com/flutter/buildroot/pull/390#pullrequestreview-522776808

## Changes

I investigated the past commit history of dart-sdk and flutter. I guess that the cause is that the changes of dart-sdk are not imported to flutter-engine.

dart-sdk was changed from gcc to clang/llvm by [this PR](https://github.com/dart-lang/sdk/commit/81e428fd39032fb23997c04c6681f8e5fcda9105#) on 21 May 2017. However, there isn't any changes in flutter. I don't think it's the critical problem, but I think it's better to modify the toolchain according to dart-sdk.

### clang_x64 and clang_x86

Changed readelf, nm, ar, strip(llvm_objcopy) commands from gcc to clang/llvm. The source code is the same with dart-sdk's.
https://github.com/dart-lang/sdk/blob/master/build/toolchain/linux/BUILD.gn

### x64 and x86
Formally, there isn't any changes without adding strip command. I just changed the code according to dart-sdk.

## Test
The tests in the CI passed.
https://github.com/flutter/engine/pull/22484
