### PR TITLE
Enable ARM NEON functions for iOS ARM Simulator builds

### DIFF
--- a/third_party/libpng/BUILD.gn
+++ b/third_party/libpng/BUILD.gn
@@ -29,9 +29,8 @@ source_set("libpng") {
     "pngwutil.c",
   ]
 
-  if ((is_ios && !use_ios_simulator) ||
-      ((is_android || is_linux || is_fuchsia) &&
-       (current_cpu == "arm" || current_cpu == "arm64"))) {
+  if ((is_android || is_linux || is_fuchsia || is_ios) &&
+       (current_cpu == "arm" || current_cpu == "arm64")) {
     if (is_android) {
       import("//build/config/android/config.gni")
       rebased_android_toolchain_root =


### PR DESCRIPTION
With M1 Macs we can now build for ARM simulator.