### PR TITLE
Add third_party/libpng to .gitignore

### DIFF
--- a/third_party/.gitignore
+++ b/third_party/.gitignore
@@ -12,7 +12,6 @@
 !.gitignore
 !expat/
 !fontconfig/
-!libpng/
 !libxml/
 !zlib/
 !.dartignore


### PR DESCRIPTION
This has now been moved
https://flutter.googlesource.com/third_party/libpng and is pulled in via
DEPS in the main Flutter repo.