### PR TITLE
add -Wno-deprecated-copy to fuchsia builds

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -687,13 +687,13 @@ if (is_win) {
     default_warning_flags += [
       "-Wno-implicit-int-float-conversion",
       "-Wno-c99-designator",
+      "-Wno-deprecated-copy",
       # Needed for compiling Skia with clang-12
       "-Wno-psabi",
     ]
     if (!is_fuchsia) {
       default_warning_flags += [
         "-Wno-non-c-typedef-for-linkage",
-        "-Wno-deprecated-copy",
         "-Wno-range-loop-construct",
       ]
     }


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/83268

Fuchsia is failing to build because the new flexible enums are
tripping up the deprecated-copy warning (fxbug.dev/77383.) This
removes the warning for fuchsia builds to roll the new clang.