### PR TITLE
Support iOS ARM64 simulator builds

### DIFF
--- a/build/config/BUILDCONFIG.gn
+++ b/build/config/BUILDCONFIG.gn
@@ -543,7 +543,11 @@ if (custom_toolchain != "") {
   import("//build/config/ios/ios_sdk.gni")  # For use_ios_simulator
   host_toolchain = "//build/toolchain/mac:clang_$host_cpu"
   if (use_ios_simulator) {
-    set_default_toolchain("//build/toolchain/mac:ios_clang_x64")
+    if (target_cpu == "arm" || target_cpu == "arm64") {
+      set_default_toolchain("//build/toolchain/mac:ios_clang_arm_sim")
+    } else {
+      set_default_toolchain("//build/toolchain/mac:ios_clang_x64_sim")
+    }
   } else {
     set_default_toolchain("//build/toolchain/mac:ios_clang_arm")
   }

--- a/build/toolchain/clang.gni
+++ b/build/toolchain/clang.gni
@@ -2,6 +2,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//build/config/ios/ios_sdk.gni") # For use_ios_simulator
+
 declare_args() {
   # Enable the optional type profiler in Clang, which will tag heap allocations
   # with the allocation type.
@@ -26,5 +28,7 @@ declare_args() {
   # TODO(dnfield): We shouldn't need Xcode for bitcode_marker builds, but we do
   # until libpng and dart have explicitly added LLVM asm sections to their
   # assembly sources. https://github.com/flutter/flutter/issues/39281
-  use_xcode = enable_bitcode
+  # TODO(gw280): Once our own copy of clang 12 is capable of building for arm64 simulator,
+  # we can safely remove the requirement that we use xcode for arm64 simulator builds.
+  use_xcode = enable_bitcode || (use_ios_simulator && (target_cpu == "arm" || target_cpu == "arm64"))
 }

--- a/build/toolchain/mac/BUILD.gn
+++ b/build/toolchain/mac/BUILD.gn
@@ -250,8 +250,22 @@ mac_toolchain("ios_clang_arm") {
   sysroot_flags = "-isysroot $ios_device_sdk_path -miphoneos-version-min=$ios_deployment_target"
 }
 
-# Toolchain used for iOS simulator targets.
-mac_toolchain("ios_clang_x64") {
+# Toolchain used for iOS simulator targets (arm64).
+mac_toolchain("ios_clang_arm_sim") {
+  toolchain_cpu = "arm"
+  toolchain_os = "mac"
+  # TODO(gw280): We have to use llvm from xcode until we upgrade our copy of llvm
+  ar = "ar"
+  cc = "clang"
+  cxx = "clang++"
+  ld = "clang++"
+  is_clang = true
+  # We have to ignore unknown options and range loop analysis as this isn't our expected toolchain
+  sysroot_flags = "-isysroot $ios_simulator_sdk_path -mios-simulator-version-min=$ios_deployment_target -Wno-unknown-warning-option -Wno-range-loop-analysis"
+}
+
+# Toolchain used for iOS simulator targets (x64).
+mac_toolchain("ios_clang_x64_sim") {
   toolchain_cpu = "x64"
   toolchain_os = "mac"
   prefix = rebase_path(llvm_bin_path, root_build_dir)

--- a/build/toolchain/mac/BUILD.gn
+++ b/build/toolchain/mac/BUILD.gn
@@ -260,6 +260,8 @@ mac_toolchain("ios_clang_arm_sim") {
     cc = "$prefix/clang"
     cxx = "$prefix/clang++"
   } else {
+    # TODO: https://github.com/harfbuzz/harfbuzz/issues/2834
+    # harfbuzz has a non-fatal warning right now with Xcode 12
     ar = "ar"
     cc = "clang"
     cxx = "clang++"

--- a/build/toolchain/mac/BUILD.gn
+++ b/build/toolchain/mac/BUILD.gn
@@ -254,14 +254,19 @@ mac_toolchain("ios_clang_arm") {
 mac_toolchain("ios_clang_arm_sim") {
   toolchain_cpu = "arm"
   toolchain_os = "mac"
-  # TODO(gw280): We have to use llvm from xcode until we upgrade our copy of llvm
-  ar = "ar"
-  cc = "clang"
-  cxx = "clang++"
-  ld = "clang++"
+  if (!use_xcode) {
+    prefix = rebase_path(llvm_bin_path, root_build_dir)
+    ar = "$prefix/llvm-ar"
+    cc = "$prefix/clang"
+    cxx = "$prefix/clang++"
+  } else {
+    ar = "ar"
+    cc = "clang"
+    cxx = "clang++"
+  }
+  ld = cxx
   is_clang = true
-  # We have to ignore unknown options and range loop analysis as this isn't our expected toolchain
-  sysroot_flags = "-isysroot $ios_simulator_sdk_path -mios-simulator-version-min=$ios_deployment_target -Wno-unknown-warning-option -Wno-range-loop-analysis"
+  sysroot_flags = "-isysroot $ios_simulator_sdk_path -mios-simulator-version-min=$ios_deployment_target"
 }
 
 # Toolchain used for iOS simulator targets (x64).


### PR DESCRIPTION
I'm not convinced this is the right way to go just yet, but basically in order to support ARM64 simulator builds, we need to have a newer version of LLVM.

We already have a mechanism in place for us to use LLVM from Xcode (e.g. https://github.com/flutter/buildroot/blob/master/build/toolchain/mac/BUILD.gn#L238), so I'm proposing that we simply have a new toolchain definition for ARM64 simulator builds only that uses the system Xcode.

Unfortunately, to get Flutter and third party deps to even build in clang 12 shipped with Xcode 12.2, I had to add a couple of warning suppression options.