### PR TITLE
Fix: Strip option doesn't work for linux .so files

### DIFF
--- a/build/toolchain/clang.gni
+++ b/build/toolchain/clang.gni
@@ -21,7 +21,7 @@ declare_args() {
   bitcode_marker = false
 
   # Set this flag to strip .so files.
-  stripped_symbols = true
+  stripped_symbols = !is_debug
 }
 
 declare_args() {

--- a/build/toolchain/clang.gni
+++ b/build/toolchain/clang.gni
@@ -19,6 +19,9 @@ declare_args() {
 
   # Set this flag to cause bitcode to be marker only.
   bitcode_marker = false
+
+  # Set this flag to strip .so files.
+  stripped_symbols = true
 }
 
 declare_args() {

--- a/build/toolchain/gcc_toolchain.gni
+++ b/build/toolchain/gcc_toolchain.gni
@@ -176,6 +176,22 @@ template("gcc_toolchain") {
       replace_command = "if ! cmp -s $temporary_tocname $tocfile; then mv $temporary_tocname $tocfile; fi"
 
       command = "$link_command && $toc_command && $replace_command"
+      if (stripped_symbols) {
+        if (defined(invoker.strip) || defined(invoker.llvm_objcopy)) {
+          unstripped_outfile = "{{root_out_dir}}/lib.unstripped/$sofile"
+          pre_strip_command = "mkdir -p {{root_out_dir}}/lib.unstripped && cp $sofile {{root_out_dir}}/lib.unstripped/"
+        }
+        if (defined(invoker.strip)) {
+          strip = invoker.strip
+          strip_command =
+              "${strip} --strip-unneeded -o  $sofile $unstripped_outfile"
+          command += " && " + pre_strip_command + " && " + strip_command
+        } else if (defined(invoker.llvm_objcopy)) {
+          strip = invoker.llvm_objcopy
+          strip_command = "${strip} --strip-all $unstripped_outfile $sofile"
+          command += " && " + pre_strip_command + " && " + strip_command
+        }
+      }
       if (defined(invoker.postsolink)) {
         command += " && " + invoker.postsolink
       }


### PR DESCRIPTION
## Description
Currently, the debug symbols of .so files like `libflutter_engine.so` and `libflutter_linux_gtk.so` are not stripped if we use `--stripped (default: enabled)` option in GN. Therefore, the .so file size is too big.

- libflutter_linux_gtk.so (release mode, no-stripped): **48**MB
- libflutter_linux_gtk.so (release mode, stripped): 11MB
- libflutter_linux_gtk.so (debug mode, no-stripped): **108**MB
- libflutter_linux_gtk.so (debug mode, stripped): 30MB

In Android case, it is striped correctly (See: [build/toolchain/android/BUILD.gn](https://github.com/flutter/buildroot/blob/master/build/toolchain/android/BUILD.gn#L86)).

## Changes
I added a strip command into `gcc_toolchain.gni`. 

## Related PRs
- https://github.com/flutter/engine/pull/26358

## Build-tests in CI
- ~~https://github.com/flutter/engine/pull/26358/checks?sha=576649e6e61849b6f106f3dc77be942a3811c158~~
- https://github.com/flutter/engine/pull/26358/checks?sha=55aac0ded0ff2347b925be6e414b43f305bd7abe
