### PR TITLE
Ignore deprecated_syntax token in FIDL files

### DIFF
--- a/build/fuchsia/fidl_gen_cpp.py
+++ b/build/fuchsia/fidl_gen_cpp.py
@@ -53,6 +53,8 @@ def main():
 
   fidlc_command = [
     args.fidlc_bin,
+    '--experimental',
+    'old_syntax_only',
     '--tables',
     args.output_c_tables,
     '--json',


### PR DESCRIPTION
This is the first step of the FIDL syntax migration, in preparation
for adding `deprecated_syntax;` to the top of all old syntax FIDL
files.