### PR TITLE
Support iOS ARM64 simulator builds

### DIFF
--- a/build/config/BUILDCONFIG.gn
+++ b/build/config/BUILDCONFIG.gn
@@ -543,7 +543,11 @@ if (custom_toolchain != "") {
   import("//build/config/ios/ios_sdk.gni")  # For use_ios_simulator
   host_toolchain = "//build/toolchain/mac:clang_$host_cpu"
   if (use_ios_simulator) {
-    set_default_toolchain("//build/toolchain/mac:ios_clang_x64")
+    if (target_cpu == "arm" || target_cpu == "arm64") {
+      set_default_toolchain("//build/toolchain/mac:ios_clang_arm_sim")
+    } else {
+      set_default_toolchain("//build/toolchain/mac:ios_clang_x64_sim")
+    }
   } else {
     set_default_toolchain("//build/toolchain/mac:ios_clang_arm")
   }

--- a/build/toolchain/clang.gni
+++ b/build/toolchain/clang.gni
@@ -2,7 +2,9 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//build/config/ios/ios_sdk.gni") # For use_ios_simulator
+if (is_mac) {
+  import("//build/config/ios/ios_sdk.gni") # For use_ios_simulator
+}
 
 declare_args() {
   # Enable the optional type profiler in Clang, which will tag heap allocations
@@ -30,5 +32,9 @@ declare_args() {
   # assembly sources. https://github.com/flutter/flutter/issues/39281
   # TODO(gw280): Once our own copy of clang 12 is capable of building for arm64 simulator,
   # we can safely remove the requirement that we use xcode for arm64 simulator builds.
-  use_xcode = enable_bitcode || (use_ios_simulator && (target_cpu == "arm" || target_cpu == "arm64"))
+  if (is_mac) {
+    use_xcode = enable_bitcode || (use_ios_simulator && (target_cpu == "arm" || target_cpu == "arm64"))
+  } else {
+    use_xcode = false
+  }
 }

--- a/build/toolchain/clang.gni
+++ b/build/toolchain/clang.gni
@@ -2,6 +2,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//build/config/ios/ios_sdk.gni") # For use_ios_simulator
+
 declare_args() {
   # Enable the optional type profiler in Clang, which will tag heap allocations
   # with the allocation type.
@@ -26,5 +28,7 @@ declare_args() {
   # TODO(dnfield): We shouldn't need Xcode for bitcode_marker builds, but we do
   # until libpng and dart have explicitly added LLVM asm sections to their
   # assembly sources. https://github.com/flutter/flutter/issues/39281
-  use_xcode = enable_bitcode
+  # TODO(gw280): Once our own copy of clang 12 is capable of building for arm64 simulator,
+  # we can safely remove the requirement that we use xcode for arm64 simulator builds.
+  use_xcode = enable_bitcode || (use_ios_simulator && (target_cpu == "arm" || target_cpu == "arm64"))
 }

--- a/build/toolchain/mac/BUILD.gn
+++ b/build/toolchain/mac/BUILD.gn
@@ -250,8 +250,29 @@ mac_toolchain("ios_clang_arm") {
   sysroot_flags = "-isysroot $ios_device_sdk_path -miphoneos-version-min=$ios_deployment_target"
 }
 
-# Toolchain used for iOS simulator targets.
-mac_toolchain("ios_clang_x64") {
+# Toolchain used for iOS simulator targets (arm64).
+mac_toolchain("ios_clang_arm_sim") {
+  toolchain_cpu = "arm"
+  toolchain_os = "mac"
+  if (!use_xcode) {
+    prefix = rebase_path(llvm_bin_path, root_build_dir)
+    ar = "$prefix/llvm-ar"
+    cc = "$prefix/clang"
+    cxx = "$prefix/clang++"
+  } else {
+    # TODO: https://github.com/harfbuzz/harfbuzz/issues/2834
+    # harfbuzz has a non-fatal warning right now with Xcode 12
+    ar = "ar"
+    cc = "clang"
+    cxx = "clang++"
+  }
+  ld = cxx
+  is_clang = true
+  sysroot_flags = "-isysroot $ios_simulator_sdk_path -mios-simulator-version-min=$ios_deployment_target"
+}
+
+# Toolchain used for iOS simulator targets (x64).
+mac_toolchain("ios_clang_x64_sim") {
   toolchain_cpu = "x64"
   toolchain_os = "mac"
   prefix = rebase_path(llvm_bin_path, root_build_dir)


### PR DESCRIPTION
Redo of https://github.com/flutter/buildroot/pull/422, but with fixes to allow it to build on !mac.

Test CI run at https://github.com/flutter/engine/pull/24242