### PR TITLE
Fix: remove non-existent dep in spirv_tools_flutter BUILD.gn

### DIFF
--- a/build/secondary/third_party/spirv_tools_flutter/BUILD.gn
+++ b/build/secondary/third_party/spirv_tools_flutter/BUILD.gn
@@ -428,7 +428,6 @@ source_set("spvtools") {
   public_deps = [
     ":spvtools_core_enums_unified1",
     ":spvtools_headers",
-    "${spirv_headers}:spv_headers",
   ]
 
   configs += [ ":spvtools_internal_config" ]


### PR DESCRIPTION
It was found that this dep does not exist in a build that depend on spirv_tools_flutter.

Here is the error

```
ERROR at //third_party/spirv_tools_flutter/BUILD.gn:431:5: Can't load input file.
    "${spirv_headers}:spvtools_headers",
    ^----------------------------------
Unable to load:
  /Users/antrob/git/engine/src/third_party/spirv_headers/BUILD.gn
I also checked in the secondary tree for:
  /Users/antrob/git/engine/src/build/secondary/third_party/spirv_headers/BUILD.gn
ninja: error: rebuilding 'build.ninja': subcommand failed
```

The same build works without the dep, but I am not sure if it should be replaced by something else for other cases.
