### PR TITLE
Add library bcrypt.lib to the default list of libraries for windows.

### DIFF
--- a/build/config/BUILD.gn
+++ b/build/config/BUILD.gn
@@ -108,6 +108,7 @@ config("default_libs") {
     # winspool) should include those explicitly.
     libs = [
       "advapi32.lib",
+      "bcrypt.lib",
       "comdlg32.lib",
       "delayimp.lib",
       "dnsapi.lib",


### PR DESCRIPTION
This is needed to account for the change made in Dart
(https://dart-review.googlesource.com/c/sdk/+/200160)