### PR TITLE
Migrate all Python scripts to Python 3

### DIFF
--- a/build/android/gyp/jar.py
+++ b/build/android/gyp/jar.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2013 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
@@ -48,8 +48,7 @@ def Jar(class_files, classes_dir, jar_path, manifest_file=None, additional_jar_f
 def JarDirectory(classes_dir, excluded_classes, jar_path, manifest_file=None, additional_jar_files=None):
   class_files = build_utils.FindInDirectory(classes_dir, '*.class')
   for exclude in excluded_classes:
-    class_files = filter(
-        lambda f: not fnmatch.fnmatch(f, exclude), class_files)
+    class_files = [f for f in class_files if not fnmatch.fnmatch(f, exclude)]
 
   Jar(class_files, classes_dir, jar_path, manifest_file=manifest_file,
       additional_jar_files=additional_jar_files)

--- a/build/android/gyp/javac.py
+++ b/build/android/gyp/javac.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2013 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
@@ -301,7 +301,7 @@ def main(argv):
     if options.jar_path:
       if options.main_class or options.manifest_entry:
         if options.manifest_entry:
-          entries = map(lambda e: e.split(":"), options.manifest_entry)
+          entries = [e.split(":") for e in options.manifest_entry]
         else:
           entries = []
         manifest_file = os.path.join(temp_dir, 'manifest')

--- a/build/android/gyp/util/build_utils.py
+++ b/build/android/gyp/util/build_utils.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # Copyright 2013 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -297,10 +299,10 @@ def GetSortedTransitiveDependencies(top, deps_func):
 
   # Then: simple, slow topological sort.
   sorted_deps = []
-  unsorted_deps = dict(map(Node, all_deps))
+  unsorted_deps = dict(list(map(Node, all_deps)))
   while unsorted_deps:
-    for library, dependencies in unsorted_deps.items():
-      if not dependencies.intersection(unsorted_deps.keys()):
+    for library, dependencies in list(unsorted_deps.items()):
+      if not dependencies.intersection(list(unsorted_deps.keys())):
         sorted_deps.append(library)
         del unsorted_deps[library]
 
@@ -314,9 +316,9 @@ def GetPythonDependencies():
   src/. The paths will be relative to the current directory.
   """
   _ForceLazyModulesToLoad()
-  module_paths = (m.__file__ for m in sys.modules.values()
+  module_paths = (m.__file__ for m in list(sys.modules.values())
                   if m is not None and hasattr(m, '__file__'))
-  abs_module_paths = map(os.path.abspath, module_paths)
+  abs_module_paths = list(map(os.path.abspath, module_paths))
 
   assert os.path.isabs(DIR_SOURCE_ROOT)
   non_system_module_paths = [
@@ -326,8 +328,8 @@ def GetPythonDependencies():
       return s[:-1]
     return s
 
-  non_system_module_paths = map(ConvertPycToPy, non_system_module_paths)
-  non_system_module_paths = map(os.path.relpath, non_system_module_paths)
+  non_system_module_paths = list(map(ConvertPycToPy, non_system_module_paths))
+  non_system_module_paths = list(map(os.path.relpath, non_system_module_paths))
   return sorted(set(non_system_module_paths))
 
 
@@ -339,11 +341,11 @@ def _ForceLazyModulesToLoad():
   over the values until sys.modules stabilizes so that no modules are missed.
   """
   while True:
-    num_modules_before = len(sys.modules.keys())
-    for m in sys.modules.values():
+    num_modules_before = len(list(sys.modules.keys()))
+    for m in list(sys.modules.values()):
       if m is not None and hasattr(m, '__file__'):
         _ = m.__file__
-    num_modules_after = len(sys.modules.keys())
+    num_modules_after = len(list(sys.modules.keys()))
     if num_modules_before == num_modules_after:
       break
 

--- a/build/apply_locales.py
+++ b/build/apply_locales.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+#
 # Copyright (c) 2009 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -20,7 +21,7 @@ def main(argv):
   (options, arglist) = parser.parse_args(argv)
 
   if len(arglist) < 3:
-    print 'ERROR: need string and list of locales'
+    print('ERROR: need string and list of locales')
     return 1
 
   str_template = arglist[1]
@@ -39,7 +40,7 @@ def main(argv):
 
   # Quote each element so filename spaces don't mess up GYP's attempt to parse
   # it into a list.
-  print ' '.join(["'%s'" % x for x in results])
+  print(' '.join(["'%s'" % x for x in results]))
 
 if __name__ == '__main__':
   sys.exit(main(sys.argv))

--- a/build/check_return_value.py
+++ b/build/check_return_value.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+#
 # Copyright 2014 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -12,6 +13,6 @@ import sys
 
 devnull = open(os.devnull, 'wb')
 if not subprocess.call(sys.argv[1:], stdout=devnull, stderr=devnull):
-  print 1
+  print(1)
 else:
-  print 0
+  print(0)

--- a/build/compiler_version.py
+++ b/build/compiler_version.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+#
 # Copyright (c) 2012 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -19,9 +20,9 @@ compiler_version_cache = {}  # Map from (compiler, tool) -> version.
 
 
 def Usage(program_name):
-  print '%s MODE TOOL' % os.path.basename(program_name)
-  print 'MODE: host or target.'
-  print 'TOOL: assembler or compiler or linker.'
+  print('%s MODE TOOL' % os.path.basename(program_name))
+  print('MODE: host or target.')
+  print('TOOL: assembler or compiler or linker.')
   return 1
 
 
@@ -91,24 +92,24 @@ def GetVersion(compiler, tool):
     result = parsed_output.group(1) + parsed_output.group(2)
     compiler_version_cache[cache_key] = result
     return result
-  except Exception, e:
+  except Exception as e:
     if tool_error:
       sys.stderr.write(tool_error)
-    print >> sys.stderr, "compiler_version.py failed to execute:", compiler
-    print >> sys.stderr, e
+    print("compiler_version.py failed to execute:", compiler, file=sys.stderr)
+    print(e, file=sys.stderr)
     return ""
 
 
 def main(args):
   try:
     (mode, tool) = ParseArgs(args[1:])
-  except Exception, e:
+  except Exception as e:
     sys.stderr.write(e.message + '\n\n')
     return Usage(args[0])
 
   ret_code, result = ExtractVersion(mode, tool)
   if ret_code == 0:
-    print result
+    print(result)
   return ret_code
 
 

--- a/build/config/linux/pkg-config.py
+++ b/build/config/linux/pkg-config.py
@@ -1,9 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+#
 # Copyright (c) 2013 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-from __future__ import print_function
+
 
 import json
 import os

--- a/build/config/linux/sysroot_ld_path.py
+++ b/build/config/linux/sysroot_ld_path.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # Copyright (c) 2013 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/build/copy_test_data_ios.py
+++ b/build/copy_test_data_ios.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+#
 # Copyright (c) 2012 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -94,11 +95,11 @@ def DoMain(argv):
 def main(argv):
   try:
     result = DoMain(argv[1:])
-  except WrongNumberOfArgumentsException, e:
-    print >>sys.stderr, e
+  except WrongNumberOfArgumentsException as e:
+    print(e, file=sys.stderr)
     return 1
   if result:
-    print result
+    print(result)
   return 0
 
 if __name__ == '__main__':

--- a/build/detect_host_arch.py
+++ b/build/detect_host_arch.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+#
 # Copyright 2014 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -37,4 +38,4 @@ def DoMain(_):
   return HostArch()
 
 if __name__ == '__main__':
-  print DoMain([])
+  print(DoMain([]))

--- a/build/download_nacl_toolchains.py
+++ b/build/download_nacl_toolchains.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+#
 # Copyright (c) 2012 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -21,9 +22,9 @@ def Main(args):
   package_version_dir = os.path.join(nacl_build_dir, 'package_version')
   package_version = os.path.join(package_version_dir, 'package_version.py')
   if not os.path.exists(package_version):
-    print "Can't find '%s'" % package_version
-    print 'Presumably you are intentionally building without NativeClient.'
-    print 'Skipping NativeClient toolchain download.'
+    print("Can't find '%s'" % package_version)
+    print('Presumably you are intentionally building without NativeClient.')
+    print('Skipping NativeClient toolchain download.')
     sys.exit(0)
   sys.path.insert(0, package_version_dir)
   import package_version
@@ -40,7 +41,7 @@ def Main(args):
     if 'pnacl' in buildbot_name and 'sdk' in buildbot_name:
       use_pnacl = True
     if use_pnacl:
-      print '\n*** DOWNLOADING PNACL TOOLCHAIN ***\n'
+      print('\n*** DOWNLOADING PNACL TOOLCHAIN ***\n')
     else:
       args = ['--exclude', 'pnacl_newlib'] + args
 

--- a/build/env_dump.py
+++ b/build/env_dump.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
+#
 # Copyright 2013 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -44,7 +45,7 @@ def main():
 
     env_diff = {}
     new_env = json.loads(output)
-    for k, val in new_env.items():
+    for k, val in list(new_env.items()):
       if k == '_' or (k in os.environ and os.environ[k] == val):
         continue
       env_diff[k] = val

--- a/build/extract_from_cab.py
+++ b/build/extract_from_cab.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+#
 # Copyright (c) 2012 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -17,12 +18,12 @@ def run_quiet(*args):
   out, _ = popen.communicate()
   if popen.returncode:
     # expand emits errors to stdout, so if we fail, then print that out.
-    print out
+    print(out)
   return popen.returncode
 
 def main():
   if len(sys.argv) != 4:
-    print 'Usage: extract_from_cab.py cab_path archived_file output_dir'
+    print('Usage: extract_from_cab.py cab_path archived_file output_dir')
     return 1
 
   [cab_path, archived_file, output_dir] = sys.argv[1:]

--- a/build/fuchsia/fidl_gen_cpp.py
+++ b/build/fuchsia/fidl_gen_cpp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
@@ -59,7 +59,7 @@ def main():
     args.json
   ]
 
-  for _, fidl_files in fidl_files_by_name.iteritems():
+  for _, fidl_files in fidl_files_by_name.items():
     fidlc_command.append('--files')
     for fidl_file in fidl_files:
       fidl_abspath = os.path.abspath('%s/%s' % (args.sdk_base, fidl_file))

--- a/build/get_landmines.py
+++ b/build/get_landmines.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+#
 # Copyright 2013 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -30,7 +31,7 @@ def print_landmines():
   # dependency problems, fix the dependency problems instead of adding a
   # landmine.
 
-  print 'Lets start a new landmines file.'
+  print('Lets start a new landmines file.')
 
 
 def main():

--- a/build/get_sdk_extras_packages.py
+++ b/build/get_sdk_extras_packages.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+#
 # Copyright (c) 2014 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -18,7 +19,7 @@ def main():
   for package in packages:
     out.append(package['package_id'])
 
-  print ','.join(out)
+  print(','.join(out))
 
 if __name__ == '__main__':
   sys.exit(main())

--- a/build/get_syzygy_binaries.py
+++ b/build/get_syzygy_binaries.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+#
 # Copyright 2014 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -86,18 +87,18 @@ def _StateIsValid(state):
     _LOGGER.debug('State must be a dict.')
     return False
   r = state.get('revision', None)
-  if not isinstance(r, basestring) or not _REVISION_RE.match(r):
+  if not isinstance(r, str) or not _REVISION_RE.match(r):
     _LOGGER.debug('State contains an invalid revision.')
     return False
   c = state.get('contents', None)
   if not isinstance(c, dict):
     _LOGGER.debug('State must contain a contents dict.')
     return False
-  for (relpath, md5) in c.iteritems():
-    if not isinstance(relpath, basestring) or len(relpath) == 0:
+  for (relpath, md5) in c.items():
+    if not isinstance(relpath, str) or len(relpath) == 0:
       _LOGGER.debug('State contents dict contains an invalid path.')
       return False
-    if not isinstance(md5, basestring) or not _MD5_RE.match(md5):
+    if not isinstance(md5, str) or not _MD5_RE.match(md5):
       _LOGGER.debug('State contents dict contains an invalid MD5 digest.')
       return False
   return True
@@ -111,7 +112,7 @@ def _BuildActualState(stored, revision, output_dir):
   """
   contents = {}
   state = { 'revision': revision, 'contents': contents }
-  for relpath, md5 in stored['contents'].iteritems():
+  for relpath, md5 in stored['contents'].items():
     abspath = os.path.abspath(os.path.join(output_dir, relpath))
     if os.path.isfile(abspath):
       m = _Md5(abspath)
@@ -129,7 +130,7 @@ def _StatesAreConsistent(stored, actual):
     return False
   cont_stored = stored['contents']
   cont_actual = actual['contents']
-  for relpath, md5 in cont_stored.iteritems():
+  for relpath, md5 in cont_stored.items():
     if relpath not in cont_actual:
       _LOGGER.debug('Missing content: %s', relpath)
       return False
@@ -226,7 +227,7 @@ def _CleanState(output_dir, state, dry_run=False):
 
   # Sort directories from longest name to shortest. This lets us remove empty
   # directories from the most nested paths first.
-  dirs = sorted(dirs.keys(), key=lambda x: len(x), reverse=True)
+  dirs = sorted(list(dirs.keys()), key=lambda x: len(x), reverse=True)
   for p in dirs:
     if os.path.exists(p) and _DirIsEmpty(p):
       _LOGGER.debug('Deleting empty directory "%s".', p)

--- a/build/gn_helpers.py
+++ b/build/gn_helpers.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # Copyright 2014 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -15,7 +17,7 @@ def ToGNString(value, allow_dicts = True):
   allow_dicts indicates if this function will allow converting dictionaries
   to GN scopes. This is only possible at the top level, you can't nest a
   GN scope in a list, so this should be set to False for recursive calls."""
-  if isinstance(value, str) or isinstance(value, unicode):
+  if isinstance(value, str) or isinstance(value, str):
     if value.find('\n') >= 0:
       raise GNException("Trying to print a string with a newline in it.")
     return '"' + value.replace('"', '\\"') + '"'

--- a/build/gyp_chromium.py
+++ b/build/gyp_chromium.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # Copyright 2012 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -15,4 +17,4 @@
 import os
 
 path = os.path.abspath(os.path.split(__file__)[0])
-execfile(os.path.join(path, 'gyp_chromium'))
+exec(compile(open(os.path.join(path, 'gyp_chromium'), "rb").read(), os.path.join(path, 'gyp_chromium'), 'exec'))

--- a/build/gyp_helper.py
+++ b/build/gyp_helper.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # Copyright (c) 2012 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -19,7 +21,7 @@ def apply_gyp_environment_from_file(file_path):
     file_contents = f.read()
   try:
     file_data = eval(file_contents, {'__builtins__': None}, None)
-  except SyntaxError, e:
+  except SyntaxError as e:
     e.filename = os.path.abspath(file_path)
     raise
   supported_vars = (
@@ -50,12 +52,12 @@ def apply_gyp_environment_from_file(file_path):
           behavior = 'merges with, and individual components override,'
         else:
           result = os.environ[var]
-        print 'INFO: Environment value for "%s" %s value in %s' % (
+        print('INFO: Environment value for "%s" %s value in %s' % (
             var, behavior, os.path.abspath(file_path)
-        )
+        ))
         string_padding = max(len(var), len(file_path), len('result'))
-        print '      %s: %s' % (var.rjust(string_padding), os.environ[var])
-        print '      %s: %s' % (file_path.rjust(string_padding), file_val)
+        print('      %s: %s' % (var.rjust(string_padding), os.environ[var]))
+        print('      %s: %s' % (file_path.rjust(string_padding), file_val))
         os.environ[var] = result
       else:
         os.environ[var] = file_val

--- a/build/gypi_to_gn.py
+++ b/build/gypi_to_gn.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # Copyright 2014 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -77,10 +79,10 @@ def LoadPythonDictionary(path):
   file_string = open(path).read()
   try:
     file_data = eval(file_string, {'__builtins__': None}, None)
-  except SyntaxError, e:
+  except SyntaxError as e:
     e.filename = path
     raise
-  except Exception, e:
+  except Exception as e:
     raise Exception("Unexpected error while reading %s: %s" % (path, str(e)))
 
   assert isinstance(file_data, dict), "%s does not eval to a dictionary" % path
@@ -119,7 +121,7 @@ def ReplaceSubstrings(values, search_for, replace_with):
   if isinstance(values, dict):
     # For dictionaries, do the search for both the key and values.
     result = {}
-    for key, value in values.items():
+    for key, value in list(values.items()):
       new_key = ReplaceSubstrings(key, search_for, replace_with)
       new_value = ReplaceSubstrings(value, search_for, replace_with)
       result[new_key] = new_value
@@ -157,11 +159,11 @@ def main():
       data[key[:-1]] = data[key]
       del data[key]
 
-  print gn_helpers.ToGNString(data)
+  print(gn_helpers.ToGNString(data))
 
 if __name__ == '__main__':
   try:
     main()
-  except Exception, e:
-    print str(e)
+  except Exception as e:
+    print(str(e))
     sys.exit(1)

--- a/build/install-build-deps.py
+++ b/build/install-build-deps.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+#
 # Copyright 2015 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -375,7 +376,7 @@ def quick_check(packages):
       'dpkg-query', '-W', '-f', '${PackageSpec}:${Status}\n'] + list(packages))
   if rc == 0 and not stderr:
     return 0
-  print stderr
+  print(stderr)
   return 1
 
 
@@ -391,8 +392,8 @@ def main(argv):
 
   lsb_codename = lsb_release_short_codename()
   if not args.unsupported and not args.quick_check:
-    if lsb_codename not in map(
-        operator.itemgetter('codename'), SUPPORTED_UBUNTU_VERSIONS):
+    if lsb_codename not in list(map(
+        operator.itemgetter('codename'), SUPPORTED_UBUNTU_VERSIONS)):
       supported_ubuntus = ['%(number)s (%(codename)s)' % v
                            for v in SUPPORTED_UBUNTU_VERSIONS]
       write_error('Only Ubuntu %s are currently supported.' %
@@ -404,10 +405,10 @@ def main(argv):
       return 1
 
   if os.geteuid() != 0 and not args.quick_check:
-    print 'Running as non-root user.'
-    print 'You might have to enter your password one or more times'
-    print 'for \'sudo\'.'
-    print
+    print('Running as non-root user.')
+    print('You might have to enter your password one or more times')
+    print('for \'sudo\'.')
+    print()
 
   compute_dynamic_package_lists()
 

--- a/build/inverse_depth.py
+++ b/build/inverse_depth.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+#
 # Copyright 2014 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -14,9 +15,9 @@ def DoMain(argv):
 
 def main(argv):
   if len(argv) < 2:
-    print "USAGE: inverse_depth.py depth"
+    print("USAGE: inverse_depth.py depth")
     return 1
-  print DoMain(argv[1:])
+  print(DoMain(argv[1:]))
   return 0
 
 

--- a/build/landmine_utils.py
+++ b/build/landmine_utils.py
@@ -1,7 +1,8 @@
+#!/usr/bin/env python3
+#
 # Copyright 2013 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
-
 
 import functools
 import logging
@@ -20,7 +21,7 @@ def memoize(default=None):
         ret = func()
         val.append(ret if ret is not None else default)
         if logging.getLogger().isEnabledFor(logging.INFO):
-          print '%s -> %r' % (func.__name__, val[0])
+          print('%s -> %r' % (func.__name__, val[0]))
       return val[0]
     return inner
   return memoizer

--- a/build/linux/dump_app_syms.py
+++ b/build/linux/dump_app_syms.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # Copyright 2015 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -10,8 +12,8 @@ import subprocess
 import sys
 
 if len(sys.argv) != 5:
-  print "dump_app_syms.py <dump_syms_exe> <strip_binary>"
-  print "                 <binary_with_symbols> <symbols_output>"
+  print("dump_app_syms.py <dump_syms_exe> <strip_binary>")
+  print("                 <binary_with_symbols> <symbols_output>")
   sys.exit(1)
 
 dumpsyms = sys.argv[1]

--- a/build/linux/install-chromeos-fonts.py
+++ b/build/linux/install-chromeos-fonts.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+#
 # Copyright 2013 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -20,15 +21,15 @@ FONTS_DIR = '/usr/local/share/fonts'
 
 def main(args):
   if not sys.platform.startswith('linux'):
-    print "Error: %s must be run on Linux." % __file__
+    print("Error: %s must be run on Linux." % __file__)
     return 1
 
   if os.getuid() != 0:
-    print "Error: %s must be run as root." % __file__
+    print("Error: %s must be run as root." % __file__)
     return 1
 
   if not os.path.isdir(FONTS_DIR):
-    print "Error: Destination directory does not exist: %s" % FONTS_DIR
+    print("Error: Destination directory does not exist: %s" % FONTS_DIR)
     return 1
 
   dest_dir = os.path.join(FONTS_DIR, 'chromeos')
@@ -37,15 +38,15 @@ def main(args):
   if os.path.exists(stamp):
     with open(stamp) as s:
       if s.read() == URL:
-        print "Chrome OS fonts already up-to-date in %s." % dest_dir
+        print("Chrome OS fonts already up-to-date in %s." % dest_dir)
         return 0
 
   if os.path.isdir(dest_dir):
     shutil.rmtree(dest_dir)
   os.mkdir(dest_dir)
-  os.chmod(dest_dir, 0755)
+  os.chmod(dest_dir, 0o755)
 
-  print "Installing Chrome OS fonts to %s." % dest_dir
+  print("Installing Chrome OS fonts to %s." % dest_dir)
   tarball = os.path.join(dest_dir, os.path.basename(URL))
   subprocess.check_call(['curl', '-L', URL, '-o', tarball])
   subprocess.check_call(['tar', '--no-same-owner', '--no-same-permissions',
@@ -63,9 +64,9 @@ def main(args):
 
   for base, dirs, files in os.walk(dest_dir):
     for dir in dirs:
-      os.chmod(os.path.join(base, dir), 0755)
+      os.chmod(os.path.join(base, dir), 0o755)
     for file in files:
-      os.chmod(os.path.join(base, file), 0644)
+      os.chmod(os.path.join(base, file), 0o644)
 
   return 0
 

--- a/build/linux/rewrite_dirs.py
+++ b/build/linux/rewrite_dirs.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+#
 # Copyright (c) 2011 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -63,7 +64,7 @@ def main(argv):
 
   for line in sys.stdin.readlines():
     line = RewriteLine(line.strip(), opts)
-    print line
+    print(line)
   return 0
 
 

--- a/build/linux/sysroot_scripts/install-sysroot.py
+++ b/build/linux/sysroot_scripts/install-sysroot.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+#
 # Copyright (c) 2013 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -18,8 +19,6 @@
 # time chrome's build dependencies are changed but should also be updated
 # periodically to include upstream security fixes from Debian.
 
-from __future__ import print_function
-
 import hashlib
 import json
 import platform
@@ -34,7 +33,7 @@ try:
     from urllib.request import urlopen
 except ImportError:
     # Fall back to Python 2's urllib2
-    from urllib2 import urlopen
+    from urllib.request import urlopen
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/build/linux/unbundle/remove_bundled_libraries.py
+++ b/build/linux/unbundle/remove_bundled_libraries.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+#
 # Copyright 2013 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -21,7 +22,7 @@ def DoMain(argv):
     os.path.join(my_dirname, '..', '..', '..'))
 
   if os.path.join(source_tree_root, 'build', 'linux', 'unbundle') != my_dirname:
-    print ('Sanity check failed: please run this script from ' +
+    print('Sanity check failed: please run this script from ' +
            'build/linux/unbundle directory.')
     return 1
 
@@ -80,19 +81,19 @@ def DoMain(argv):
         os.remove(path)
       else:
         # By default just print paths that would be removed.
-        print path
+        print(path)
 
   exit_code = 0
 
   # Fail if exclusion list contains stale entries - this helps keep it
   # up to date.
-  for exclusion, used in exclusion_used.iteritems():
+  for exclusion, used in exclusion_used.items():
     if not used:
-      print '%s does not exist' % exclusion
+      print('%s does not exist' % exclusion)
       exit_code = 1
 
   if not options.do_remove:
-    print ('To actually remove files printed above, please pass ' +
+    print('To actually remove files printed above, please pass ' +
            '--do-remove flag.')
 
   return exit_code

--- a/build/linux/unbundle/replace_gyp_files.py
+++ b/build/linux/unbundle/replace_gyp_files.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+#
 # Copyright 2013 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -57,7 +58,7 @@ def DoMain(argv):
 
   options, args = parser.parse_args(argv)
 
-  for flag, path in REPLACEMENTS.items():
+  for flag, path in list(REPLACEMENTS.items()):
     if '%s=1' % flag not in options.defines:
       continue
 

--- a/build/mac/change_mach_o_flags.py
+++ b/build/mac/change_mach_o_flags.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+#
 # Copyright (c) 2011 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -106,8 +107,7 @@ def CheckedSeek(file, offset):
   file.seek(offset, os.SEEK_SET)
   new_offset = file.tell()
   if new_offset != offset:
-    raise MachOError, \
-          'seek: expected offset %d, observed %d' % (offset, new_offset)
+    raise MachOError('seek: expected offset %d, observed %d' % (offset, new_offset))
 
 
 def CheckedRead(file, count):
@@ -116,8 +116,7 @@ def CheckedRead(file, count):
 
   bytes = file.read(count)
   if len(bytes) != count:
-    raise MachOError, \
-          'read: expected length %d, observed %d' % (count, len(bytes))
+    raise MachOError('read: expected length %d, observed %d' % (count, len(bytes)))
 
   return bytes
 
@@ -189,17 +188,15 @@ def HandleMachOFile(file, options, offset=0):
   elif magic == MH_CIGAM or magic == MH_CIGAM_64:
     endian = '>'
   else:
-    raise MachOError, \
-          'Mach-O file at offset %d has illusion of magic' % offset
+    raise MachOError('Mach-O file at offset %d has illusion of magic' % offset)
 
   CheckedSeek(file, offset)
   magic, cputype, cpusubtype, filetype, ncmds, sizeofcmds, flags = \
       ReadMachHeader(file, endian)
   assert magic == MH_MAGIC or magic == MH_MAGIC_64
   if filetype != MH_EXECUTE:
-    raise MachOError, \
-          'Mach-O file at offset %d is type 0x%x, expected MH_EXECUTE' % \
-              (offset, filetype)
+    raise MachOError('Mach-O file at offset %d is type 0x%x, expected MH_EXECUTE' % \
+              (offset, filetype))
 
   original_flags = flags
 
@@ -228,7 +225,7 @@ def HandleFatFile(file, options, fat_offset=0):
 
   nfat_arch = ReadUInt32(file, '>')
 
-  for index in xrange(0, nfat_arch):
+  for index in range(0, nfat_arch):
     cputype, cpusubtype, offset, size, align = ReadFatArch(file)
     assert size >= 28
 
@@ -263,7 +260,7 @@ def main(me, args):
       magic == MH_MAGIC_64 or magic == MH_CIGAM_64:
     HandleMachOFile(executable_file, options)
   else:
-    raise MachOError, '%s is not a Mach-O or fat file' % executable_file
+    raise MachOError('%s is not a Mach-O or fat file' % executable_file)
 
   executable_file.close()
   return 0

--- a/build/mac/find_sdk.py
+++ b/build/mac/find_sdk.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+#
 # Copyright (c) 2012 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/build/mac/tweak_info_plist.py
+++ b/build/mac/tweak_info_plist.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python
-
+#!/usr/bin/env python3
+#
 # Copyright (c) 2012 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -68,7 +68,7 @@ def _AddVersionKeys(plist, version=None):
   if version:
     match = re.match('\d+\.\d+\.(\d+\.\d+)$', version)
     if not match:
-      print >>sys.stderr, 'Invalid version string specified: "%s"' % version
+      print('Invalid version string specified: "%s"' % version, file=sys.stderr)
       return False
 
     full_version = match.group(0)
@@ -127,7 +127,7 @@ def _DoSCMKeys(plist, add_keys):
   if scm_revision != None:
     plist['SCMRevision'] = scm_revision
   elif add_keys:
-    print >>sys.stderr, 'Could not determine SCM revision.  This may be OK.'
+    print('Could not determine SCM revision.  This may be OK.', file=sys.stderr)
 
   return True
 
@@ -165,9 +165,9 @@ def _TagSuffixes():
   components_len = len(components)
   combinations = 1 << components_len
   tag_suffixes = []
-  for combination in xrange(0, combinations):
+  for combination in range(0, combinations):
     tag_suffix = ''
-    for component_index in xrange(0, components_len):
+    for component_index in range(0, components_len):
       if combination & (1 << component_index):
         tag_suffix += '-' + components[component_index]
     tag_suffixes.append(tag_suffix)
@@ -221,7 +221,7 @@ def Main(argv):
   (options, args) = parser.parse_args(argv)
 
   if len(args) > 0:
-    print >>sys.stderr, parser.get_usage()
+    print(parser.get_usage(), file=sys.stderr)
     return 1
 
   # Read the plist into its parsed format.
@@ -235,7 +235,7 @@ def Main(argv):
   # Add Breakpad if configured to do so.
   if options.use_breakpad:
     if options.branding is None:
-      print >>sys.stderr, 'Use of Breakpad requires branding.'
+      print('Use of Breakpad requires branding.', file=sys.stderr)
       return 1
     _AddBreakpadKeys(plist, options.branding)
     if options.breakpad_uploads:
@@ -254,7 +254,7 @@ def Main(argv):
   # Only add Keystone in Release builds.
   if options.use_keystone and env['CONFIGURATION'] == 'Release':
     if options.bundle_identifier is None:
-      print >>sys.stderr, 'Use of Keystone requires the bundle id.'
+      print('Use of Keystone requires the bundle id.', file=sys.stderr)
       return 1
     _AddKeystoneKeys(plist, options.bundle_identifier)
   else:

--- a/build/protoc_java.py
+++ b/build/protoc_java.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+#
 # Copyright (c) 2012 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -37,7 +38,7 @@ def main(argv):
 
   build_utils.CheckOptions(options, parser, ['protoc', 'proto_path'])
   if not options.java_out_dir and not options.srcjar:
-    print 'One of --java-out-dir or --srcjar must be specified.'
+    print('One of --java-out-dir or --srcjar must be specified.')
     return 1
 
   with build_utils.TempDir() as temp_dir:

--- a/build/symlink.py
+++ b/build/symlink.py
@@ -1,13 +1,17 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+#
 # Copyright (c) 2013 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 """Make a symlink and optionally touch a file (to handle dependencies)."""
+
 import errno
 import optparse
 import os.path
 import shutil
 import sys
+
+
 def Main(argv):
   parser = optparse.OptionParser()
   parser.add_option('-f', '--force', action='store_true')
@@ -23,7 +27,7 @@ def Main(argv):
       t = target
     try:
       os.symlink(s, t)
-    except OSError, e:
+    except OSError as e:
       if e.errno == errno.EEXIST and options.force:
         if os.path.isdir(t):
           shutil.rmtree(t, ignore_errors=True)

--- a/build/toolchain/clang_static_analyzer_wrapper.py
+++ b/build/toolchain/clang_static_analyzer_wrapper.py
@@ -1,16 +1,20 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+#
 # Copyright 2017 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 """Adds an analysis build step to invocations of the Clang C/C++ compiler.
 Usage: clang_static_analyzer_wrapper.py <compiler> [args...]
 """
+
 import argparse
 import fnmatch
 import itertools
 import os
 import sys
 import wrapper_utils
+
+
 # Flags used to enable analysis for Clang invocations.
 analyzer_enable_flags = [
     '--analyze',
@@ -34,7 +38,7 @@ analyzer_option_flags = [
 # e.g. ['-analyzer-foo', '-analyzer-bar'] => ['-Xanalyzer', '-analyzer-foo',
 #                                             '-Xanalyzer', '-analyzer-bar']
 def interleave_args(args, token):
-  return list(sum(zip([token] * len(args), args), ()))
+  return list(sum(list(zip([token] * len(args), args)), ()))
 def main():
   parser = argparse.ArgumentParser()
   parser.add_argument('--mode',

--- a/build/toolchain/win/setup_toolchain.py
+++ b/build/toolchain/win/setup_toolchain.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # Copyright (c) 2013 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -75,7 +77,7 @@ def _FormatAsEnvironmentBlock(envvar_dict):
   CreateProcess documentation for more details."""
   block = ''
   nul = '\0'
-  for key, value in envvar_dict.iteritems():
+  for key, value in envvar_dict.items():
     block += key + '=' + value + nul
   block += nul
   return block
@@ -146,7 +148,7 @@ def main():
       f.write(env_block)
 
   assert vc_bin_dir
-  print 'vc_bin_dir = "%s"' % vc_bin_dir
+  print('vc_bin_dir = "%s"' % vc_bin_dir)
 
 
 if __name__ == '__main__':

--- a/build/vs_toolchain.py
+++ b/build/vs_toolchain.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+#
 # Copyright 2014 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -11,8 +12,6 @@
 # To update to a new MSVC toolchain, copy the updated script from the Chromium
 # tree, and edit to make it work in the Dart tree by updating paths in the original script.
 
-from __future__ import print_function
-
 import collections
 import glob
 import json
@@ -24,7 +23,6 @@ import shutil
 import stat
 import subprocess
 import sys
-
 
 from gn_helpers import ToGNString
 
@@ -124,12 +122,12 @@ def _RegistryGetValueUsingWinReg(key, value):
     contents of the registry key's value, or None on failure.  Throws
     ImportError if _winreg is unavailable.
   """
-  import _winreg
+  import winreg
   try:
     root, subkey = key.split('\\', 1)
     assert root == 'HKLM'  # Only need HKLM for now.
-    with _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE, subkey) as hkey:
-      return _winreg.QueryValueEx(hkey, value)[0]
+    with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, subkey) as hkey:
+      return winreg.QueryValueEx(hkey, value)[0]
   except WindowsError:
     return None
 
@@ -149,7 +147,7 @@ def GetVisualStudioVersion():
   if env_version:
     return env_version
 
-  supported_versions = MSVS_VERSIONS.keys()
+  supported_versions = list(MSVS_VERSIONS.keys())
 
   # VS installed in depot_tools for Googlers
   if bool(int(os.environ.get('DEPOT_TOOLS_WIN_TOOLCHAIN', '1'))):
@@ -157,7 +155,7 @@ def GetVisualStudioVersion():
 
   # VS installed in system for external developers
   supported_versions_str = ', '.join('{} ({})'.format(v,k)
-      for k,v in MSVS_VERSIONS.items())
+      for k, v in list(MSVS_VERSIONS.items()))
   available_versions = []
   for version in supported_versions:
     for path in (

--- a/build/win/generate_winrt_headers.py
+++ b/build/win/generate_winrt_headers.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+#
 # Copyright 2014 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/build/win/importlibs/create_importlib_win.py
+++ b/build/win/importlibs/create_importlib_win.py
@@ -1,9 +1,11 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+#
 # Copyright (c) 2012 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 #
 """Creates an import library from an import description file."""
+
 import ast
 import logging
 import optparse
@@ -202,7 +204,7 @@ def main():
     generator = _ImportLibraryGenerator(temp_dir)
 
     ret = generator.CreateImportLib(args[0], options.output_file)
-  except Exception, e:
+  except Exception as e:
     _LOGGER.exception('Failed to create import lib.')
     ret = 1
   finally:

--- a/build/win/importlibs/filter_export_list.py
+++ b/build/win/importlibs/filter_export_list.py
@@ -1,9 +1,11 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+#
 # Copyright (c) 2012 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 #
 """Help maintaining DLL import lists."""
+
 import ast
 import optparse
 import re
@@ -77,7 +79,7 @@ def main():
     found_exports = set(master_mapping.values()) - set(found_exports)
 
   # Sort the found exports for tidy output.
-  print '\n'.join(sorted(found_exports))
+  print('\n'.join(sorted(found_exports)))
   return 0
 
 

--- a/build/win/use_ansi_codes.py
+++ b/build/win/use_ansi_codes.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+#
 # Copyright (c) 2015 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -7,4 +8,4 @@
 import os
 
 # Add more terminals here as needed.
-print 'ANSICON' in os.environ
+print('ANSICON' in os.environ)

--- a/build/win_is_xtree_patched.py
+++ b/build/win_is_xtree_patched.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+#
 # Copyright 2014 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -23,4 +24,4 @@ def DoMain(_):
 
 
 if __name__ == '__main__':
-  print DoMain([])
+  print(DoMain([]))

--- a/third_party/libxml/src/check-relaxng-test-suite.py
+++ b/third_party/libxml/src/check-relaxng-test-suite.py
@@ -1,9 +1,10 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
+
 import sys
 import time
 import os
 import string
-import StringIO
+import io
 sys.path.insert(0, "python")
 import libxml2
 
@@ -47,8 +48,8 @@ def resolver(URL, ID, ctxt):
 
     if string.find(URL, '#') != -1:
         URL = URL[0:string.find(URL, '#')]
-    if resources.has_key(URL):
-        return(StringIO.StringIO(resources[URL]))
+    if URL in resources:
+        return(io.StringIO(resources[URL]))
     log.write("Resolver failure: asked %s\n" % (URL))
     log.write("resources: %s\n" % (resources))
     return None
@@ -77,7 +78,7 @@ def handle_valid(node, schema):
     while child != None:
         if child.type != 'text':
 	    instance = instance + child.serialize()
-	child = child.next
+	child = child.__next__
 
     try:
 	doc = libxml2.parseDoc(instance)
@@ -118,7 +119,7 @@ def handle_invalid(node, schema):
     while child != None:
         if child.type != 'text':
 	    instance = instance + child.serialize()
-	child = child.next
+	child = child.__next__
 
     try:
 	doc = libxml2.parseDoc(instance)
@@ -158,7 +159,7 @@ def handle_correct(node):
     while child != None:
         if child.type != 'text':
 	    schema = schema + child.serialize()
-	child = child.next
+	child = child.__next__
 
     try:
 	rngp = libxml2.relaxNGNewMemParserCtxt(schema, len(schema))
@@ -184,7 +185,7 @@ def handle_incorrect(node):
     while child != None:
         if child.type != 'text':
 	    schema = schema + child.serialize()
-	child = child.next
+	child = child.__next__
 
     try:
 	rngp = libxml2.relaxNGNewMemParserCtxt(schema, len(schema))
@@ -227,7 +228,7 @@ def handle_resource(node, dir):
     while child != None:
         if child.type != 'text':
 	    res = res + child.serialize()
-	child = child.next
+	child = child.__next__
     resources[name] = res
 
 #
@@ -268,7 +269,7 @@ def handle_testCase(node):
               nb_schemas_tests, node.lineNo(), sections))
     resources = {}
     if debug:
-        print "test %d line %d" % (nb_schemas_tests, node.lineNo())
+        print("test %d line %d" % (nb_schemas_tests, node.lineNo()))
 
     dirs = node.xpathEval('dir')
     for dir in dirs:
@@ -280,16 +281,16 @@ def handle_testCase(node):
     tsts = node.xpathEval('incorrect')
     if tsts != []:
         if len(tsts) != 1:
-	    print "warning test line %d has more than one <incorrect> example" %(node.lineNo())
+	    print("warning test line %d has more than one <incorrect> example" %(node.lineNo()))
 	schema = handle_incorrect(tsts[0])
     else:
         tsts = node.xpathEval('correct')
 	if tsts != []:
 	    if len(tsts) != 1:
-		print "warning test line %d has more than one <correct> example"% (node.lineNo())
+		print("warning test line %d has more than one <correct> example"% (node.lineNo()))
 	    schema = handle_correct(tsts[0])
 	else:
-	    print "warning <testCase> line %d has no <correct> nor <incorrect> child" % (node.lineNo())
+	    print("warning <testCase> line %d has no <correct> nor <incorrect> child" % (node.lineNo()))
 
     nb_schemas_tests = nb_schemas_tests + 1;
     
@@ -329,14 +330,14 @@ def handle_testSuite(node, level = 0):
 	    for author in authors:
 	        msg = msg + author.content + " "
 	if quiet == 0:
-	    print msg
+	    print(msg)
     sections = node.xpathEval('section')
     if sections != [] and level <= 0:
         msg = ""
         for section in sections:
 	    msg = msg + section.content + " "
 	if quiet == 0:
-	    print "Tests for section %s" % (msg)
+	    print("Tests for section %s" % (msg))
     for test in node.xpathEval('testCase'):
         handle_testCase(test)
     for test in node.xpathEval('testSuite'):
@@ -347,17 +348,17 @@ def handle_testSuite(node, level = 0):
         msg = ""
         for section in sections:
 	    msg = msg + section.content + " "
-        print "Result of tests for section %s" % (msg)
+        print("Result of tests for section %s" % (msg))
         if nb_schemas_tests != old_schemas_tests:
-	    print "found %d test schemas: %d success %d failures" % (
+	    print("found %d test schemas: %d success %d failures" % (
 		  nb_schemas_tests - old_schemas_tests,
 		  nb_schemas_success - old_schemas_success,
-		  nb_schemas_failed - old_schemas_failed)
+		  nb_schemas_failed - old_schemas_failed))
 	if nb_instances_tests != old_instances_tests:
-	    print "found %d test instances: %d success %d failures" % (
+	    print("found %d test instances: %d success %d failures" % (
 		  nb_instances_tests - old_instances_tests,
 		  nb_instances_success - old_instances_success,
-		  nb_instances_failed - old_instances_failed)
+		  nb_instances_failed - old_instances_failed))
 #
 # Parse the conf file
 #
@@ -366,20 +367,20 @@ testsuite = libxml2.parseFile(CONF)
 libxml2.setEntityLoader(resolver)
 root = testsuite.getRootElement()
 if root.name != 'testSuite':
-    print "%s doesn't start with a testSuite element, aborting" % (CONF)
+    print("%s doesn't start with a testSuite element, aborting" % (CONF))
     sys.exit(1)
 if quiet == 0:
-    print "Running Relax NG testsuite"
+    print("Running Relax NG testsuite")
 handle_testSuite(root)
 
 if quiet == 0:
-    print "\nTOTAL:\n"
+    print("\nTOTAL:\n")
 if quiet == 0 or nb_schemas_failed != 0:
-    print "found %d test schemas: %d success %d failures" % (
-      nb_schemas_tests, nb_schemas_success, nb_schemas_failed)
+    print("found %d test schemas: %d success %d failures" % (
+      nb_schemas_tests, nb_schemas_success, nb_schemas_failed))
 if quiet == 0 or nb_instances_failed != 0:
-    print "found %d test instances: %d success %d failures" % (
-      nb_instances_tests, nb_instances_success, nb_instances_failed)
+    print("found %d test instances: %d success %d failures" % (
+      nb_instances_tests, nb_instances_success, nb_instances_failed))
 
 testsuite.freeDoc()
 
@@ -388,7 +389,7 @@ libxml2.relaxNGCleanupTypes()
 libxml2.cleanupParser()
 if libxml2.debugMemory(1) == 0:
     if quiet == 0:
-	print "OK"
+	print("OK")
 else:
-    print "Memory leak %d bytes" % (libxml2.debugMemory(1))
+    print("Memory leak %d bytes" % (libxml2.debugMemory(1)))
     libxml2.dumpMemory()

--- a/third_party/libxml/src/check-xinclude-test-suite.py
+++ b/third_party/libxml/src/check-xinclude-test-suite.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
+
 import sys
 import time
 import os
@@ -49,7 +50,7 @@ def testXInclude(filename, id):
     error_nr = 0
     error_msg = ''
 
-    print "testXInclude(%s, %s)" % (filename, id)
+    print("testXInclude(%s, %s)" % (filename, id))
     return 1
 
 def runTest(test, basedir):
@@ -65,20 +66,20 @@ def runTest(test, basedir):
     id = test.prop('id')
     type = test.prop('type')
     if uri == None:
-        print "Test without ID:", uri
+        print("Test without ID:", uri)
 	return -1
     if id == None:
-        print "Test without URI:", id
+        print("Test without URI:", id)
 	return -1
     if type == None:
-        print "Test without URI:", id
+        print("Test without URI:", id)
 	return -1
     if basedir != None:
 	URI = basedir + "/" + uri
     else:
         URI = uri
     if os.access(URI, os.R_OK) == 0:
-        print "Test %s missing: base %s uri %s" % (URI, basedir, uri)
+        print("Test %s missing: base %s uri %s" % (URI, basedir, uri))
 	return -1
 
     expected = None
@@ -94,7 +95,7 @@ def runTest(test, basedir):
 	    if basedir != None:
 		output = basedir + "/" + output
 	    if os.access(output, os.R_OK) == 0:
-		print "Result for %s missing: %s" % (id, output)
+		print("Result for %s missing: %s" % (id, output))
 		output = None
 	    else:
 		try:
@@ -102,7 +103,7 @@ def runTest(test, basedir):
 		    expected = f.read()
 		    outputfile = output
 		except:
-		    print "Result for %s unreadable: %s" % (id, output)
+		    print("Result for %s unreadable: %s" % (id, output))
 
     try:
         # print "testing %s" % (URI)
@@ -114,13 +115,13 @@ def runTest(test, basedir):
 	if res >= 0 and expected != None:
 	    result = doc.serialize()
 	    if result != expected:
-	        print "Result for %s differs" % (id)
+	        print("Result for %s differs" % (id))
 		open("xinclude.res", "w").write(result)
 		diff = os.popen("diff %s xinclude.res" % outputfile).read()
 
 	doc.freeDoc()
     else:
-        print "Failed to parse %s" % (URI)
+        print("Failed to parse %s" % (URI))
 	res = -1
 
     
@@ -131,24 +132,24 @@ def runTest(test, basedir):
 	    test_succeed = test_succeed + 1
 	elif res == 0:
 	    test_failed = test_failed + 1
-	    print "Test %s: no substitution done ???" % (id)
+	    print("Test %s: no substitution done ???" % (id))
 	elif res < 0:
 	    test_error = test_error + 1
-	    print "Test %s: failed valid XInclude processing" % (id)
+	    print("Test %s: failed valid XInclude processing" % (id))
     elif type == 'error':
 	if res > 0:
 	    test_error = test_error + 1
-	    print "Test %s: failed to detect invalid XInclude processing" % (id)
+	    print("Test %s: failed to detect invalid XInclude processing" % (id))
 	elif res == 0:
 	    test_failed = test_failed + 1
-	    print "Test %s: Invalid but no substitution done" % (id)
+	    print("Test %s: Invalid but no substitution done" % (id))
 	elif res < 0:
 	    test_succeed = test_succeed + 1
     elif type == 'optional':
 	if res > 0:
 	    test_succeed = test_succeed + 1
 	else:
-	    print "Test %s: failed optional test" % (id)
+	    print("Test %s: failed optional test" % (id))
 
     # Log the ontext
     if res != 1:
@@ -172,7 +173,7 @@ def runTest(test, basedir):
 def runTestCases(case):
     creator = case.prop('creator')
     if creator != None:
-	print "=>", creator
+	print("=>", creator)
     base = case.getBase(None)
     basedir = case.prop('basedir')
     if basedir != None:
@@ -183,21 +184,21 @@ def runTestCases(case):
 	    runTest(test, base)
 	if test.name == 'testcases':
 	    runTestCases(test)
-        test = test.next
+        test = test.__next__
         
 conf = libxml2.parseFile(CONF)
 if conf == None:
-    print "Unable to load %s" % CONF
+    print("Unable to load %s" % CONF)
     sys.exit(1)
 
 testsuite = conf.getRootElement()
 if testsuite.name != 'testsuite':
-    print "Expecting TESTSUITE root element: aborting"
+    print("Expecting TESTSUITE root element: aborting")
     sys.exit(1)
 
 profile = testsuite.prop('PROFILE')
 if profile != None:
-    print profile
+    print(profile)
 
 start = time.time()
 
@@ -209,13 +210,13 @@ while case != None:
 	old_test_failed = test_failed
 	old_test_error = test_error
         runTestCases(case)
-	print "   Ran %d tests: %d suceeded, %d failed and %d generated an error" % (
+	print("   Ran %d tests: %d suceeded, %d failed and %d generated an error" % (
 	       test_nr - old_test_nr, test_succeed - old_test_succeed,
-	       test_failed - old_test_failed, test_error - old_test_error)
-    case = case.next
+	       test_failed - old_test_failed, test_error - old_test_error))
+    case = case.__next__
 
 conf.freeDoc()
 log.close()
 
-print "Ran %d tests: %d suceeded, %d failed and %d generated an error in %.2f s." % (
-      test_nr, test_succeed, test_failed, test_error, time.time() - start)
+print("Ran %d tests: %d suceeded, %d failed and %d generated an error in %.2f s." % (
+      test_nr, test_succeed, test_failed, test_error, time.time() - start))

--- a/third_party/libxml/src/check-xml-test-suite.py
+++ b/third_party/libxml/src/check-xml-test-suite.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
+
 import sys
 import time
 import os
@@ -90,7 +91,7 @@ def testNotWf(filename, id):
     if doc != None:
 	doc.freeDoc()
     if ret == 0 or ctxt.wellFormed() != 0:
-        print "%s: error: Well Formedness error not detected" % (id)
+        print("%s: error: Well Formedness error not detected" % (id))
 	log.write("%s: error: Well Formedness error not detected\n" % (id))
 	return 0
     return 1
@@ -116,7 +117,7 @@ def testNotWfEnt(filename, id):
     if doc != None:
 	doc.freeDoc()
     if ret == 0 or ctxt.wellFormed() != 0:
-        print "%s: error: Well Formedness error not detected" % (id)
+        print("%s: error: Well Formedness error not detected" % (id))
 	log.write("%s: error: Well Formedness error not detected\n" % (id))
 	return 0
     return 1
@@ -143,7 +144,7 @@ def testNotWfEntDtd(filename, id):
     if doc != None:
 	doc.freeDoc()
     if ret == 0 or ctxt.wellFormed() != 0:
-        print "%s: error: Well Formedness error not detected" % (id)
+        print("%s: error: Well Formedness error not detected" % (id))
 	log.write("%s: error: Well Formedness error not detected\n" % (id))
 	return 0
     return 1
@@ -168,13 +169,13 @@ def testWfEntDtd(filename, id):
     except:
         doc = None
     if doc == None or ret != 0 or ctxt.wellFormed() == 0:
-        print "%s: error: wrongly failed to parse the document" % (id)
+        print("%s: error: wrongly failed to parse the document" % (id))
 	log.write("%s: error: wrongly failed to parse the document\n" % (id))
 	if doc != None:
 	    doc.freeDoc()
 	return 0
     if error_nr != 0:
-        print "%s: warning: WF document generated an error msg" % (id)
+        print("%s: warning: WF document generated an error msg" % (id))
 	log.write("%s: error: WF document generated an error msg\n" % (id))
 	doc.freeDoc()
 	return 2
@@ -203,11 +204,11 @@ def testError(filename, id):
     if doc != None:
 	doc.freeDoc()
     if ctxt.wellFormed() == 0:
-        print "%s: warning: failed to parse the document but accepted" % (id)
+        print("%s: warning: failed to parse the document but accepted" % (id))
 	log.write("%s: warning: failed to parse the document but accepte\n" % (id))
 	return 2
     if error_nr != 0:
-        print "%s: warning: WF document generated an error msg" % (id)
+        print("%s: warning: WF document generated an error msg" % (id))
 	log.write("%s: error: WF document generated an error msg\n" % (id))
 	return 2
     return 1
@@ -232,16 +233,16 @@ def testInvalid(filename, id):
         doc = None
     valid = ctxt.isValid()
     if doc == None:
-        print "%s: error: wrongly failed to parse the document" % (id)
+        print("%s: error: wrongly failed to parse the document" % (id))
 	log.write("%s: error: wrongly failed to parse the document\n" % (id))
 	return 0
     if valid == 1:
-        print "%s: error: Validity error not detected" % (id)
+        print("%s: error: Validity error not detected" % (id))
 	log.write("%s: error: Validity error not detected\n" % (id))
 	doc.freeDoc()
 	return 0
     if error_nr == 0:
-        print "%s: warning: Validity error not reported" % (id)
+        print("%s: warning: Validity error not reported" % (id))
 	log.write("%s: warning: Validity error not reported\n" % (id))
 	doc.freeDoc()
 	return 2
@@ -268,16 +269,16 @@ def testValid(filename, id):
         doc = None
     valid = ctxt.isValid()
     if doc == None:
-        print "%s: error: wrongly failed to parse the document" % (id)
+        print("%s: error: wrongly failed to parse the document" % (id))
 	log.write("%s: error: wrongly failed to parse the document\n" % (id))
 	return 0
     if valid != 1:
-        print "%s: error: Validity check failed" % (id)
+        print("%s: error: Validity check failed" % (id))
 	log.write("%s: error: Validity check failed\n" % (id))
 	doc.freeDoc()
 	return 0
     if error_nr != 0 or valid != 1:
-        print "%s: warning: valid document reported an error" % (id)
+        print("%s: warning: valid document reported an error" % (id))
 	log.write("%s: warning: valid document reported an error\n" % (id))
 	doc.freeDoc()
 	return 2
@@ -294,19 +295,19 @@ def runTest(test):
     uri = test.prop('URI')
     id = test.prop('ID')
     if uri == None:
-        print "Test without ID:", uri
+        print("Test without ID:", uri)
 	return -1
     if id == None:
-        print "Test without URI:", id
+        print("Test without URI:", id)
 	return -1
     base = test.getBase(None)
     URI = libxml2.buildURI(uri, base)
     if os.access(URI, os.R_OK) == 0:
-        print "Test %s missing: base %s uri %s" % (URI, base, uri)
+        print("Test %s missing: base %s uri %s" % (URI, base, uri))
 	return -1
     type = test.prop('TYPE')
     if type == None:
-        print "Test %s missing TYPE" % (id)
+        print("Test %s missing TYPE" % (id))
 	return -1
 
     extra = None
@@ -364,28 +365,28 @@ def runTestCases(case):
     profile = case.prop('PROFILE')
     if profile != None and \
        string.find(profile, "IBM XML Conformance Test Suite - Production") < 0:
-	print "=>", profile
+	print("=>", profile)
     test = case.children
     while test != None:
         if test.name == 'TEST':
 	    runTest(test)
 	if test.name == 'TESTCASES':
 	    runTestCases(test)
-        test = test.next
+        test = test.__next__
         
 conf = loadNoentDoc(CONF)
 if conf == None:
-    print "Unable to load %s" % CONF
+    print("Unable to load %s" % CONF)
     sys.exit(1)
 
 testsuite = conf.getRootElement()
 if testsuite.name != 'TESTSUITE':
-    print "Expecting TESTSUITE root element: aborting"
+    print("Expecting TESTSUITE root element: aborting")
     sys.exit(1)
 
 profile = testsuite.prop('PROFILE')
 if profile != None:
-    print profile
+    print(profile)
 
 start = time.time()
 
@@ -397,13 +398,13 @@ while case != None:
 	old_test_failed = test_failed
 	old_test_error = test_error
         runTestCases(case)
-	print "   Ran %d tests: %d suceeded, %d failed and %d generated an error" % (
+	print("   Ran %d tests: %d suceeded, %d failed and %d generated an error" % (
 	       test_nr - old_test_nr, test_succeed - old_test_succeed,
-	       test_failed - old_test_failed, test_error - old_test_error)
-    case = case.next
+	       test_failed - old_test_failed, test_error - old_test_error))
+    case = case.__next__
 
 conf.freeDoc()
 log.close()
 
-print "Ran %d tests: %d suceeded, %d failed and %d generated an error in %.2f s." % (
-      test_nr, test_succeed, test_failed, test_error, time.time() - start)
+print("Ran %d tests: %d suceeded, %d failed and %d generated an error in %.2f s." % (
+      test_nr, test_succeed, test_failed, test_error, time.time() - start))

--- a/third_party/libxml/src/check-xsddata-test-suite.py
+++ b/third_party/libxml/src/check-xsddata-test-suite.py
@@ -1,9 +1,10 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
+
 import sys
 import time
 import os
 import string
-import StringIO
+import io
 sys.path.insert(0, "python")
 import libxml2
 
@@ -44,8 +45,8 @@ resources = {}
 def resolver(URL, ID, ctxt):
     global resources
 
-    if resources.has_key(URL):
-        return(StringIO.StringIO(resources[URL]))
+    if URL in resources:
+        return(io.StringIO(resources[URL]))
     log.write("Resolver failure: asked %s\n" % (URL))
     log.write("resources: %s\n" % (resources))
     return None
@@ -65,7 +66,7 @@ def handle_valid(node, schema):
     while child != None:
         if child.type != 'text':
 	    instance = instance + child.serialize()
-	child = child.next
+	child = child.__next__
 
     mem = libxml2.debugMemory(1);
     try:
@@ -81,7 +82,7 @@ def handle_valid(node, schema):
 	return
 
     if debug:
-        print "instance line %d" % (node.lineNo())
+        print("instance line %d" % (node.lineNo()))
        
     try:
         ctxt = schema.relaxNGNewValidCtxt()
@@ -92,8 +93,8 @@ def handle_valid(node, schema):
 
     doc.freeDoc()
     if mem != libxml2.debugMemory(1):
-	print "validating instance %d line %d leaks" % (
-		  nb_instances_tests, node.lineNo())
+	print("validating instance %d line %d leaks" % (
+		  nb_instances_tests, node.lineNo()))
 
     if ret != 0:
         log.write("\nFailed to validate correct instance:\n-----\n")
@@ -118,7 +119,7 @@ def handle_invalid(node, schema):
     while child != None:
         if child.type != 'text':
 	    instance = instance + child.serialize()
-	child = child.next
+	child = child.__next__
 
 #    mem = libxml2.debugMemory(1);
 
@@ -134,7 +135,7 @@ def handle_invalid(node, schema):
 	return
 
     if debug:
-        print "instance line %d" % (node.lineNo())
+        print("instance line %d" % (node.lineNo()))
        
     try:
         ctxt = schema.relaxNGNewValidCtxt()
@@ -170,7 +171,7 @@ def handle_correct(node):
     while child != None:
         if child.type != 'text':
 	    schema = schema + child.serialize()
-	child = child.next
+	child = child.__next__
 
     try:
 	rngp = libxml2.relaxNGNewMemParserCtxt(schema, len(schema))
@@ -196,7 +197,7 @@ def handle_incorrect(node):
     while child != None:
         if child.type != 'text':
 	    schema = schema + child.serialize()
-	child = child.next
+	child = child.__next__
 
     try:
 	rngp = libxml2.relaxNGNewMemParserCtxt(schema, len(schema))
@@ -239,7 +240,7 @@ def handle_resource(node, dir):
     while child != None:
         if child.type != 'text':
 	    res = res + child.serialize()
-	child = child.next
+	child = child.__next__
     resources[name] = res
 
 #
@@ -280,7 +281,7 @@ def handle_testCase(node):
               nb_schemas_tests, node.lineNo(), sections))
     resources = {}
     if debug:
-        print "test %d line %d" % (nb_schemas_tests, node.lineNo())
+        print("test %d line %d" % (nb_schemas_tests, node.lineNo()))
 
     dirs = node.xpathEval('dir')
     for dir in dirs:
@@ -292,16 +293,16 @@ def handle_testCase(node):
     tsts = node.xpathEval('incorrect')
     if tsts != []:
         if len(tsts) != 1:
-	    print "warning test line %d has more than one <incorrect> example" %(node.lineNo())
+	    print("warning test line %d has more than one <incorrect> example" %(node.lineNo()))
 	schema = handle_incorrect(tsts[0])
     else:
         tsts = node.xpathEval('correct')
 	if tsts != []:
 	    if len(tsts) != 1:
-		print "warning test line %d has more than one <correct> example"% (node.lineNo())
+		print("warning test line %d has more than one <correct> example"% (node.lineNo()))
 	    schema = handle_correct(tsts[0])
 	else:
-	    print "warning <testCase> line %d has no <correct> nor <incorrect> child" % (node.lineNo())
+	    print("warning <testCase> line %d has no <correct> nor <incorrect> child" % (node.lineNo()))
 
     nb_schemas_tests = nb_schemas_tests + 1;
     
@@ -340,14 +341,14 @@ def handle_testSuite(node, level = 0):
 	    for author in authors:
 	        msg = msg + author.content + " "
 	if quiet == 0:
-	    print msg
+	    print(msg)
     sections = node.xpathEval('section')
     if verbose and sections != [] and level <= 0:
         msg = ""
         for section in sections:
 	    msg = msg + section.content + " "
 	if quiet == 0:
-	    print "Tests for section %s" % (msg)
+	    print("Tests for section %s" % (msg))
     for test in node.xpathEval('testCase'):
         handle_testCase(test)
     for test in node.xpathEval('testSuite'):
@@ -359,23 +360,23 @@ def handle_testSuite(node, level = 0):
 	    msg = ""
 	    for section in sections:
 		msg = msg + section.content + " "
-	    print "Result of tests for section %s" % (msg)
+	    print("Result of tests for section %s" % (msg))
 	elif docs != []:
 	    msg = ""
 	    for doc in docs:
 	        msg = msg + doc.content + " "
-	    print "Result of tests for %s" % (msg)
+	    print("Result of tests for %s" % (msg))
 
         if nb_schemas_tests != old_schemas_tests:
-	    print "found %d test schemas: %d success %d failures" % (
+	    print("found %d test schemas: %d success %d failures" % (
 		  nb_schemas_tests - old_schemas_tests,
 		  nb_schemas_success - old_schemas_success,
-		  nb_schemas_failed - old_schemas_failed)
+		  nb_schemas_failed - old_schemas_failed))
 	if nb_instances_tests != old_instances_tests:
-	    print "found %d test instances: %d success %d failures" % (
+	    print("found %d test instances: %d success %d failures" % (
 		  nb_instances_tests - old_instances_tests,
 		  nb_instances_success - old_instances_success,
-		  nb_instances_failed - old_instances_failed)
+		  nb_instances_failed - old_instances_failed))
 #
 # Parse the conf file
 #
@@ -394,18 +395,18 @@ libxml2.registerErrorHandler(callback, "")
 libxml2.setEntityLoader(resolver)
 root = testsuite.getRootElement()
 if root.name != 'testSuite':
-    print "%s doesn't start with a testSuite element, aborting" % (CONF)
+    print("%s doesn't start with a testSuite element, aborting" % (CONF))
     sys.exit(1)
 if quiet == 0:
-    print "Running Relax NG testsuite"
+    print("Running Relax NG testsuite")
 handle_testSuite(root)
 
 if quiet == 0 or nb_schemas_failed != 0:
-    print "\nTOTAL:\nfound %d test schemas: %d success %d failures" % (
-      nb_schemas_tests, nb_schemas_success, nb_schemas_failed)
+    print("\nTOTAL:\nfound %d test schemas: %d success %d failures" % (
+      nb_schemas_tests, nb_schemas_success, nb_schemas_failed))
 if quiet == 0 or nb_instances_failed != 0:
-    print "found %d test instances: %d success %d failures" % (
-      nb_instances_tests, nb_instances_success, nb_instances_failed)
+    print("found %d test instances: %d success %d failures" % (
+      nb_instances_tests, nb_instances_success, nb_instances_failed))
 
 testsuite.freeDoc()
 
@@ -414,7 +415,7 @@ libxml2.relaxNGCleanupTypes()
 libxml2.cleanupParser()
 if libxml2.debugMemory(1) == 0:
     if quiet == 0:
-	print "OK"
+	print("OK")
 else:
-    print "Memory leak %d bytes" % (libxml2.debugMemory(1))
+    print("Memory leak %d bytes" % (libxml2.debugMemory(1)))
     libxml2.dumpMemory()

--- a/third_party/libxml/src/genUnicode.py
+++ b/third_party/libxml/src/genUnicode.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -u
+#!/usr/bin/env python3 -u
 #
 # Original script modified in November 2003 to take advantage of
 # the character-validation range routines, and updated to the
@@ -43,7 +43,7 @@ BlockNames = {}
 try:
     blocks = open(blockfile, "r")
 except:
-    print "Missing %s, aborting ..." % blockfile
+    print("Missing %s, aborting ..." % blockfile)
     sys.exit(1)
 
 for line in blocks.readlines():
@@ -59,7 +59,7 @@ for line in blocks.readlines():
         name = string.strip(fields[1])
         name = string.replace(name, ' ', '')
     except:
-        print "Failed to process line: %s" % (line)
+        print("Failed to process line: %s" % (line))
         continue
     start = "0x" + start
     end = "0x" + end
@@ -68,19 +68,19 @@ for line in blocks.readlines():
     except:
         BlockNames[name] = [(start, end)]
 blocks.close()
-print "Parsed %d blocks descriptions" % (len(BlockNames.keys()))
+print("Parsed %d blocks descriptions" % (len(list(BlockNames.keys()))))
 
 for block in blockAliases:
     alias = string.split(block,':')
     alist = string.split(alias[1],',')
     for comp in alist:
-        if BlockNames.has_key(comp):
+        if comp in BlockNames:
             if alias[0] not in BlockNames:
                 BlockNames[alias[0]] = []
             for r in BlockNames[comp]:
                 BlockNames[alias[0]].append(r)
         else:
-            print "Alias %s: %s not in Blocks" % (alias[0], comp)
+            print("Alias %s: %s not in Blocks" % (alias[0], comp))
             continue
 
 #
@@ -96,7 +96,7 @@ for block in blockAliases:
 try:
     data = open(catfile, "r")
 except:
-    print "Missing %s, aborting ..." % catfile
+    print("Missing %s, aborting ..." % catfile)
     sys.exit(1)
 
 nbchar = 0;
@@ -122,7 +122,7 @@ for line in data.readlines():
             point = point[1:]
         name = fields[2]
     except:
-        print "Failed to process line: %s" % (line)
+        print("Failed to process line: %s" % (line))
         continue
     
     nbchar = nbchar + 1
@@ -133,7 +133,7 @@ for line in data.readlines():
         try:
             Categories[name] = [value]
         except:
-            print "Failed to process line: %s" % (line)
+            print("Failed to process line: %s" % (line))
     # update "general category" name
     try:
         Categories[name[0]].append(value)
@@ -141,16 +141,16 @@ for line in data.readlines():
         try:
             Categories[name[0]] = [value]
         except:
-            print "Failed to process line: %s" % (line)
+            print("Failed to process line: %s" % (line))
 
 blocks.close()
-print "Parsed %d char generating %d categories" % (nbchar, len(Categories.keys()))
+print("Parsed %d char generating %d categories" % (nbchar, len(list(Categories.keys()))))
 
 #
 # The data is now all read.  Time to process it into a more useful form.
 #
 # reduce the number list into ranges
-for cat in Categories.keys():
+for cat in list(Categories.keys()):
     list = Categories[cat]
     start = -1
     prev = -1
@@ -184,10 +184,10 @@ for cat in Categories.keys():
 # Assure all data is in alphabetic order, since we will be doing binary
 # searches on the tables.
 #
-bkeys = BlockNames.keys()
+bkeys = list(BlockNames.keys())
 bkeys.sort()
 
-ckeys = Categories.keys()
+ckeys = list(Categories.keys())
 ckeys.sort()
 
 #
@@ -196,13 +196,13 @@ ckeys.sort()
 try:
     header = open("include/libxml/xmlunicode.h", "w")
 except:
-    print "Failed to open include/libxml/xmlunicode.h"
+    print("Failed to open include/libxml/xmlunicode.h")
     sys.exit(1)
 
 try:
     output = open("xmlunicode.c", "w")
 except:
-    print "Failed to open xmlunicode.c"
+    print("Failed to open xmlunicode.c")
     sys.exit(1)
 
 date = time.asctime(time.localtime(time.time()))

--- a/third_party/libxml/src/gentest.py
+++ b/third_party/libxml/src/gentest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -u
+#!/usr/bin/env python3 -u
 #
 # generate a tester program for the API
 #
@@ -8,7 +8,7 @@ import string
 try:
     import libxml2
 except:
-    print "libxml2 python bindings not available, skipping testapi.c generation"
+    print("libxml2 python bindings not available, skipping testapi.c generation")
     sys.exit(0)
 
 if len(sys.argv) > 1:
@@ -415,7 +415,7 @@ def is_known_param_type(name, rtype):
 	    crtype = rtype
 
         define = 0
-	if modules_defines.has_key(module):
+	if module in modules_defines:
 	    test.write("#ifdef %s\n" % (modules_defines[module]))
 	    define = 1
         test.write("""
@@ -488,12 +488,12 @@ while line != "":
 input.close()
 
 if line == "":
-    print "Could not find the CUT marker in testapi.c skipping generation"
+    print("Could not find the CUT marker in testapi.c skipping generation")
     test.close()
     sys.exit(0)
 
-print("Scanned testapi.c: found %d parameters types and %d return types\n" % (
-      len(known_param_types), len(known_return_types)))
+print(("Scanned testapi.c: found %d parameters types and %d return types\n" % (
+      len(known_param_types), len(known_return_types))))
 test.write("/* CUT HERE: everything below that line is generated */\n")
 
 
@@ -502,7 +502,7 @@ test.write("/* CUT HERE: everything below that line is generated */\n")
 #
 doc = libxml2.readFile(srcPref + 'doc/libxml2-api.xml', None, 0)
 if doc == None:
-    print "Failed to load doc/libxml2-api.xml"
+    print("Failed to load doc/libxml2-api.xml")
     sys.exit(1)
 ctxt = doc.xpathNewContext()
 
@@ -517,7 +517,7 @@ for arg in args:
     func = arg.xpathEval('string(../@name)')
     if (mod not in skipped_modules) and (func not in skipped_functions):
 	type = arg.xpathEval('string(@type)')
-	if not argtypes.has_key(type):
+	if type not in argtypes:
 	    argtypes[type] = func
 
 # similarly for return types
@@ -528,7 +528,7 @@ for ret in rets:
     func = ret.xpathEval('string(../@name)')
     if (mod not in skipped_modules) and (func not in skipped_functions):
         type = ret.xpathEval('string(@type)')
-	if not rettypes.has_key(type):
+	if type not in rettypes:
 	    rettypes[type] = func
 
 #
@@ -546,7 +546,7 @@ for enum in enums:
         continue;
     define = 0
 
-    if argtypes.has_key(name) and is_known_param_type(name, name) == 0:
+    if name in argtypes and is_known_param_type(name, name) == 0:
 	values = ctxt.xpathEval("/api/symbols/enum[@type='%s']" % name)
 	i = 0
 	vals = []
@@ -559,9 +559,9 @@ for enum in enums:
 		break;
 	    vals.append(vname)
 	if vals == []:
-	    print "Didn't find any value for enum %s" % (name)
+	    print("Didn't find any value for enum %s" % (name))
 	    continue
-	if modules_defines.has_key(module):
+	if module in modules_defines:
 	    test.write("#ifdef %s\n" % (modules_defines[module]))
 	    define = 1
 	test.write("#define gen_nb_%s %d\n" % (name, len(vals)))
@@ -581,7 +581,7 @@ static void des_%s(int no ATTRIBUTE_UNUSED, %s val ATTRIBUTE_UNUSED, int nr ATTR
 	known_param_types.append(name)
 
     if (is_known_return_type(name) == 0) and (name in rettypes):
-	if define == 0 and modules_defines.has_key(module):
+	if define == 0 and module in modules_defines:
 	    test.write("#ifdef %s\n" % (modules_defines[module]))
 	    define = 1
         test.write("""static void desret_%s(%s val ATTRIBUTE_UNUSED) {
@@ -613,7 +613,7 @@ for file in headers:
     #
     desc = file.xpathEval('string(description)')
     if string.find(desc, 'DEPRECATED') != -1:
-        print "Skipping deprecated interface %s" % name
+        print("Skipping deprecated interface %s" % name)
 	continue;
 
     test.write("#include <libxml/%s.h>\n" % name)
@@ -742,7 +742,7 @@ test_%s(void) {
         pass
 
     define = 0
-    if function_defines.has_key(name):
+    if name in function_defines:
         test.write("#ifdef %s\n" % (function_defines[name]))
 	define = 1
     
@@ -783,7 +783,7 @@ test_%s(void) {
 	i = i + 1;
 
     # do the call, and clanup the result
-    if extra_pre_call.has_key(name):
+    if name in extra_pre_call:
 	test.write("        %s\n"% (extra_pre_call[name]))
     if t_ret != None:
 	test.write("\n        ret_val = %s(" % (name))
@@ -798,7 +798,7 @@ test_%s(void) {
 	        test.write("(%s)" % rtype)
 	    test.write("%s" % nam);
 	test.write(");\n")
-	if extra_post_call.has_key(name):
+	if name in extra_post_call:
 	    test.write("        %s\n"% (extra_post_call[name]))
 	test.write("        desret_%s(ret_val);\n" % t_ret[0])
     else:
@@ -814,7 +814,7 @@ test_%s(void) {
 	        test.write("(%s)" % rtype)
 	    test.write("%s" % nam)
 	test.write(");\n")
-	if extra_post_call.has_key(name):
+	if name in extra_post_call:
 	    test.write("        %s\n"% (extra_post_call[name]))
 
     test.write("        call_tests++;\n");
@@ -876,7 +876,7 @@ for module in modules:
     try:
 	functions = ctxt.xpathEval("/api/symbols/function[@file='%s']" % (module))
     except:
-        print "Failed to gather functions from module %s" % (module)
+        print("Failed to gather functions from module %s" % (module))
 	continue;
 
     # iterate over all functions in the module generating the test
@@ -922,12 +922,12 @@ test.write("""    return(0);
 }
 """);
 
-print "Generated test for %d modules and %d functions" %(len(modules), nb_tests)
+print("Generated test for %d modules and %d functions" %(len(modules), nb_tests))
 
 compare_and_save()
 
 missing_list = []
-for missing in missing_types.keys():
+for missing in list(missing_types.keys()):
     if missing == 'va_list' or missing == '...':
         continue;
 
@@ -938,7 +938,7 @@ def compare_missing(a, b):
     return b[0] - a[0]
 
 missing_list.sort(compare_missing)
-print "Missing support for %d functions and %d types see missing.lst" % (missing_functions_nr, len(missing_list))
+print("Missing support for %d functions and %d types see missing.lst" % (missing_functions_nr, len(missing_list)))
 lst = open("missing.lst", "w")
 lst.write("Missing support for %d types" % (len(missing_list)))
 lst.write("\n")
@@ -955,7 +955,7 @@ for miss in missing_list:
 lst.write("\n")
 lst.write("\n")
 lst.write("Missing support per module");
-for module in missing_functions.keys():
+for module in list(missing_functions.keys()):
     lst.write("module %s:\n   %s\n" % (module, missing_functions[module]))
 
 lst.close()

--- a/third_party/libxml/src/regressions.py
+++ b/third_party/libxml/src/regressions.py
@@ -1,5 +1,5 @@
-#!/usr/bin/python -u
-import glob, os, string, sys, thread, time
+#!/usr/bin/env python3 -u
+import glob, os, string, sys, _thread, time
 # import difflib
 import libxml2
 
@@ -74,19 +74,19 @@ def compFiles(res, expected, base1, base2):
     rl = len(res)
     el = len(exp)
     if el != rl:
-        print 'Length of expected is %d, result is %d' % (el, rl)
+        print('Length of expected is %d, result is %d' % (el, rl))
 	ret = -1
     for i in range(min(el, rl)):
         if string.strip(res[i]) != string.strip(exp[i]):
-            print '+:%s-:%s' % (res[i], exp[i])
+            print('+:%s-:%s' % (res[i], exp[i]))
             ret = -1
     if el > rl:
         for i in range(rl, el):
-            print '-:%s' % exp[i]
+            print('-:%s' % exp[i])
             ret = -1
     elif rl > el:
         for i in range (el, rl):
-            print '+:%s' % res[i]
+            print('+:%s' % res[i])
             ret = -1
     return ret
 
@@ -127,7 +127,7 @@ def runOneTest(testDescription, filename, inbase, errbase):
             fname = errbase + filename + ext
             expout = open(fname, 'rt')
         except:
-            print "Can't open result file %s - bypassing test" % fname
+            print("Can't open result file %s - bypassing test" % fname)
             return
 
     noErrors = 0
@@ -169,29 +169,29 @@ def runOneTest(testDescription, filename, inbase, errbase):
     th2Flag = []
     outfile = []	# lists to contain the pipe data
     errfile = []
-    th1 = thread.start_new_thread(readPfile, (pout, outfile, th1Flag))
-    th2 = thread.start_new_thread(readPfile, (perr, errfile, th2Flag))
+    th1 = _thread.start_new_thread(readPfile, (pout, outfile, th1Flag))
+    th2 = _thread.start_new_thread(readPfile, (perr, errfile, th2Flag))
     while (len(th1Flag)==0) or (len(th2Flag)==0):
         time.sleep(0.001)
     if not noResult:
         ret = compFiles(outfile, expout, inbase, 'test/')
         if ret != 0:
-            print 'trouble with %s' % cmd
+            print('trouble with %s' % cmd)
     else:
         if len(outfile) != 0:
             for l in outfile:
-                print l
-            print 'trouble with %s' % cmd
+                print(l)
+            print('trouble with %s' % cmd)
     if experr != None:
         ret = compFiles(errfile, experr, inbase, 'test/')
         if ret != 0:
-            print 'trouble with %s' % cmd
+            print('trouble with %s' % cmd)
     else:
         if not noErrors:
             if len(errfile) != 0:
                 for l in errfile:
-                    print l
-                print 'trouble with %s' % cmd
+                    print(l)
+                print('trouble with %s' % cmd)
 
     if 'stdin' not in testDescription:
         pin.close()
@@ -203,9 +203,9 @@ def runTest(description):
     testDescription = defaultParams.copy()		# set defaults
     testDescription.update(description)			# override with current ent
     if 'testname' in testDescription:
-        print "## %s" % testDescription['testname']
+        print("## %s" % testDescription['testname'])
     if not 'file' in testDescription:
-        print "No file specified - can't run this test!"
+        print("No file specified - can't run this test!")
         return
     # Set up the source and results directory paths from the decoded params
     dir = ''
@@ -222,7 +222,7 @@ def runTest(description):
 
     testFiles = glob.glob(os.path.abspath(dir + testDescription['file']))
     if testFiles == []:
-        print "No files result from '%s'" % testDescription['file']
+        print("No files result from '%s'" % testDescription['file'])
         return
 
     # Some test programs just don't work (yet).  For now we exclude them.
@@ -271,9 +271,9 @@ class testDefaults:
                 self.curText += reader.Value()
 
         elif reader.NodeType() == 15:	# end of element
-            print "Defaults have been set to:"
-            for k in defaultParams.keys():
-                print "   %s : '%s'" % (k, defaultParams[k])
+            print("Defaults have been set to:")
+            for k in list(defaultParams.keys()):
+                print("   %s : '%s'" % (k, defaultParams[k]))
             curClass = rootClass()
         return curClass
 
@@ -316,8 +316,8 @@ class rootClass:
         if reader.Depth() == 0:
             return curClass
         if reader.Depth() != 1:
-            print "Unexpected junk: Level %d, type %d, name %s" % (
-                  reader.Depth(), reader.NodeType(), reader.Name())
+            print("Unexpected junk: Level %d, type %d, name %s" % (
+                  reader.Depth(), reader.NodeType(), reader.Name()))
             return curClass
         if reader.Name() == 'test':
             curClass = testClass()
@@ -330,7 +330,7 @@ def streamFile(filename):
     try:
         reader = libxml2.newTextReaderFilename(filename)
     except:
-        print "unable to open %s" % (filename)
+        print("unable to open %s" % (filename))
         return
 
     curClass = rootClass()
@@ -340,11 +340,11 @@ def streamFile(filename):
         ret = reader.Read()
 
     if ret != 0:
-        print "%s : failed to parse" % (filename)
+        print("%s : failed to parse" % (filename))
 
 # OK, we're finished with all the routines.  Now for the main program:-
 if len(sys.argv) != 2:
-    print "Usage: maketest {filename}"
+    print("Usage: maketest {filename}")
     sys.exit(-1)
 
 streamFile(sys.argv[1])

--- a/tools/dart/create_updated_flutter_deps.py
+++ b/tools/dart/create_updated_flutter_deps.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+#
 # Copyright 2017 The Dart project authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -104,7 +105,7 @@ def Main(argv):
         i = i + 1
       for (k, v) in sorted(old_deps.items()):
         if (k.startswith('src/third_party/dart/')):
-          for (dart_k, dart_v) in (new_deps.items()):
+          for (dart_k, dart_v) in (list(new_deps.items())):
             dart_k_suffix = dart_k[len('sdk/') if dart_k.startswith('sdk/') else 0:]
             if (k.endswith(dart_k_suffix)):
               if (isinstance(dart_v, str)):

--- a/tools/dart/dart_roll_utils.py
+++ b/tools/dart/dart_roll_utils.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+#
 # Copyright 2019 The Dart project authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/tools/find_depot_tools.py
+++ b/tools/find_depot_tools.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # Copyright (c) 2011 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -36,7 +38,7 @@ def add_depot_tools_to_path():
       return i
     previous_dir = root_dir
     root_dir = os.path.dirname(root_dir)
-  print >> sys.stderr, 'Failed to find depot_tools'
+  print('Failed to find depot_tools', file=sys.stderr)
   return None
 
 add_depot_tools_to_path()


### PR DESCRIPTION
This migrates all checked in Python scripts to run under Python 3.x.
Python 2.7 reached end-of-life in January of 2020 and has been removed
from may OS distributions at this point.

This will be paired with a similar migration of flutter/engine python scripts
in the roll patch.

Issue: https://github.com/flutter/flutter/issues/83043