### PR TITLE
Add build rules for family of dependencies that work with SPIRV.

### DIFF
--- a/build/secondary/third_party/glslang_flutter/BUILD.gn
+++ b/build/secondary/third_party/glslang_flutter/BUILD.gn
@@ -1,0 +1,138 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+source_root = "//third_party/glslang"
+
+config("glslang_flutter_config") {
+  include_dirs = [
+    source_root,
+    "//build/secondary/third_party/glslang_flutter",
+  ]
+}
+
+source_set("glslang_flutter") {
+  defines = [
+    "ENABLE_OPT=1",
+    "ENABLE_HLSL=1",
+  ]
+
+  public_configs = [ ":glslang_flutter_config" ]
+
+  configs += [ "//third_party/spirv_tools_flutter:spvtools_public_config" ]
+
+  sources = [
+    "$source_root/OGLCompilersDLL/InitializeDll.cpp",
+    "$source_root/OGLCompilersDLL/InitializeDll.h",
+    "$source_root/SPIRV/GLSL.ext.AMD.h",
+    "$source_root/SPIRV/GLSL.ext.EXT.h",
+    "$source_root/SPIRV/GLSL.ext.KHR.h",
+    "$source_root/SPIRV/GLSL.ext.NV.h",
+    "$source_root/SPIRV/GLSL.std.450.h",
+    "$source_root/SPIRV/GlslangToSpv.cpp",
+    "$source_root/SPIRV/GlslangToSpv.h",
+    "$source_root/SPIRV/InReadableOrder.cpp",
+    "$source_root/SPIRV/Logger.cpp",
+    "$source_root/SPIRV/Logger.h",
+    "$source_root/SPIRV/NonSemanticDebugPrintf.h",
+    "$source_root/SPIRV/SPVRemapper.cpp",
+    "$source_root/SPIRV/SPVRemapper.h",
+    "$source_root/SPIRV/SpvBuilder.cpp",
+    "$source_root/SPIRV/SpvBuilder.h",
+    "$source_root/SPIRV/SpvPostProcess.cpp",
+    "$source_root/SPIRV/SpvTools.cpp",
+    "$source_root/SPIRV/SpvTools.h",
+    "$source_root/SPIRV/bitutils.h",
+    "$source_root/SPIRV/disassemble.cpp",
+    "$source_root/SPIRV/disassemble.h",
+    "$source_root/SPIRV/doc.cpp",
+    "$source_root/SPIRV/doc.h",
+    "$source_root/SPIRV/hex_float.h",
+    "$source_root/SPIRV/spirv.hpp",
+    "$source_root/SPIRV/spvIR.h",
+    "$source_root/glslang/GenericCodeGen/CodeGen.cpp",
+    "$source_root/glslang/GenericCodeGen/Link.cpp",
+    "$source_root/glslang/HLSL/hlslAttributes.cpp",
+    "$source_root/glslang/HLSL/hlslAttributes.h",
+    "$source_root/glslang/HLSL/hlslGrammar.cpp",
+    "$source_root/glslang/HLSL/hlslGrammar.h",
+    "$source_root/glslang/HLSL/hlslOpMap.cpp",
+    "$source_root/glslang/HLSL/hlslOpMap.h",
+    "$source_root/glslang/HLSL/hlslParseHelper.cpp",
+    "$source_root/glslang/HLSL/hlslParseHelper.h",
+    "$source_root/glslang/HLSL/hlslParseables.cpp",
+    "$source_root/glslang/HLSL/hlslParseables.h",
+    "$source_root/glslang/HLSL/hlslScanContext.cpp",
+    "$source_root/glslang/HLSL/hlslScanContext.h",
+    "$source_root/glslang/HLSL/hlslTokenStream.cpp",
+    "$source_root/glslang/HLSL/hlslTokenStream.h",
+    "$source_root/glslang/HLSL/hlslTokens.h",
+    "$source_root/glslang/HLSL/pch.h",
+    "$source_root/glslang/Include/BaseTypes.h",
+    "$source_root/glslang/Include/Common.h",
+    "$source_root/glslang/Include/ConstantUnion.h",
+    "$source_root/glslang/Include/InfoSink.h",
+    "$source_root/glslang/Include/InitializeGlobals.h",
+    "$source_root/glslang/Include/PoolAlloc.h",
+    "$source_root/glslang/Include/ResourceLimits.h",
+    "$source_root/glslang/Include/ShHandle.h",
+    "$source_root/glslang/Include/Types.h",
+    "$source_root/glslang/Include/arrays.h",
+    "$source_root/glslang/Include/intermediate.h",
+    "$source_root/glslang/MachineIndependent/Constant.cpp",
+    "$source_root/glslang/MachineIndependent/InfoSink.cpp",
+    "$source_root/glslang/MachineIndependent/Initialize.cpp",
+    "$source_root/glslang/MachineIndependent/Initialize.h",
+    "$source_root/glslang/MachineIndependent/IntermTraverse.cpp",
+    "$source_root/glslang/MachineIndependent/Intermediate.cpp",
+    "$source_root/glslang/MachineIndependent/LiveTraverser.h",
+    "$source_root/glslang/MachineIndependent/ParseContextBase.cpp",
+    "$source_root/glslang/MachineIndependent/ParseHelper.cpp",
+    "$source_root/glslang/MachineIndependent/ParseHelper.h",
+    "$source_root/glslang/MachineIndependent/PoolAlloc.cpp",
+    "$source_root/glslang/MachineIndependent/RemoveTree.cpp",
+    "$source_root/glslang/MachineIndependent/RemoveTree.h",
+    "$source_root/glslang/MachineIndependent/Scan.cpp",
+    "$source_root/glslang/MachineIndependent/Scan.h",
+    "$source_root/glslang/MachineIndependent/ScanContext.h",
+    "$source_root/glslang/MachineIndependent/ShaderLang.cpp",
+    "$source_root/glslang/MachineIndependent/SymbolTable.cpp",
+    "$source_root/glslang/MachineIndependent/SymbolTable.h",
+    "$source_root/glslang/MachineIndependent/Versions.cpp",
+    "$source_root/glslang/MachineIndependent/Versions.h",
+    "$source_root/glslang/MachineIndependent/attribute.cpp",
+    "$source_root/glslang/MachineIndependent/attribute.h",
+    "$source_root/glslang/MachineIndependent/gl_types.h",
+    "$source_root/glslang/MachineIndependent/glslang_tab.cpp",
+    "$source_root/glslang/MachineIndependent/glslang_tab.cpp.h",
+    "$source_root/glslang/MachineIndependent/intermOut.cpp",
+    "$source_root/glslang/MachineIndependent/iomapper.cpp",
+    "$source_root/glslang/MachineIndependent/iomapper.h",
+    "$source_root/glslang/MachineIndependent/limits.cpp",
+    "$source_root/glslang/MachineIndependent/linkValidate.cpp",
+    "$source_root/glslang/MachineIndependent/localintermediate.h",
+    "$source_root/glslang/MachineIndependent/parseConst.cpp",
+    "$source_root/glslang/MachineIndependent/parseVersions.h",
+    "$source_root/glslang/MachineIndependent/preprocessor/Pp.cpp",
+    "$source_root/glslang/MachineIndependent/preprocessor/PpAtom.cpp",
+    "$source_root/glslang/MachineIndependent/preprocessor/PpContext.cpp",
+    "$source_root/glslang/MachineIndependent/preprocessor/PpContext.h",
+    "$source_root/glslang/MachineIndependent/preprocessor/PpScanner.cpp",
+    "$source_root/glslang/MachineIndependent/preprocessor/PpTokens.cpp",
+    "$source_root/glslang/MachineIndependent/preprocessor/PpTokens.h",
+    "$source_root/glslang/MachineIndependent/propagateNoContraction.cpp",
+    "$source_root/glslang/MachineIndependent/propagateNoContraction.h",
+    "$source_root/glslang/MachineIndependent/reflection.cpp",
+    "$source_root/glslang/MachineIndependent/reflection.h",
+    "$source_root/glslang/OSDependent/osinclude.h",
+    "$source_root/glslang/Public/ShaderLang.h",
+  ]
+
+  if (is_win) {
+    sources += [ "$source_root/glslang/OSDependent/Windows/ossource.cpp" ]
+  } else {
+    sources += [ "$source_root/glslang/OSDependent/Unix/ossource.cpp" ]
+  }
+
+  deps = [ "//third_party/spirv_tools_flutter:SPIRV-Tools" ]
+}

--- a/build/secondary/third_party/glslang_flutter/glslang/build_info.h
+++ b/build/secondary/third_party/glslang_flutter/glslang/build_info.h
@@ -1,0 +1,71 @@
+// Copyright (C) 2020 The Khronos Group Inc.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//    Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+//    Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+//    Neither the name of The Khronos Group Inc. nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef GLSLANG_BUILD_INFO
+#define GLSLANG_BUILD_INFO
+
+// 11.4.0
+#define GLSLANG_VERSION_MAJOR 11
+#define GLSLANG_VERSION_MINOR 4
+#define GLSLANG_VERSION_PATCH 0
+#define GLSLANG_VERSION_FLAVOR "flutter"
+
+#define GLSLANG_VERSION_GREATER_THAN(major, minor, patch) \
+  (((major) > GLSLANG_VERSION_MAJOR) ||                   \
+   ((major) == GLSLANG_VERSION_MAJOR &&                   \
+    (((minor) > GLSLANG_VERSION_MINOR) ||                 \
+     ((minor) == GLSLANG_VERSION_MINOR &&                 \
+      ((patch) > GLSLANG_VERSION_PATCH)))))
+
+#define GLSLANG_VERSION_GREATER_OR_EQUAL_TO(major, minor, patch) \
+  (((major) > GLSLANG_VERSION_MAJOR) ||                          \
+   ((major) == GLSLANG_VERSION_MAJOR &&                          \
+    (((minor) > GLSLANG_VERSION_MINOR) ||                        \
+     ((minor) == GLSLANG_VERSION_MINOR &&                        \
+      ((patch) >= GLSLANG_VERSION_PATCH)))))
+
+#define GLSLANG_VERSION_LESS_THAN(major, minor, patch) \
+  (((major) < GLSLANG_VERSION_MAJOR) ||                \
+   ((major) == GLSLANG_VERSION_MAJOR &&                \
+    (((minor) < GLSLANG_VERSION_MINOR) ||              \
+     ((minor) == GLSLANG_VERSION_MINOR &&              \
+      ((patch) < GLSLANG_VERSION_PATCH)))))
+
+#define GLSLANG_VERSION_LESS_OR_EQUAL_TO(major, minor, patch) \
+  (((major) < GLSLANG_VERSION_MAJOR) ||                       \
+   ((major) == GLSLANG_VERSION_MAJOR &&                       \
+    (((minor) < GLSLANG_VERSION_MINOR) ||                     \
+     ((minor) == GLSLANG_VERSION_MINOR &&                     \
+      ((patch) <= GLSLANG_VERSION_PATCH)))))
+
+#endif  // GLSLANG_BUILD_INFO

--- a/build/secondary/third_party/shaderc_flutter/BUILD.gn
+++ b/build/secondary/third_party/shaderc_flutter/BUILD.gn
@@ -1,0 +1,74 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+shaderc_base = "//third_party/shaderc"
+
+config("shaderc_util_config") {
+  include_dirs = [ "$shaderc_base/libshaderc_util/include/" ]
+}
+
+source_set("shaderc_util_flutter") {
+  public_configs = [ ":shaderc_util_config" ]
+
+  configs += [ "//third_party/spirv_tools_flutter:spvtools_public_config" ]
+
+  public_deps = [
+    "//third_party/glslang_flutter",
+    "//third_party/spirv_tools_flutter:spvtools",
+  ]
+
+  defines = [ "ENABLE_HLSL=1" ]
+
+  sources = [
+    "$shaderc_base/libshaderc_util/include/libshaderc_util/counting_includer.h",
+    "$shaderc_base/libshaderc_util/include/libshaderc_util/exceptions.h",
+    "$shaderc_base/libshaderc_util/include/libshaderc_util/file_finder.h",
+    "$shaderc_base/libshaderc_util/include/libshaderc_util/format.h",
+    "$shaderc_base/libshaderc_util/include/libshaderc_util/io_shaderc.h",
+    "$shaderc_base/libshaderc_util/include/libshaderc_util/message.h",
+    "$shaderc_base/libshaderc_util/include/libshaderc_util/mutex.h",
+    "$shaderc_base/libshaderc_util/include/libshaderc_util/resources.h",
+    "$shaderc_base/libshaderc_util/include/libshaderc_util/spirv_tools_wrapper.h",
+    "$shaderc_base/libshaderc_util/include/libshaderc_util/string_piece.h",
+    "$shaderc_base/libshaderc_util/include/libshaderc_util/universal_unistd.h",
+    "$shaderc_base/libshaderc_util/include/libshaderc_util/version_profile.h",
+    "$shaderc_base/libshaderc_util/src/compiler.cc",
+    "$shaderc_base/libshaderc_util/src/file_finder.cc",
+    "$shaderc_base/libshaderc_util/src/io_shaderc.cc",
+    "$shaderc_base/libshaderc_util/src/message.cc",
+    "$shaderc_base/libshaderc_util/src/resources.cc",
+    "$shaderc_base/libshaderc_util/src/shader_stage.cc",
+    "$shaderc_base/libshaderc_util/src/spirv_tools_wrapper.cc",
+    "$shaderc_base/libshaderc_util/src/version_profile.cc",
+  ]
+}
+
+config("shaderc_config") {
+  include_dirs = [ "$shaderc_base/libshaderc/include/" ]
+}
+
+source_set("shaderc_flutter") {
+  defines = [ "SHADERC_IMPLEMENTATION" ]
+
+  public_configs = [ ":shaderc_config" ]
+
+  configs += [ "//third_party/spirv_tools_flutter:spvtools_public_config" ]
+
+  deps = [ ":shaderc_util_flutter" ]
+
+  public_deps = [
+    "//third_party/glslang_flutter",
+    "//third_party/spirv_tools_flutter:spvtools",
+  ]
+
+  sources = [
+    "$shaderc_base/libshaderc/include/shaderc/env.h",
+    "$shaderc_base/libshaderc/include/shaderc/shaderc.h",
+    "$shaderc_base/libshaderc/include/shaderc/shaderc.hpp",
+    "$shaderc_base/libshaderc/include/shaderc/status.h",
+    "$shaderc_base/libshaderc/include/shaderc/visibility.h",
+    "$shaderc_base/libshaderc/src/shaderc.cc",
+    "$shaderc_base/libshaderc/src/shaderc_private.h",
+  ]
+}

--- a/build/secondary/third_party/spirv_cross_flutter/BUILD.gn
+++ b/build/secondary/third_party/spirv_cross_flutter/BUILD.gn
@@ -1,0 +1,41 @@
+# Copyright 2016 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+source_root = "//third_party/spirv_cross"
+
+config("spirv_cross_public") {
+  include_dirs = [ source_root ]
+
+  defines = [ "SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS" ]
+}
+
+source_set("spirv_cross_flutter") {
+  public_configs = [ ":spirv_cross_public" ]
+
+  sources = [
+    "$source_root/GLSL.std.450.h",
+    "$source_root/spirv.hpp",
+    "$source_root/spirv_cfg.cpp",
+    "$source_root/spirv_cfg.hpp",
+    "$source_root/spirv_common.hpp",
+    "$source_root/spirv_cross.cpp",
+    "$source_root/spirv_cross.hpp",
+    "$source_root/spirv_cross_containers.hpp",
+    "$source_root/spirv_cross_error_handling.hpp",
+    "$source_root/spirv_cross_parsed_ir.cpp",
+    "$source_root/spirv_cross_parsed_ir.hpp",
+    "$source_root/spirv_cross_util.cpp",
+    "$source_root/spirv_cross_util.hpp",
+    "$source_root/spirv_glsl.cpp",
+    "$source_root/spirv_glsl.hpp",
+    "$source_root/spirv_hlsl.cpp",
+    "$source_root/spirv_hlsl.hpp",
+    "$source_root/spirv_msl.cpp",
+    "$source_root/spirv_msl.hpp",
+    "$source_root/spirv_parser.cpp",
+    "$source_root/spirv_parser.hpp",
+    "$source_root/spirv_reflect.cpp",
+    "$source_root/spirv_reflect.hpp",
+  ]
+}

--- a/build/secondary/third_party/spirv_tools_flutter/BUILD.gn
+++ b/build/secondary/third_party/spirv_tools_flutter/BUILD.gn
@@ -1,0 +1,921 @@
+# Copyright 2018 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source_root = "//third_party/spirv_tools"
+spirv_headers = "//third_party/spirv_headers"
+spirv_is_winuwp = is_win && target_os == "winuwp"
+
+template("spvtools_core_tables") {
+  assert(defined(invoker.version), "Need version in $target_name generation.")
+
+  action("spvtools_core_tables_" + target_name) {
+    script = "$source_root/utils/generate_grammar_tables.py"
+
+    version = invoker.version
+
+    core_json_file =
+        "${spirv_headers}/include/spirv/$version/spirv.core.grammar.json"
+    core_insts_file = "${target_gen_dir}/core.insts-$version.inc"
+    operand_kinds_file = "${target_gen_dir}/operand.kinds-$version.inc"
+    debuginfo_insts_file =
+        "${spirv_headers}/include/spirv/unified1/extinst.debuginfo.grammar.json"
+    cldebuginfo100_insts_file = "${spirv_headers}/include/spirv/unified1/extinst.opencl.debuginfo.100.grammar.json"
+
+    sources = [
+      cldebuginfo100_insts_file,
+      core_json_file,
+      debuginfo_insts_file,
+    ]
+    outputs = [
+      core_insts_file,
+      operand_kinds_file,
+    ]
+    args = [
+      "--spirv-core-grammar",
+      rebase_path(core_json_file, root_build_dir),
+      "--core-insts-output",
+      rebase_path(core_insts_file, root_build_dir),
+      "--extinst-debuginfo-grammar",
+      rebase_path(debuginfo_insts_file, root_build_dir),
+      "--extinst-cldebuginfo100-grammar",
+      rebase_path(cldebuginfo100_insts_file, root_build_dir),
+      "--operand-kinds-output",
+      rebase_path(operand_kinds_file, root_build_dir),
+    ]
+  }
+}
+
+template("spvtools_core_enums") {
+  assert(defined(invoker.version), "Need version in $target_name generation.")
+
+  action("spvtools_core_enums_" + target_name) {
+    script = "$source_root/utils/generate_grammar_tables.py"
+
+    version = invoker.version
+
+    core_json_file =
+        "${spirv_headers}/include/spirv/$version/spirv.core.grammar.json"
+    debuginfo_insts_file =
+        "${spirv_headers}/include/spirv/unified1/extinst.debuginfo.grammar.json"
+    cldebuginfo100_insts_file = "${spirv_headers}/include/spirv/unified1/extinst.opencl.debuginfo.100.grammar.json"
+
+    extension_enum_file = "${target_gen_dir}/extension_enum.inc"
+    extension_map_file = "${target_gen_dir}/enum_string_mapping.inc"
+
+    args = [
+      "--spirv-core-grammar",
+      rebase_path(core_json_file, root_build_dir),
+      "--extinst-debuginfo-grammar",
+      rebase_path(debuginfo_insts_file, root_build_dir),
+      "--extinst-cldebuginfo100-grammar",
+      rebase_path(cldebuginfo100_insts_file, root_build_dir),
+      "--extension-enum-output",
+      rebase_path(extension_enum_file, root_build_dir),
+      "--enum-string-mapping-output",
+      rebase_path(extension_map_file, root_build_dir),
+    ]
+    inputs = [
+      core_json_file,
+      debuginfo_insts_file,
+      cldebuginfo100_insts_file,
+    ]
+    outputs = [
+      extension_enum_file,
+      extension_map_file,
+    ]
+  }
+}
+
+template("spvtools_glsl_tables") {
+  assert(defined(invoker.version), "Need version in $target_name generation.")
+
+  action("spvtools_glsl_tables_" + target_name) {
+    script = "$source_root/utils/generate_grammar_tables.py"
+
+    version = invoker.version
+
+    core_json_file =
+        "${spirv_headers}/include/spirv/$version/spirv.core.grammar.json"
+    glsl_json_file = "${spirv_headers}/include/spirv/${version}/extinst.glsl.std.450.grammar.json"
+    debuginfo_insts_file =
+        "${spirv_headers}/include/spirv/unified1/extinst.debuginfo.grammar.json"
+    cldebuginfo100_insts_file = "${spirv_headers}/include/spirv/unified1/extinst.opencl.debuginfo.100.grammar.json"
+
+    glsl_insts_file = "${target_gen_dir}/glsl.std.450.insts.inc"
+
+    args = [
+      "--spirv-core-grammar",
+      rebase_path(core_json_file, root_build_dir),
+      "--extinst-debuginfo-grammar",
+      rebase_path(debuginfo_insts_file, root_build_dir),
+      "--extinst-cldebuginfo100-grammar",
+      rebase_path(cldebuginfo100_insts_file, root_build_dir),
+      "--extinst-glsl-grammar",
+      rebase_path(glsl_json_file, root_build_dir),
+      "--glsl-insts-output",
+      rebase_path(glsl_insts_file, root_build_dir),
+    ]
+    inputs = [
+      core_json_file,
+      glsl_json_file,
+      debuginfo_insts_file,
+      cldebuginfo100_insts_file,
+    ]
+    outputs = [ glsl_insts_file ]
+  }
+}
+
+template("spvtools_opencl_tables") {
+  assert(defined(invoker.version), "Need version in $target_name generation.")
+
+  action("spvtools_opencl_tables_" + target_name) {
+    script = "$source_root/utils/generate_grammar_tables.py"
+
+    version = invoker.version
+
+    core_json_file =
+        "${spirv_headers}/include/spirv/$version/spirv.core.grammar.json"
+    opencl_json_file = "${spirv_headers}/include/spirv/${version}/extinst.opencl.std.100.grammar.json"
+    debuginfo_insts_file =
+        "${spirv_headers}/include/spirv/unified1/extinst.debuginfo.grammar.json"
+    cldebuginfo100_insts_file = "${spirv_headers}/include/spirv/unified1/extinst.opencl.debuginfo.100.grammar.json"
+
+    opencl_insts_file = "${target_gen_dir}/opencl.std.insts.inc"
+
+    args = [
+      "--spirv-core-grammar",
+      rebase_path(core_json_file, root_build_dir),
+      "--extinst-debuginfo-grammar",
+      rebase_path(debuginfo_insts_file, root_build_dir),
+      "--extinst-cldebuginfo100-grammar",
+      rebase_path(cldebuginfo100_insts_file, root_build_dir),
+      "--extinst-opencl-grammar",
+      rebase_path(opencl_json_file, root_build_dir),
+      "--opencl-insts-output",
+      rebase_path(opencl_insts_file, root_build_dir),
+    ]
+    inputs = [
+      core_json_file,
+      opencl_json_file,
+      debuginfo_insts_file,
+      cldebuginfo100_insts_file,
+    ]
+    outputs = [ opencl_insts_file ]
+  }
+}
+
+template("spvtools_language_header") {
+  assert(defined(invoker.name), "Need name in $target_name generation.")
+
+  action("spvtools_language_header_" + target_name) {
+    script = "$source_root/utils/generate_language_headers.py"
+
+    name = invoker.name
+    extinst_output_path = "${target_gen_dir}/${name}.h"
+
+    args = [
+      "--extinst-grammar",
+      rebase_path(invoker.grammar_file, root_build_dir),
+      "--extinst-output-path",
+      rebase_path(extinst_output_path, root_build_dir),
+    ]
+    inputs = [ invoker.grammar_file ]
+    outputs = [ "${extinst_output_path}" ]
+  }
+}
+
+template("spvtools_vendor_table") {
+  assert(defined(invoker.name), "Need name in $target_name generation.")
+
+  action("spvtools_vendor_tables_" + target_name) {
+    script = "$source_root/utils/generate_grammar_tables.py"
+
+    name = invoker.name
+    extinst_vendor_grammar =
+        "${spirv_headers}/include/spirv/unified1/extinst.${name}.grammar.json"
+    extinst_file = "${target_gen_dir}/${name}.insts.inc"
+
+    args = [
+      "--extinst-vendor-grammar",
+      rebase_path(extinst_vendor_grammar, root_build_dir),
+      "--vendor-insts-output",
+      rebase_path(extinst_file, root_build_dir),
+      "--vendor-operand-kind-prefix",
+      invoker.operand_kind_prefix,
+    ]
+    inputs = [ extinst_vendor_grammar ]
+    outputs = [ extinst_file ]
+  }
+}
+
+action("spvtools_generators_inc") {
+  script = "$source_root/utils/generate_registry_tables.py"
+
+  # TODO(dsinclair): Make work for chrome
+  xml_file = "${spirv_headers}/include/spirv/spir-v.xml"
+  inc_file = "${target_gen_dir}/generators.inc"
+
+  sources = [ xml_file ]
+  outputs = [ inc_file ]
+  args = [
+    "--xml",
+    rebase_path(xml_file, root_build_dir),
+    "--generator",
+    rebase_path(inc_file, root_build_dir),
+  ]
+}
+
+action("spvtools_build_version") {
+  script = "$source_root/utils/update_build_version.py"
+
+  src_dir = "."
+  inc_file = "${target_gen_dir}/build-version.inc"
+
+  outputs = [ inc_file ]
+  args = [
+    rebase_path(src_dir, root_build_dir),
+    rebase_path(inc_file, root_build_dir),
+  ]
+}
+
+spvtools_core_tables("unified1") {
+  version = "unified1"
+}
+spvtools_core_enums("unified1") {
+  version = "unified1"
+}
+spvtools_glsl_tables("glsl1-0") {
+  version = "1.0"
+}
+spvtools_opencl_tables("opencl1-0") {
+  version = "1.0"
+}
+spvtools_language_header("debuginfo") {
+  name = "DebugInfo"
+  grammar_file =
+      "${spirv_headers}/include/spirv/unified1/extinst.debuginfo.grammar.json"
+}
+spvtools_language_header("cldebuginfo100") {
+  name = "OpenCLDebugInfo100"
+  grammar_file = "${spirv_headers}/include/spirv/unified1/extinst.opencl.debuginfo.100.grammar.json"
+}
+
+spvtools_vendor_tables = [
+  [
+    "spv-amd-shader-explicit-vertex-parameter",
+    "...nil...",
+  ],
+  [
+    "spv-amd-shader-trinary-minmax",
+    "...nil...",
+  ],
+  [
+    "spv-amd-gcn-shader",
+    "...nil...",
+  ],
+  [
+    "spv-amd-shader-ballot",
+    "...nil...",
+  ],
+  [
+    "debuginfo",
+    "...nil...",
+  ],
+  [
+    "opencl.debuginfo.100",
+    "CLDEBUG100_",
+  ],
+  [
+    "nonsemantic.clspvreflection",
+    "...nil...",
+  ],
+]
+
+foreach(table_def, spvtools_vendor_tables) {
+  spvtools_vendor_table(table_def[0]) {
+    name = table_def[0]
+    operand_kind_prefix = table_def[1]
+  }
+}
+
+config("spvtools_public_config") {
+  include_dirs = [ "$source_root/include" ]
+}
+
+config("spvtools_internal_config") {
+  include_dirs = [
+    "$source_root",
+    "$target_gen_dir",
+    "${spirv_headers}/include",
+  ]
+
+  configs = [ ":spvtools_public_config" ]
+
+  cflags = []
+  if (is_clang) {
+    cflags += [
+      "-Wno-implicit-fallthrough",
+      "-Wno-newline-eof",
+    ]
+  } else if (!is_win) {
+    # Work around a false-positive on a Skia GCC 10 builder.
+    cflags += [ "-Wno-format-truncation" ]
+  }
+}
+
+source_set("spvtools_headers") {
+  sources = [
+    "include/spirv-tools/instrument.hpp",
+    "include/spirv-tools/libspirv.h",
+    "include/spirv-tools/libspirv.hpp",
+    "include/spirv-tools/linker.hpp",
+    "include/spirv-tools/optimizer.hpp",
+  ]
+
+  public_configs = [ ":spvtools_public_config" ]
+}
+
+source_set("spvtools") {
+  deps = [
+    ":spvtools_core_tables_unified1",
+    ":spvtools_generators_inc",
+    ":spvtools_glsl_tables_glsl1-0",
+    ":spvtools_language_header_cldebuginfo100",
+    ":spvtools_language_header_debuginfo",
+    ":spvtools_opencl_tables_opencl1-0",
+  ]
+  foreach(table_def, spvtools_vendor_tables) {
+    target_name = table_def[0]
+    deps += [ ":spvtools_vendor_tables_$target_name" ]
+  }
+
+  sources = [
+    "$source_root/source/assembly_grammar.cpp",
+    "$source_root/source/assembly_grammar.h",
+    "$source_root/source/binary.cpp",
+    "$source_root/source/binary.h",
+    "$source_root/source/cfa.h",
+    "$source_root/source/diagnostic.cpp",
+    "$source_root/source/diagnostic.h",
+    "$source_root/source/disassemble.cpp",
+    "$source_root/source/disassemble.h",
+    "$source_root/source/enum_set.h",
+    "$source_root/source/enum_string_mapping.cpp",
+    "$source_root/source/enum_string_mapping.h",
+    "$source_root/source/ext_inst.cpp",
+    "$source_root/source/ext_inst.h",
+    "$source_root/source/extensions.cpp",
+    "$source_root/source/extensions.h",
+    "$source_root/source/instruction.h",
+    "$source_root/source/latest_version_glsl_std_450_header.h",
+    "$source_root/source/latest_version_opencl_std_header.h",
+    "$source_root/source/latest_version_spirv_header.h",
+    "$source_root/source/libspirv.cpp",
+    "$source_root/source/macro.h",
+    "$source_root/source/name_mapper.cpp",
+    "$source_root/source/name_mapper.h",
+    "$source_root/source/opcode.cpp",
+    "$source_root/source/opcode.h",
+    "$source_root/source/operand.cpp",
+    "$source_root/source/operand.h",
+    "$source_root/source/parsed_operand.cpp",
+    "$source_root/source/parsed_operand.h",
+    "$source_root/source/print.cpp",
+    "$source_root/source/print.h",
+    "$source_root/source/spirv_constant.h",
+    "$source_root/source/spirv_definition.h",
+    "$source_root/source/spirv_endian.cpp",
+    "$source_root/source/spirv_endian.h",
+    "$source_root/source/spirv_optimizer_options.cpp",
+    "$source_root/source/spirv_optimizer_options.h",
+    "$source_root/source/spirv_target_env.cpp",
+    "$source_root/source/spirv_target_env.h",
+    "$source_root/source/spirv_validator_options.cpp",
+    "$source_root/source/spirv_validator_options.h",
+    "$source_root/source/table.cpp",
+    "$source_root/source/table.h",
+    "$source_root/source/text.cpp",
+    "$source_root/source/text.h",
+    "$source_root/source/text_handler.cpp",
+    "$source_root/source/text_handler.h",
+    "$source_root/source/util/bit_vector.cpp",
+    "$source_root/source/util/bit_vector.h",
+    "$source_root/source/util/bitutils.h",
+    "$source_root/source/util/hex_float.h",
+    "$source_root/source/util/ilist.h",
+    "$source_root/source/util/ilist_node.h",
+    "$source_root/source/util/make_unique.h",
+    "$source_root/source/util/parse_number.cpp",
+    "$source_root/source/util/parse_number.h",
+    "$source_root/source/util/small_vector.h",
+    "$source_root/source/util/string_utils.cpp",
+    "$source_root/source/util/string_utils.h",
+    "$source_root/source/util/timer.cpp",
+    "$source_root/source/util/timer.h",
+  ]
+
+  public_deps = [
+    ":spvtools_core_enums_unified1",
+    ":spvtools_headers",
+    "${spirv_headers}:spv_headers",
+  ]
+
+  configs += [ ":spvtools_internal_config" ]
+}
+
+source_set("spvtools_val") {
+  sources = [
+    "$source_root/source/val/basic_block.cpp",
+    "$source_root/source/val/basic_block.h",
+    "$source_root/source/val/construct.cpp",
+    "$source_root/source/val/construct.h",
+    "$source_root/source/val/decoration.h",
+    "$source_root/source/val/function.cpp",
+    "$source_root/source/val/function.h",
+    "$source_root/source/val/instruction.cpp",
+    "$source_root/source/val/validate.cpp",
+    "$source_root/source/val/validate.h",
+    "$source_root/source/val/validate_adjacency.cpp",
+    "$source_root/source/val/validate_annotation.cpp",
+    "$source_root/source/val/validate_arithmetics.cpp",
+    "$source_root/source/val/validate_atomics.cpp",
+    "$source_root/source/val/validate_barriers.cpp",
+    "$source_root/source/val/validate_bitwise.cpp",
+    "$source_root/source/val/validate_builtins.cpp",
+    "$source_root/source/val/validate_capability.cpp",
+    "$source_root/source/val/validate_cfg.cpp",
+    "$source_root/source/val/validate_composites.cpp",
+    "$source_root/source/val/validate_constants.cpp",
+    "$source_root/source/val/validate_conversion.cpp",
+    "$source_root/source/val/validate_debug.cpp",
+    "$source_root/source/val/validate_decorations.cpp",
+    "$source_root/source/val/validate_derivatives.cpp",
+    "$source_root/source/val/validate_execution_limitations.cpp",
+    "$source_root/source/val/validate_extensions.cpp",
+    "$source_root/source/val/validate_function.cpp",
+    "$source_root/source/val/validate_id.cpp",
+    "$source_root/source/val/validate_image.cpp",
+    "$source_root/source/val/validate_instruction.cpp",
+    "$source_root/source/val/validate_interfaces.cpp",
+    "$source_root/source/val/validate_layout.cpp",
+    "$source_root/source/val/validate_literals.cpp",
+    "$source_root/source/val/validate_logicals.cpp",
+    "$source_root/source/val/validate_memory.cpp",
+    "$source_root/source/val/validate_memory_semantics.cpp",
+    "$source_root/source/val/validate_memory_semantics.h",
+    "$source_root/source/val/validate_misc.cpp",
+    "$source_root/source/val/validate_mode_setting.cpp",
+    "$source_root/source/val/validate_non_uniform.cpp",
+    "$source_root/source/val/validate_primitives.cpp",
+    "$source_root/source/val/validate_scopes.cpp",
+    "$source_root/source/val/validate_scopes.h",
+    "$source_root/source/val/validate_small_type_uses.cpp",
+    "$source_root/source/val/validate_type.cpp",
+    "$source_root/source/val/validation_state.cpp",
+    "$source_root/source/val/validation_state.h",
+  ]
+
+  deps = [
+    ":spvtools",
+    ":spvtools_language_header_cldebuginfo100",
+    ":spvtools_language_header_debuginfo",
+  ]
+  public_deps = [ ":spvtools_headers" ]
+
+  configs += [ ":spvtools_internal_config" ]
+}
+
+source_set("spvtools_opt") {
+  sources = [
+    "$source_root/source/opt/aggressive_dead_code_elim_pass.cpp",
+    "$source_root/source/opt/aggressive_dead_code_elim_pass.h",
+    "$source_root/source/opt/amd_ext_to_khr.cpp",
+    "$source_root/source/opt/amd_ext_to_khr.h",
+    "$source_root/source/opt/basic_block.cpp",
+    "$source_root/source/opt/basic_block.h",
+    "$source_root/source/opt/block_merge_pass.cpp",
+    "$source_root/source/opt/block_merge_pass.h",
+    "$source_root/source/opt/block_merge_util.cpp",
+    "$source_root/source/opt/block_merge_util.h",
+    "$source_root/source/opt/build_module.cpp",
+    "$source_root/source/opt/build_module.h",
+    "$source_root/source/opt/ccp_pass.cpp",
+    "$source_root/source/opt/ccp_pass.h",
+    "$source_root/source/opt/cfg.cpp",
+    "$source_root/source/opt/cfg.h",
+    "$source_root/source/opt/cfg_cleanup_pass.cpp",
+    "$source_root/source/opt/cfg_cleanup_pass.h",
+    "$source_root/source/opt/code_sink.cpp",
+    "$source_root/source/opt/code_sink.h",
+    "$source_root/source/opt/combine_access_chains.cpp",
+    "$source_root/source/opt/combine_access_chains.h",
+    "$source_root/source/opt/compact_ids_pass.cpp",
+    "$source_root/source/opt/compact_ids_pass.h",
+    "$source_root/source/opt/composite.cpp",
+    "$source_root/source/opt/composite.h",
+    "$source_root/source/opt/const_folding_rules.cpp",
+    "$source_root/source/opt/const_folding_rules.h",
+    "$source_root/source/opt/constants.cpp",
+    "$source_root/source/opt/constants.h",
+    "$source_root/source/opt/convert_to_half_pass.cpp",
+    "$source_root/source/opt/convert_to_half_pass.h",
+    "$source_root/source/opt/copy_prop_arrays.cpp",
+    "$source_root/source/opt/copy_prop_arrays.h",
+    "$source_root/source/opt/dead_branch_elim_pass.cpp",
+    "$source_root/source/opt/dead_branch_elim_pass.h",
+    "$source_root/source/opt/dead_insert_elim_pass.cpp",
+    "$source_root/source/opt/dead_insert_elim_pass.h",
+    "$source_root/source/opt/dead_variable_elimination.cpp",
+    "$source_root/source/opt/dead_variable_elimination.h",
+    "$source_root/source/opt/debug_info_manager.cpp",
+    "$source_root/source/opt/debug_info_manager.h",
+    "$source_root/source/opt/decoration_manager.cpp",
+    "$source_root/source/opt/decoration_manager.h",
+    "$source_root/source/opt/def_use_manager.cpp",
+    "$source_root/source/opt/def_use_manager.h",
+    "$source_root/source/opt/desc_sroa.cpp",
+    "$source_root/source/opt/desc_sroa.h",
+    "$source_root/source/opt/dominator_analysis.cpp",
+    "$source_root/source/opt/dominator_analysis.h",
+    "$source_root/source/opt/dominator_tree.cpp",
+    "$source_root/source/opt/dominator_tree.h",
+    "$source_root/source/opt/eliminate_dead_constant_pass.cpp",
+    "$source_root/source/opt/eliminate_dead_constant_pass.h",
+    "$source_root/source/opt/eliminate_dead_functions_pass.cpp",
+    "$source_root/source/opt/eliminate_dead_functions_pass.h",
+    "$source_root/source/opt/eliminate_dead_functions_util.cpp",
+    "$source_root/source/opt/eliminate_dead_functions_util.h",
+    "$source_root/source/opt/eliminate_dead_members_pass.cpp",
+    "$source_root/source/opt/eliminate_dead_members_pass.h",
+    "$source_root/source/opt/empty_pass.h",
+    "$source_root/source/opt/feature_manager.cpp",
+    "$source_root/source/opt/feature_manager.h",
+    "$source_root/source/opt/fix_storage_class.cpp",
+    "$source_root/source/opt/fix_storage_class.h",
+    "$source_root/source/opt/flatten_decoration_pass.cpp",
+    "$source_root/source/opt/flatten_decoration_pass.h",
+    "$source_root/source/opt/fold.cpp",
+    "$source_root/source/opt/fold.h",
+    "$source_root/source/opt/fold_spec_constant_op_and_composite_pass.cpp",
+    "$source_root/source/opt/fold_spec_constant_op_and_composite_pass.h",
+    "$source_root/source/opt/folding_rules.cpp",
+    "$source_root/source/opt/folding_rules.h",
+    "$source_root/source/opt/freeze_spec_constant_value_pass.cpp",
+    "$source_root/source/opt/freeze_spec_constant_value_pass.h",
+    "$source_root/source/opt/function.cpp",
+    "$source_root/source/opt/function.h",
+    "$source_root/source/opt/graphics_robust_access_pass.cpp",
+    "$source_root/source/opt/graphics_robust_access_pass.h",
+    "$source_root/source/opt/if_conversion.cpp",
+    "$source_root/source/opt/if_conversion.h",
+    "$source_root/source/opt/inline_exhaustive_pass.cpp",
+    "$source_root/source/opt/inline_exhaustive_pass.h",
+    "$source_root/source/opt/inline_opaque_pass.cpp",
+    "$source_root/source/opt/inline_opaque_pass.h",
+    "$source_root/source/opt/inline_pass.cpp",
+    "$source_root/source/opt/inline_pass.h",
+    "$source_root/source/opt/inst_bindless_check_pass.cpp",
+    "$source_root/source/opt/inst_bindless_check_pass.h",
+    "$source_root/source/opt/inst_buff_addr_check_pass.cpp",
+    "$source_root/source/opt/inst_buff_addr_check_pass.h",
+    "$source_root/source/opt/inst_debug_printf_pass.cpp",
+    "$source_root/source/opt/inst_debug_printf_pass.h",
+    "$source_root/source/opt/instruction.cpp",
+    "$source_root/source/opt/instruction.h",
+    "$source_root/source/opt/instruction_list.cpp",
+    "$source_root/source/opt/instruction_list.h",
+    "$source_root/source/opt/instrument_pass.cpp",
+    "$source_root/source/opt/instrument_pass.h",
+    "$source_root/source/opt/interp_fixup_pass.cpp",
+    "$source_root/source/opt/interp_fixup_pass.h",
+    "$source_root/source/opt/ir_builder.h",
+    "$source_root/source/opt/ir_context.cpp",
+    "$source_root/source/opt/ir_context.h",
+    "$source_root/source/opt/ir_loader.cpp",
+    "$source_root/source/opt/ir_loader.h",
+    "$source_root/source/opt/iterator.h",
+    "$source_root/source/opt/licm_pass.cpp",
+    "$source_root/source/opt/licm_pass.h",
+    "$source_root/source/opt/local_access_chain_convert_pass.cpp",
+    "$source_root/source/opt/local_access_chain_convert_pass.h",
+    "$source_root/source/opt/local_redundancy_elimination.cpp",
+    "$source_root/source/opt/local_redundancy_elimination.h",
+    "$source_root/source/opt/local_single_block_elim_pass.cpp",
+    "$source_root/source/opt/local_single_block_elim_pass.h",
+    "$source_root/source/opt/local_single_store_elim_pass.cpp",
+    "$source_root/source/opt/local_single_store_elim_pass.h",
+    "$source_root/source/opt/log.h",
+    "$source_root/source/opt/loop_dependence.cpp",
+    "$source_root/source/opt/loop_dependence.h",
+    "$source_root/source/opt/loop_dependence_helpers.cpp",
+    "$source_root/source/opt/loop_descriptor.cpp",
+    "$source_root/source/opt/loop_descriptor.h",
+    "$source_root/source/opt/loop_fission.cpp",
+    "$source_root/source/opt/loop_fission.h",
+    "$source_root/source/opt/loop_fusion.cpp",
+    "$source_root/source/opt/loop_fusion.h",
+    "$source_root/source/opt/loop_fusion_pass.cpp",
+    "$source_root/source/opt/loop_fusion_pass.h",
+    "$source_root/source/opt/loop_peeling.cpp",
+    "$source_root/source/opt/loop_peeling.h",
+    "$source_root/source/opt/loop_unroller.cpp",
+    "$source_root/source/opt/loop_unroller.h",
+    "$source_root/source/opt/loop_unswitch_pass.cpp",
+    "$source_root/source/opt/loop_unswitch_pass.h",
+    "$source_root/source/opt/loop_utils.cpp",
+    "$source_root/source/opt/loop_utils.h",
+    "$source_root/source/opt/mem_pass.cpp",
+    "$source_root/source/opt/mem_pass.h",
+    "$source_root/source/opt/merge_return_pass.cpp",
+    "$source_root/source/opt/merge_return_pass.h",
+    "$source_root/source/opt/module.cpp",
+    "$source_root/source/opt/module.h",
+    "$source_root/source/opt/null_pass.h",
+    "$source_root/source/opt/optimizer.cpp",
+    "$source_root/source/opt/pass.cpp",
+    "$source_root/source/opt/pass.h",
+    "$source_root/source/opt/pass_manager.cpp",
+    "$source_root/source/opt/pass_manager.h",
+    "$source_root/source/opt/passes.h",
+    "$source_root/source/opt/private_to_local_pass.cpp",
+    "$source_root/source/opt/private_to_local_pass.h",
+    "$source_root/source/opt/propagator.cpp",
+    "$source_root/source/opt/propagator.h",
+    "$source_root/source/opt/reduce_load_size.cpp",
+    "$source_root/source/opt/reduce_load_size.h",
+    "$source_root/source/opt/redundancy_elimination.cpp",
+    "$source_root/source/opt/redundancy_elimination.h",
+    "$source_root/source/opt/reflect.h",
+    "$source_root/source/opt/register_pressure.cpp",
+    "$source_root/source/opt/register_pressure.h",
+    "$source_root/source/opt/relax_float_ops_pass.cpp",
+    "$source_root/source/opt/relax_float_ops_pass.h",
+    "$source_root/source/opt/remove_duplicates_pass.cpp",
+    "$source_root/source/opt/remove_duplicates_pass.h",
+    "$source_root/source/opt/replace_invalid_opc.cpp",
+    "$source_root/source/opt/replace_invalid_opc.h",
+    "$source_root/source/opt/scalar_analysis.cpp",
+    "$source_root/source/opt/scalar_analysis.h",
+    "$source_root/source/opt/scalar_analysis_nodes.h",
+    "$source_root/source/opt/scalar_analysis_simplification.cpp",
+    "$source_root/source/opt/scalar_replacement_pass.cpp",
+    "$source_root/source/opt/scalar_replacement_pass.h",
+    "$source_root/source/opt/set_spec_constant_default_value_pass.cpp",
+    "$source_root/source/opt/set_spec_constant_default_value_pass.h",
+    "$source_root/source/opt/simplification_pass.cpp",
+    "$source_root/source/opt/simplification_pass.h",
+    "$source_root/source/opt/ssa_rewrite_pass.cpp",
+    "$source_root/source/opt/ssa_rewrite_pass.h",
+    "$source_root/source/opt/strength_reduction_pass.cpp",
+    "$source_root/source/opt/strength_reduction_pass.h",
+    "$source_root/source/opt/strip_debug_info_pass.cpp",
+    "$source_root/source/opt/strip_debug_info_pass.h",
+    "$source_root/source/opt/strip_reflect_info_pass.cpp",
+    "$source_root/source/opt/strip_reflect_info_pass.h",
+    "$source_root/source/opt/struct_cfg_analysis.cpp",
+    "$source_root/source/opt/struct_cfg_analysis.h",
+    "$source_root/source/opt/tree_iterator.h",
+    "$source_root/source/opt/type_manager.cpp",
+    "$source_root/source/opt/type_manager.h",
+    "$source_root/source/opt/types.cpp",
+    "$source_root/source/opt/types.h",
+    "$source_root/source/opt/unify_const_pass.cpp",
+    "$source_root/source/opt/unify_const_pass.h",
+    "$source_root/source/opt/upgrade_memory_model.cpp",
+    "$source_root/source/opt/upgrade_memory_model.h",
+    "$source_root/source/opt/value_number_table.cpp",
+    "$source_root/source/opt/value_number_table.h",
+    "$source_root/source/opt/vector_dce.cpp",
+    "$source_root/source/opt/vector_dce.h",
+    "$source_root/source/opt/workaround1209.cpp",
+    "$source_root/source/opt/workaround1209.h",
+    "$source_root/source/opt/wrap_opkill.cpp",
+    "$source_root/source/opt/wrap_opkill.h",
+  ]
+
+  deps = [
+    ":spvtools",
+    ":spvtools_language_header_cldebuginfo100",
+    ":spvtools_language_header_debuginfo",
+    ":spvtools_vendor_tables_spv-amd-shader-ballot",
+  ]
+  public_deps = [ ":spvtools_headers" ]
+
+  configs += [ ":spvtools_internal_config" ]
+}
+
+source_set("spvtools_link") {
+  sources = [ "$source_root/source/link/linker.cpp" ]
+  deps = [
+    ":spvtools",
+    ":spvtools_opt",
+    ":spvtools_val",
+  ]
+  public_deps = [ ":spvtools_headers" ]
+
+  configs += [ ":spvtools_internal_config" ]
+}
+
+source_set("spvtools_reduce") {
+  sources = [
+    "$source_root/source/reduce/change_operand_reduction_opportunity.cpp",
+    "$source_root/source/reduce/change_operand_reduction_opportunity.h",
+    "$source_root/source/reduce/change_operand_to_undef_reduction_opportunity.cpp",
+    "$source_root/source/reduce/change_operand_to_undef_reduction_opportunity.h",
+    "$source_root/source/reduce/conditional_branch_to_simple_conditional_branch_opportunity_finder.cpp",
+    "$source_root/source/reduce/conditional_branch_to_simple_conditional_branch_opportunity_finder.h",
+    "$source_root/source/reduce/conditional_branch_to_simple_conditional_branch_reduction_opportunity.cpp",
+    "$source_root/source/reduce/conditional_branch_to_simple_conditional_branch_reduction_opportunity.h",
+    "$source_root/source/reduce/merge_blocks_reduction_opportunity.cpp",
+    "$source_root/source/reduce/merge_blocks_reduction_opportunity.h",
+    "$source_root/source/reduce/merge_blocks_reduction_opportunity_finder.cpp",
+    "$source_root/source/reduce/merge_blocks_reduction_opportunity_finder.h",
+    "$source_root/source/reduce/operand_to_const_reduction_opportunity_finder.cpp",
+    "$source_root/source/reduce/operand_to_const_reduction_opportunity_finder.h",
+    "$source_root/source/reduce/operand_to_dominating_id_reduction_opportunity_finder.cpp",
+    "$source_root/source/reduce/operand_to_dominating_id_reduction_opportunity_finder.h",
+    "$source_root/source/reduce/operand_to_undef_reduction_opportunity_finder.cpp",
+    "$source_root/source/reduce/operand_to_undef_reduction_opportunity_finder.h",
+    "$source_root/source/reduce/reducer.cpp",
+    "$source_root/source/reduce/reducer.h",
+    "$source_root/source/reduce/reduction_opportunity.cpp",
+    "$source_root/source/reduce/reduction_opportunity.h",
+    "$source_root/source/reduce/reduction_opportunity_finder.cpp",
+    "$source_root/source/reduce/reduction_opportunity_finder.h",
+    "$source_root/source/reduce/reduction_pass.cpp",
+    "$source_root/source/reduce/reduction_pass.h",
+    "$source_root/source/reduce/reduction_util.cpp",
+    "$source_root/source/reduce/reduction_util.h",
+    "$source_root/source/reduce/remove_block_reduction_opportunity.cpp",
+    "$source_root/source/reduce/remove_block_reduction_opportunity.h",
+    "$source_root/source/reduce/remove_block_reduction_opportunity_finder.cpp",
+    "$source_root/source/reduce/remove_block_reduction_opportunity_finder.h",
+    "$source_root/source/reduce/remove_function_reduction_opportunity.cpp",
+    "$source_root/source/reduce/remove_function_reduction_opportunity.h",
+    "$source_root/source/reduce/remove_function_reduction_opportunity_finder.cpp",
+    "$source_root/source/reduce/remove_function_reduction_opportunity_finder.h",
+    "$source_root/source/reduce/remove_instruction_reduction_opportunity.cpp",
+    "$source_root/source/reduce/remove_instruction_reduction_opportunity.h",
+    "$source_root/source/reduce/remove_selection_reduction_opportunity.cpp",
+    "$source_root/source/reduce/remove_selection_reduction_opportunity.h",
+    "$source_root/source/reduce/remove_selection_reduction_opportunity_finder.cpp",
+    "$source_root/source/reduce/remove_selection_reduction_opportunity_finder.h",
+    "$source_root/source/reduce/remove_struct_member_reduction_opportunity.cpp",
+    "$source_root/source/reduce/remove_struct_member_reduction_opportunity.h",
+    "$source_root/source/reduce/remove_unused_instruction_reduction_opportunity_finder.cpp",
+    "$source_root/source/reduce/remove_unused_instruction_reduction_opportunity_finder.h",
+    "$source_root/source/reduce/remove_unused_struct_member_reduction_opportunity_finder.cpp",
+    "$source_root/source/reduce/remove_unused_struct_member_reduction_opportunity_finder.h",
+    "$source_root/source/reduce/simple_conditional_branch_to_branch_opportunity_finder.cpp",
+    "$source_root/source/reduce/simple_conditional_branch_to_branch_opportunity_finder.h",
+    "$source_root/source/reduce/simple_conditional_branch_to_branch_reduction_opportunity.cpp",
+    "$source_root/source/reduce/simple_conditional_branch_to_branch_reduction_opportunity.h",
+    "$source_root/source/reduce/structured_loop_to_selection_reduction_opportunity.cpp",
+    "$source_root/source/reduce/structured_loop_to_selection_reduction_opportunity.h",
+    "$source_root/source/reduce/structured_loop_to_selection_reduction_opportunity_finder.cpp",
+    "$source_root/source/reduce/structured_loop_to_selection_reduction_opportunity_finder.h",
+    "$source_root/source/spirv_reducer_options.cpp",
+    "$source_root/source/spirv_reducer_options.h",
+  ]
+  deps = [
+    ":spvtools",
+    ":spvtools_opt",
+  ]
+  public_deps = [ ":spvtools_headers" ]
+  configs += [ ":spvtools_internal_config" ]
+}
+
+group("SPIRV-Tools") {
+  public_deps = [
+    ":spvtools",
+    ":spvtools_link",
+    ":spvtools_opt",
+    ":spvtools_reduce",
+    ":spvtools_val",
+  ]
+}
+
+source_set("spvtools_util_cli_consumer") {
+  sources = [
+    "tools/util/cli_consumer.cpp",
+    "tools/util/cli_consumer.h",
+  ]
+  deps = [ ":spvtools_headers" ]
+  configs += [ ":spvtools_internal_config" ]
+}
+
+source_set("spvtools_software_version") {
+  sources = [ "source/software_version.cpp" ]
+  deps = [
+    ":spvtools_build_version",
+    ":spvtools_headers",
+  ]
+  configs += [ ":spvtools_internal_config" ]
+}
+
+executable("spirv-as") {
+  sources = [ "tools/as/as.cpp" ]
+  deps = [
+    ":spvtools",
+    ":spvtools_software_version",
+  ]
+  configs += [ ":spvtools_internal_config" ]
+}
+
+executable("spirv-dis") {
+  sources = [ "tools/dis/dis.cpp" ]
+  deps = [
+    ":spvtools",
+    ":spvtools_software_version",
+  ]
+  configs += [ ":spvtools_internal_config" ]
+}
+
+executable("spirv-val") {
+  sources = [ "tools/val/val.cpp" ]
+  deps = [
+    ":spvtools",
+    ":spvtools_software_version",
+    ":spvtools_util_cli_consumer",
+    ":spvtools_val",
+  ]
+  configs += [ ":spvtools_internal_config" ]
+}
+
+executable("spirv-cfg") {
+  sources = [
+    "tools/cfg/bin_to_dot.cpp",
+    "tools/cfg/bin_to_dot.h",
+    "tools/cfg/cfg.cpp",
+  ]
+  deps = [
+    ":spvtools",
+    ":spvtools_software_version",
+  ]
+  configs += [ ":spvtools_internal_config" ]
+}
+
+executable("spirv-opt") {
+  sources = [ "tools/opt/opt.cpp" ]
+  deps = [
+    ":spvtools",
+    ":spvtools_opt",
+    ":spvtools_software_version",
+    ":spvtools_util_cli_consumer",
+    ":spvtools_val",
+  ]
+  configs += [ ":spvtools_internal_config" ]
+}
+
+executable("spirv-link") {
+  sources = [ "tools/link/linker.cpp" ]
+  deps = [
+    ":spvtools",
+    ":spvtools_link",
+    ":spvtools_opt",
+    ":spvtools_software_version",
+    ":spvtools_val",
+  ]
+  configs += [ ":spvtools_internal_config" ]
+}
+
+if (!is_ios && !spirv_is_winuwp) {
+  # iOS and UWP do not allow std::system calls which spirv-reduce requires
+  executable("spirv-reduce") {
+    sources = [ "tools/reduce/reduce.cpp" ]
+    deps = [
+      ":spvtools",
+      ":spvtools_opt",
+      ":spvtools_reduce",
+      ":spvtools_software_version",
+      ":spvtools_util_cli_consumer",
+      ":spvtools_val",
+    ]
+    configs += [ ":spvtools_internal_config" ]
+  }
+}
+
+group("all_spirv_tools") {
+  deps = [
+    ":spirv-as",
+    ":spirv-cfg",
+    ":spirv-dis",
+    ":spirv-link",
+    ":spirv-opt",
+    ":spirv-val",
+  ]
+  if (!is_ios && !spirv_is_winuwp) {
+    deps += [ ":spirv-reduce" ]
+  }
+}


### PR DESCRIPTION
This patch adds build rules for the following dependencies. These dependencies
will be added to DEPS in the engine when as this patch is rolled in:

* `glslang`: 9431c53c84c14fa9e9cd37678262ebba55c62c87
* `shaderc`: 948660cccfbbc303d2590c7f44a4cee40b66fdd6
* `spirv_cross`: 418542eaefdb609f548d25a1e3962fb69d80da63
* `spirv_tools`: 1020e394cb1267332d58497150d2b024371a8e41

The primary use case for these dependencies is in the Impeller offline pipeline
processing workflow. However, these are now necessary also to add unit-tests for
`//flutter/lib/spirv`.

Of particular note is the explicit rule for `spirv_tools`. There is already a
version of `spriv_tools` in the engine via its `SwiftShader` dependency.
However, `SwiftShader` adds this dependency directly to its sources and this
version is fairly old. That version is also incompatible with the requirements
of the other newly added dependencies. To let `SwiftShader` pick the dependency
it wants and to use the latest versions everywhere else, an explicit
`spirv_tools` dependency will be added. GN target names do not collide and
`SwiftShader` targets are used via a dynamic library.

Also, while there are no build rules for the SPIRV headers, they are necessary
and will be added to the engine DEPS.