### PR TITLE
use current_cpu instead of target_cpu in swiftshader

### DIFF
--- a/build/secondary/third_party/swiftshader_flutter/BUILD.gn
+++ b/build/secondary/third_party/swiftshader_flutter/BUILD.gn
@@ -143,12 +143,12 @@ source_set("subzero") {
     cflags += [ "-Wno-macro-redefined" ]
   }
 
-  if (target_cpu == "x64") {
+  if (current_cpu == "x64") {
     defines += [
       "SZTARGET=X8664",
       "SUBZERO_TARGET=X8664",
     ]
-  } else if (target_cpu == "x86") {
+  } else if (current_cpu == "x86") {
     defines += [
       "SZTARGET=X8632",
       "SUBZERO_TARGET=X8632",
@@ -230,12 +230,12 @@ source_set("subzero") {
     "$source_root/third_party/subzero/src/IceVariableSplitting.cpp",
   ]
 
-  if (target_cpu == "x64") {
+  if (current_cpu == "x64") {
     sources += [
       "$source_root/third_party/subzero/src/IceInstX8664.cpp",
       "$source_root/third_party/subzero/src/IceTargetLoweringX8664.cpp",
     ]
-  } else if (target_cpu == "x86") {
+  } else if (current_cpu == "x86") {
     sources += [
       "$source_root/third_party/subzero/src/IceInstX8632.cpp",
       "$source_root/third_party/subzero/src/IceTargetLoweringX8632.cpp",


### PR DESCRIPTION
To fix this failure: 
https://ci.chromium.org/ui/p/flutter/builders/try/Linux%20Fuchsia/25463/overview

For this PR:
https://github.com/flutter/engine/pull/25480

Context:
https://gn.googlesource.com/gn/+/HEAD/docs/cross_compiles.md#as-a-build_gn-author