### PR TITLE
Stop generating FIDL C bindings

### DIFF
--- a/build/fuchsia/fidl_gen_cpp.py
+++ b/build/fuchsia/fidl_gen_cpp.py
@@ -42,7 +42,6 @@ def main():
   parser.add_argument('--json', dest='json', action='store', required=True)
   parser.add_argument('--include-base', dest='include_base', action='store', required=True)
   parser.add_argument('--output-base-cc', dest='output_base_cc', action='store', required=True)
-  parser.add_argument('--output-c-header', dest='output_header_c', action='store', required=True)
   parser.add_argument('--output-c-tables', dest='output_c_tables', action='store', required=True)
 
   args = parser.parse_args()
@@ -54,8 +53,6 @@ def main():
 
   fidlc_command = [
     args.fidlc_bin,
-    '--c-header',
-    args.output_header_c,
     '--tables',
     args.output_c_tables,
     '--json',

--- a/build/fuchsia/sdk.gni
+++ b/build/fuchsia/sdk.gni
@@ -101,7 +101,6 @@ template("_fuchsia_fidl_library") {
     ]
 
     outputs = [
-      "$target_gen_dir/$library_name_slashes/c/fidl.h",
       "$target_gen_dir/$library_name_slashes/cpp/fidl.h",
       "$target_gen_dir/$library_name_slashes/cpp/fidl.cc",
       "$target_gen_dir/$library_name_slashes/cpp/tables.c",
@@ -122,8 +121,6 @@ template("_fuchsia_fidl_library") {
       rebase_path("$target_gen_dir"),
       "--output-base-cc",
       rebase_path("$target_gen_dir/$library_name_slashes/cpp/fidl"),
-      "--output-c-header",
-      rebase_path("$target_gen_dir/$library_name_slashes/c/fidl.h"),
       "--output-c-tables",
       rebase_path("$target_gen_dir/$library_name_slashes/cpp/tables.c"),
     ]


### PR DESCRIPTION
This updates the Fuchsia SDK build script to stop generating
FIDL C bindings which are deprecated.
No behavior change, since the C bindings are not used in this
repo.