### PR TITLE
Python 3 support macOS/iOS builds

### DIFF
--- a/build/config/ios/ios_sdk.py
+++ b/build/config/ios/ios_sdk.py
@@ -31,7 +31,7 @@ def main(argv):
     'Path'
   ]
 
-  sdk_output = subprocess.check_output(command).strip()
+  sdk_output = subprocess.check_output(command).decode('utf-8').strip()
   if args.symlink:
     symlink_target = os.path.join(args.symlink, 'SDKs', os.path.basename(sdk_output))
     symlink(sdk_output, symlink_target)

--- a/build/config/mac/package_framework.py
+++ b/build/config/mac/package_framework.py
@@ -23,7 +23,7 @@ def Main():
   # Foo.framework/Versions/Current symlink to it.
   if args.version:
     try:
-      os.makedirs(os.path.join(args.framework, VERSIONS, args.version), 0744)
+      os.makedirs(os.path.join(args.framework, VERSIONS, args.version), 744)
     except OSError as e:
       if e.errno != errno.EEXIST:
         raise e

--- a/build/config/mac/xcode_toolchain.py
+++ b/build/config/mac/xcode_toolchain.py
@@ -18,7 +18,7 @@ def main(argv):
                       help='Whether to create a symlink in the buildroot to the SDK.')
   args = parser.parse_args()
 
-  path = subprocess.check_output(['/usr/bin/env', 'xcode-select', '-p']).strip()
+  path = subprocess.check_output(['/usr/bin/env', 'xcode-select', '-p']).decode('utf-8').strip()
   path = os.path.join(path, "Toolchains", "XcodeDefault.xctoolchain")
   assert os.path.exists(path)
 

--- a/build/env_dump.py
+++ b/build/env_dump.py
@@ -38,7 +38,7 @@ def main():
         '. %s > /dev/null; %s -d' % (envsetup_cmd, os.path.abspath(__file__))
     ]
     try:
-      output = subprocess.check_output(full_cmd)
+      output = subprocess.check_output(full_cmd, universal_newlines=True)
     except Exception as e:
       sys.exit('Error running %s and dumping environment.' % envsetup_cmd)
 

--- a/build/mac/find_sdk.py
+++ b/build/mac/find_sdk.py
@@ -23,7 +23,7 @@ from pyutil.file_util import symlink
 
 def parse_version(version_str):
   """'10.6' => [10, 6]"""
-  return map(int, re.findall(r'(\d+)', version_str))
+  return [int(x) for x in re.findall(r'(\d+)', version_str)]
 
 
 def main():
@@ -44,6 +44,7 @@ def main():
   min_sdk_version = args[0]
 
   job = subprocess.Popen(['xcode-select', '-print-path'],
+                         universal_newlines=True,
                          stdout=subprocess.PIPE,
                          stderr=subprocess.STDOUT)
   out, err = job.communicate()
@@ -82,7 +83,7 @@ def main():
 
   if options.symlink or options.print_sdk_path:
     sdk_output = subprocess.check_output(['xcodebuild', '-version', '-sdk',
-                                          'macosx' + best_sdk, 'Path']).strip()
+                                          'macosx' + best_sdk, 'Path']).decode('utf-8').strip()
     if options.symlink:
       symlink_target = os.path.join(options.symlink, 'SDKs', os.path.basename(sdk_output))
       symlink(sdk_output, symlink_target)

--- a/build/toolchain/mac/setup_toolchain.py
+++ b/build/toolchain/mac/setup_toolchain.py
@@ -24,6 +24,6 @@ def CopyTool(source_path):
 
 # Find the tool source, it's the first argument, and copy it.
 if len(sys.argv) != 2:
-  print "Need one argument (mac_tool source path)."
+  print("Need one argument (mac_tool source path).")
   sys.exit(1)
 CopyTool(sys.argv[1])

--- a/tools/dart/dart_buildbot_helper.py
+++ b/tools/dart/dart_buildbot_helper.py
@@ -87,7 +87,7 @@ def filter_builders(name, filter_by_list):
 
 
 def update_dart_sdk_repo():
-  subprocess.check_output(['git', 'pull', '--rebase'], cwd=DART_SDK_HOME)
+  subprocess.check_output(['git', 'pull', '--rebase'], cwd=DART_SDK_HOME).decode('utf-8')
 
 
 def get_builder_names(filter_by_list=['vm-', 'app-kernel', 'analyzer']):
@@ -115,14 +115,14 @@ def get_buildbot_states(builder_name):
 
 def get_dart_sdk_commits_in_range(start, end):
   args = ['git', 'log', '--pretty=oneline', '{}..{}'.format(start, end)]
-  output = subprocess.check_output(args, cwd=DART_SDK_HOME)
+  output = subprocess.check_output(args, cwd=DART_SDK_HOME).decode('utf-8')
   commits = [x.split(' ')[0] for x in output.splitlines()]
   return commits
 
 
 def get_commit_timestamp(commit):
   args = ['git', 'show', '-s', '--format=%at', commit]
-  return int(subprocess.check_output(args, cwd=DART_SDK_HOME))
+  return int(subprocess.check_output(args, cwd=DART_SDK_HOME)).decode('utf-8')
 
 
 def bucket_states_by_commit(builder_states):

--- a/tools/dart/dart_roll_helper.py
+++ b/tools/dart/dart_roll_helper.py
@@ -237,7 +237,7 @@ def get_commit_range(start, finish):
   command = ['git', 'log', '--oneline', range_str]
   orig_dir = os.getcwd()
   os.chdir(dart_sdk_home())
-  result = subprocess.check_output(command)
+  result = subprocess.check_output(command).decode('utf-8')
   result = '\n'.join(['dart-lang/sdk@' + l for l in result.splitlines()])
   os.chdir(orig_dir)
   return result
@@ -247,7 +247,7 @@ def get_short_rev(rev):
   command = ['git', 'rev-parse', '--short', rev]
   orig_dir = os.getcwd()
   os.chdir(dart_sdk_home())
-  result = subprocess.check_output(command).rstrip()
+  result = subprocess.check_output(command).decode('utf-8').rstrip()
   os.chdir(orig_dir)
   return result
 


### PR DESCRIPTION
* subcommand invocations use universal_newlines/decode('utf-8') to convert
  output from a list of bytes to a utf-8 string.
* map() applied to a list returns a map rather than a list; instead
  we use a list comprehension to apply the type conversion from string
  to int on each component of Xcode version numbers.
* Add brackets to print() calls.

Issue: https://github.com/flutter/flutter/issues/83043