### PR TITLE
Partially revert python3 migration in vs_toolchain

### DIFF
--- a/build/vs_toolchain.py
+++ b/build/vs_toolchain.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python3
-#
+#!/usr/bin/env python
 # Copyright 2014 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -12,6 +11,8 @@
 # To update to a new MSVC toolchain, copy the updated script from the Chromium
 # tree, and edit to make it work in the Dart tree by updating paths in the original script.
 
+from __future__ import print_function
+
 import collections
 import glob
 import json
@@ -23,6 +24,7 @@ import shutil
 import stat
 import subprocess
 import sys
+
 
 from gn_helpers import ToGNString
 
@@ -122,12 +124,12 @@ def _RegistryGetValueUsingWinReg(key, value):
     contents of the registry key's value, or None on failure.  Throws
     ImportError if _winreg is unavailable.
   """
-  import winreg
+  import _winreg
   try:
     root, subkey = key.split('\\', 1)
     assert root == 'HKLM'  # Only need HKLM for now.
-    with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, subkey) as hkey:
-      return winreg.QueryValueEx(hkey, value)[0]
+    with _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE, subkey) as hkey:
+      return _winreg.QueryValueEx(hkey, value)[0]
   except WindowsError:
     return None
 


### PR DESCRIPTION
The migration uncovered some python3 incompatibility in depot_tools:
```
Traceback (most recent call last):
  File "C:\b\s\w\ir\kitchen-checkout\depot_tools\win_toolchain\get_toolchain_if_necessary.py", line 608, in <module>
    sys.exit(main())
  File "C:\b\s\w\ir\kitchen-checkout\depot_tools\win_toolchain\get_toolchain_if_necessary.py", line 579, in main
    data_json = json.dumps(data)
  File "C:\b\s\w\ir\cipd_bin_packages\cpython3\bin\lib\json\__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "C:\b\s\w\ir\cipd_bin_packages\cpython3\bin\lib\json\encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "C:\b\s\w\ir\cipd_bin_packages\cpython3\bin\lib\json\encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "C:\b\s\w\ir\cipd_bin_packages\cpython3\bin\lib\json\encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type bytes is not JSON serializable
Traceback (most recent call last):
  File "src/build/vs_toolchain.py", line 557, in <module>
    sys.exit(main())
  File "src/build/vs_toolchain.py", line 553, in main
    return commands[sys.argv[1]](*sys.argv[2:])
  File "src/build/vs_toolchain.py", line 501, in Update
    subprocess.check_call(get_toolchain_args)
  File "C:\b\s\w\ir\cipd_bin_packages\cpython3\bin\lib\subprocess.py", line 364, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['C:\\b\\s\\w\\ir\\cipd_bin_packages\\cpython3\\bin\\python3.exe', 'C:\\b\\s\\w\\ir\\kitchen-checkout\\depot_tools\\win_toolchain\\get_toolchain_if_necessary.py', '--output-json', 'C:\\b\\s\\w\\ir\\cache\\builder\\src\\build\\win_toolchain.json', '418b3076791776573a815eb298c8aa590307af63']' returned non-zero exit status 1.
Error: Command 'python3 src/build/vs_toolchain.py update' returned non-zero exit status 1 in C:\b\s\w\ir\cache\builder
Hook 'python3 src/build/vs_toolchain.py update' took 67.10 secs
```