### PR TITLE
Update sysroot_ld_path.py for Python3

### DIFF
--- a/build/config/linux/sysroot_ld_path.py
+++ b/build/config/linux/sysroot_ld_path.py
@@ -12,9 +12,10 @@ import subprocess
 import sys
 
 if len(sys.argv) != 3:
-  print "Need two arguments"
+  print("Need two arguments")
   sys.exit(1)
 
-result = subprocess.check_output([sys.argv[1], sys.argv[2]]).strip()
+result = subprocess.check_output([sys.argv[1], sys.argv[2]],
+                                 universal_newlines=True).strip()
 
-print '"' + result + '"'
+print('"%s"' % result)


### PR DESCRIPTION
In Python 3, subprocess.check_output returns an encoding-independent
byte array. If passed universal_newlines=True, both Python 2 and 3
decode and return a UTF-8 string.

Issue: https://github.com/flutter/flutter/issues/83043