### PR TITLE
Add BUILD.gn for googletest

### DIFF
--- a/build/secondary/third_party/googletest/BUILD.gn
+++ b/build/secondary/third_party/googletest/BUILD.gn
@@ -1,0 +1,365 @@
+# Copyright 2018 The Fuchsia Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+if (is_fuchsia) {
+  import("//build/fuchsia/sdk.gni")
+}
+
+config("gtest_private_config") {
+  visibility = [ ":*" ]
+  include_dirs = [ "googletest" ]
+}
+
+config("gtest_config") {
+  include_dirs = [ "googletest/include" ]
+}
+
+static_library("gtest") {
+  testonly = true
+  public = [
+    "googletest/include/gtest/gtest-spi.h",
+    "googletest/include/gtest/gtest.h",
+  ]
+  sources = [
+    "googletest/include/gtest/gtest-death-test.h",
+    "googletest/include/gtest/gtest-message.h",
+    "googletest/include/gtest/gtest-param-test.h",
+    "googletest/include/gtest/gtest-printers.h",
+    "googletest/include/gtest/gtest-test-part.h",
+    "googletest/include/gtest/gtest-typed-test.h",
+    "googletest/include/gtest/gtest_pred_impl.h",
+    "googletest/include/gtest/gtest_prod.h",
+    "googletest/include/gtest/internal/custom/gtest-port.h",
+    "googletest/include/gtest/internal/custom/gtest-printers.h",
+    "googletest/include/gtest/internal/custom/gtest.h",
+    "googletest/include/gtest/internal/gtest-death-test-internal.h",
+    "googletest/include/gtest/internal/gtest-filepath.h",
+    "googletest/include/gtest/internal/gtest-internal.h",
+    "googletest/include/gtest/internal/gtest-linked_ptr.h",
+    "googletest/include/gtest/internal/gtest-param-util-generated.h",
+    "googletest/include/gtest/internal/gtest-param-util.h",
+    "googletest/include/gtest/internal/gtest-port-arch.h",
+    "googletest/include/gtest/internal/gtest-port.h",
+    "googletest/include/gtest/internal/gtest-string.h",
+    "googletest/include/gtest/internal/gtest-tuple.h",
+    "googletest/include/gtest/internal/gtest-type-util.h",
+    "googletest/src/gtest-all.cc",
+    "googletest/src/gtest-death-test.cc",
+    "googletest/src/gtest-filepath.cc",
+    "googletest/src/gtest-internal-inl.h",
+    "googletest/src/gtest-matchers.cc",
+    "googletest/src/gtest-port.cc",
+    "googletest/src/gtest-printers.cc",
+    "googletest/src/gtest-test-part.cc",
+    "googletest/src/gtest-typed-test.cc",
+    "googletest/src/gtest.cc",
+  ]
+  sources -= [ "googletest/src/gtest-all.cc" ]
+  public_configs = [ ":gtest_config" ]
+  configs += [ ":gtest_private_config" ]
+
+  if (is_fuchsia) {
+    if (using_fuchsia_sdk) {
+      deps = [
+        "$fuchsia_sdk_root/pkg:fdio",
+        "$fuchsia_sdk_root/pkg:zx",
+      ]
+    } else {
+      deps = [
+        "//zircon/public/lib/fdio",
+        "//zircon/public/lib/zx",
+      ]
+    }
+  }
+}
+
+# Library that defines the FRIEND_TEST macro.
+source_set("gtest_prod") {
+  testonly = false
+  public = [
+    "googletest/include/gtest/gtest_prod.h",
+  ]
+  public_configs = [ ":gtest_config" ]
+}
+
+static_library("gtest_main") {
+  testonly = true
+  sources = [
+    "googletest/src/gtest_main.cc",
+  ]
+  public_deps = [
+    ":gtest",
+  ]
+}
+
+executable("gtest_all_test") {
+  testonly = true
+  sources = [
+    "googletest/test/gtest-death-test_test.cc",
+    "googletest/test/gtest-filepath_test.cc",
+    "googletest/test/gtest-linked_ptr_test.cc",
+    "googletest/test/gtest-message_test.cc",
+    "googletest/test/gtest-options_test.cc",
+    "googletest/test/gtest-port_test.cc",
+    "googletest/test/gtest-printers_test.cc",
+    "googletest/test/gtest-test-part_test.cc",
+    "googletest/test/gtest-typed-test2_test.cc",
+    "googletest/test/gtest-typed-test_test.cc",
+    "googletest/test/gtest-typed-test_test.h",
+    "googletest/test/gtest_main_unittest.cc",
+    "googletest/test/gtest_pred_impl_unittest.cc",
+    "googletest/test/gtest_prod_test.cc",
+    "googletest/test/gtest_unittest.cc",
+    "googletest/test/production.cc",
+    "googletest/test/production.h",
+  ]
+  configs += [ ":gtest_private_config" ]
+  deps = [
+    ":gtest",
+    ":gtest_main",
+  ]
+}
+
+executable("gtest_environment_test") {
+  testonly = true
+  sources = [
+    "googletest/test/gtest_environment_test.cc",
+  ]
+  configs += [ ":gtest_private_config" ]
+  deps = [
+    ":gtest",
+  ]
+}
+
+executable("gtest_listener_test") {
+  testonly = true
+  sources = [
+    "googletest/test/gtest-listener_test.cc",
+  ]
+  deps = [
+    ":gtest",
+  ]
+}
+
+executable("gtest_no_test") {
+  testonly = true
+  sources = [
+    "googletest/test/gtest_no_test_unittest.cc",
+  ]
+  deps = [
+    ":gtest",
+  ]
+}
+
+executable("gtest_param_test") {
+  testonly = true
+  sources = [
+    "googletest/test/gtest-param-test2_test.cc",
+    "googletest/test/gtest-param-test_test.cc",
+    "googletest/test/gtest-param-test_test.h",
+  ]
+  configs += [ ":gtest_private_config" ]
+  deps = [
+    ":gtest",
+  ]
+}
+
+executable("gtest_premature_exit_test") {
+  testonly = true
+  sources = [
+    "googletest/test/gtest_premature_exit_test.cc",
+  ]
+  deps = [
+    ":gtest",
+  ]
+}
+
+executable("gtest_repeat_test") {
+  testonly = true
+  sources = [
+    "googletest/test/gtest_repeat_test.cc",
+  ]
+  configs += [ ":gtest_private_config" ]
+  deps = [
+    ":gtest",
+  ]
+}
+
+executable("gtest_sole_header_test") {
+  testonly = true
+  sources = [
+    "googletest/test/gtest_sole_header_test.cc",
+  ]
+  deps = [
+    ":gtest",
+    ":gtest_main",
+  ]
+}
+
+executable("gtest_stress_test") {
+  testonly = true
+  sources = [
+    "googletest/test/gtest_stress_test.cc",
+  ]
+  configs += [ ":gtest_private_config" ]
+  deps = [
+    ":gtest",
+  ]
+}
+
+executable("gtest_unittest_api_test") {
+  testonly = true
+  sources = [
+    "googletest/test/gtest-unittest-api_test.cc",
+  ]
+  deps = [
+    ":gtest",
+  ]
+}
+
+group("gtest_all_tests") {
+  testonly = true
+  deps = [
+    ":gtest_all_test",
+    ":gtest_environment_test",
+    ":gtest_listener_test",
+    ":gtest_no_test",
+    ":gtest_param_test",
+    ":gtest_premature_exit_test",
+    ":gtest_repeat_test",
+    ":gtest_sole_header_test",
+    ":gtest_stress_test",
+    ":gtest_unittest_api_test",
+  ]
+}
+
+config("gmock_private_config") {
+  visibility = [ ":*" ]
+  include_dirs = [ "googlemock" ]
+}
+
+config("gmock_config") {
+  include_dirs = [ "googlemock/include" ]
+
+  cflags_cc = [
+    # The MOCK_METHODn() macros do not specify "override", which triggers this
+    # warning in users: "error: 'Method' overrides a member function but is not
+    # marked 'override' [-Werror,-Winconsistent-missing-override]". Suppress
+    # these warnings until https://github.com/google/googletest/issues/533 is
+    # fixed.
+    "-Wno-inconsistent-missing-override",
+  ]
+}
+
+static_library("gmock") {
+  testonly = true
+  public = [
+    "googlemock/include/gmock/gmock.h",
+  ]
+  sources = [
+    "googlemock/include/gmock/gmock-actions.h",
+    "googlemock/include/gmock/gmock-cardinalities.h",
+    "googlemock/include/gmock/gmock-generated-actions.h",
+    "googlemock/include/gmock/gmock-generated-function-mockers.h",
+    "googlemock/include/gmock/gmock-generated-matchers.h",
+    "googlemock/include/gmock/gmock-generated-nice-strict.h",
+    "googlemock/include/gmock/gmock-matchers.h",
+    "googlemock/include/gmock/gmock-more-actions.h",
+    "googlemock/include/gmock/gmock-more-matchers.h",
+    "googlemock/include/gmock/gmock-spec-builders.h",
+    "googlemock/include/gmock/internal/custom/gmock-generated-actions.h",
+    "googlemock/include/gmock/internal/custom/gmock-matchers.h",
+    "googlemock/include/gmock/internal/custom/gmock-port.h",
+    "googlemock/include/gmock/internal/gmock-generated-internal-utils.h",
+    "googlemock/include/gmock/internal/gmock-internal-utils.h",
+    "googlemock/include/gmock/internal/gmock-port.h",
+    "googlemock/src/gmock-all.cc",
+    "googlemock/src/gmock-cardinalities.cc",
+    "googlemock/src/gmock-internal-utils.cc",
+    "googlemock/src/gmock-matchers.cc",
+    "googlemock/src/gmock-spec-builders.cc",
+    "googlemock/src/gmock.cc",
+  ]
+  sources -= [ "googlemock/src/gmock-all.cc" ]
+  public_configs = [ ":gmock_config" ]
+  configs += [ ":gmock_private_config" ]
+  deps = [
+    ":gtest",
+  ]
+}
+
+static_library("gmock_main") {
+  testonly = true
+  sources = [
+    "googlemock/src/gmock_main.cc",
+  ]
+  public_deps = [
+    ":gmock",
+    ":gtest",
+  ]
+}
+
+executable("gmock_all_test") {
+  testonly = true
+  sources = [
+    "googlemock/test/gmock-actions_test.cc",
+    "googlemock/test/gmock-cardinalities_test.cc",
+    "googlemock/test/gmock-generated-actions_test.cc",
+    "googlemock/test/gmock-generated-function-mockers_test.cc",
+    "googlemock/test/gmock-generated-internal-utils_test.cc",
+    "googlemock/test/gmock-generated-matchers_test.cc",
+    "googlemock/test/gmock-internal-utils_test.cc",
+    "googlemock/test/gmock-matchers_test.cc",
+    "googlemock/test/gmock-more-actions_test.cc",
+    "googlemock/test/gmock-nice-strict_test.cc",
+    "googlemock/test/gmock-port_test.cc",
+    "googlemock/test/gmock-spec-builders_test.cc",
+    "googlemock/test/gmock_test.cc",
+  ]
+  configs += [
+    ":gmock_private_config",
+    ":gtest_private_config",
+  ]
+  deps = [
+    ":gmock",
+    ":gmock_main",
+    ":gtest",
+  ]
+}
+
+executable("gmock_link_test") {
+  testonly = true
+  sources = [
+    "googlemock/test/gmock_link2_test.cc",
+    "googlemock/test/gmock_link_test.cc",
+    "googlemock/test/gmock_link_test.h",
+  ]
+  configs += [ ":gmock_private_config" ]
+  deps = [
+    ":gmock",
+    ":gmock_main",
+    ":gtest",
+  ]
+}
+
+executable("gmock_stress_test") {
+  testonly = true
+  sources = [
+    "googlemock/test/gmock_stress_test.cc",
+  ]
+  configs += [ ":gmock_private_config" ]
+  deps = [
+    ":gmock",
+    ":gtest",
+  ]
+}
+
+group("gmock_all_tests") {
+  testonly = true
+  deps = [
+    ":gmock_all_test",
+    ":gmock_link_test",
+    ":gmock_stress_test",
+  ]
+}


### PR DESCRIPTION
7 months ago, the fuchsia toolchain team turned down the repository at https://fuchsia.googlesource.com/third_party/googletest and moved all development to the https://github.com//google/googletest repo. The new repository does not have a BUILD.gn file so we need to put a definition in build/secondary so gn can find it. 

This BUILD.gn is an exact copy of the version that was being mapped in previously. We may need to adjust this file in the future if we need to update our googletest version but for now it builds correctly.