### PR TITLE
Python 3 migration required for Android builds

### DIFF
--- a/build/android/gyp/util/build_utils.py
+++ b/build/android/gyp/util/build_utils.py
@@ -146,11 +146,13 @@ def CheckOutput(args, cwd=None,
                 print_stdout=False, print_stderr=True,
                 stdout_filter=None,
                 stderr_filter=None,
+                universal_newlines=True,
                 fail_func=lambda returncode, stderr: returncode != 0):
   if not cwd:
     cwd = os.getcwd()
 
   child = subprocess.Popen(args,
+      universal_newlines=universal_newlines,
       stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd)
   stdout, stderr = child.communicate()
 
@@ -260,13 +262,13 @@ def MergeZips(output, inputs, exclude_patterns=None):
 
 
 def PrintWarning(message):
-  print 'WARNING: ' + message
+  print('WARNING: %s' % message)
 
 
 def PrintBigWarning(message):
-  print '*****     ' * 8
+  print('*****     ' * 8)
   PrintWarning(message)
-  print '*****     ' * 8
+  print('*****     ' * 8)
 
 
 def GetSortedTransitiveDependencies(top, deps_func):
@@ -312,7 +314,7 @@ def GetPythonDependencies():
   src/. The paths will be relative to the current directory.
   """
   _ForceLazyModulesToLoad()
-  module_paths = (m.__file__ for m in sys.modules.itervalues()
+  module_paths = (m.__file__ for m in sys.modules.values()
                   if m is not None and hasattr(m, '__file__'))
   abs_module_paths = map(os.path.abspath, module_paths)
 

--- a/build/android/gyp/util/md5_check.py
+++ b/build/android/gyp/util/md5_check.py
@@ -70,7 +70,7 @@ class _Md5Checker(object):
     for i in sorted(input_paths):
       _UpdateMd5ForPath(md5, i)
     for s in input_strings:
-      md5.update(s)
+      md5.update(s.encode('utf-8'))
     self.new_digest = md5.hexdigest()
 
     self.old_digest = ''

--- a/build/ls.py
+++ b/build/ls.py
@@ -16,7 +16,7 @@ def main(target_directory, file_extension):
     for f in files:
       if file_extension is None or os.path.splitext(f)[-1] == file_extension:
         path = os.path.join(root, f)
-        print path
+        print(path)
 
 if __name__ == '__main__':
   parser = argparse.ArgumentParser(


### PR DESCRIPTION
This migrates all Python scripts required to build Android targets to be
Python 3.x compatible.

Main changes:
* Communication with processes now returns bytestreams by default. By
  specifying universal_newlines=True, these streams are decoded as UTF-8.
* md5.update() takes a bytes type, but strings are now utf-8 by default.
  We call string.encode('utf-8') convert to bytes.
* print now uses function syntax

Issue: https://github.com/flutter/flutter/issues/83043