### PR TITLE
avoid unsupported Xcode warning

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -683,6 +683,8 @@ if (is_win) {
     default_warning_flags += [
       "-Wno-implicit-int-float-conversion",
       "-Wno-c99-designator",
+      # Needed for compiling Skia with clang-12
+      "-Wno-psabi",
     ]
     if (!is_fuchsia) {
       default_warning_flags += [
@@ -703,11 +705,6 @@ if (is_win) {
   if (allow_deprecated_api_calls) {
     default_warning_flags += [ "-Wno-deprecated-declarations" ]
   }
-
-  default_warning_flags += [
-    # Needed for compiling Skia with clang-12
-    "-Wno-psabi",
-  ]
 }
 
 # chromium_code ---------------------------------------------------------------


### PR DESCRIPTION
Guard the psabi warning removal against whether we're using Xcode, since the Xcode toolchain that CI uses doesn't support this flag.