### PR TITLE
Add a flag for disabling hidden visibility so that symbols can be resolved in test backtraces.

### DIFF
--- a/build/config/gcc/BUILD.gn
+++ b/build/config/gcc/BUILD.gn
@@ -17,7 +17,7 @@ import("//build/config/profiler.gni")
 config("symbol_visibility_hidden") {
   # Note that -fvisibility-inlines-hidden is set globally in the compiler
   # config since that can almost always be applied.
-  if (!enable_profiling) {
+  if (!enable_profiling && !disable_hidden_visibility) {
     defines = [ "_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS" ]
     cflags = [ "-fvisibility=hidden" ]
   }

--- a/build/config/profiler.gni
+++ b/build/config/profiler.gni
@@ -7,6 +7,11 @@ declare_args() {
   # example, don't omit the frame pointer and leave in symbols.
   enable_profiling = false
 
+  # Use default visibility for all symbols.
+  # Without this, any symbol that is not specifically exported will have
+  # hidden visibility.
+  disable_hidden_visibility = false
+
   # Compile in such a way as to make it possible for the profiler to unwind full
   # stack frames. Setting this flag has a large effect on the performance of the
   # generated code than just setting profiling, but gives the profiler more


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/83286