### PR TITLE
Update NDK from r21 to r22

### DIFF
--- a/build/config/android/BUILD.gn
+++ b/build/config/android/BUILD.gn
@@ -8,8 +8,7 @@ import("//build/config/sysroot.gni")
 config("sdk") {
   if (sysroot != "") {
     cflags = [ "--sysroot=" + sysroot ]
-    ldflags = [ "--sysroot=" +
-                rebase_path("$android_ndk_root/$android_sysroot_subdir") ]
+    ldflags = [ "-L" + rebase_path("$android_lib") ]
 
     # Need to get some linker flags out of the sysroot.
     sysroot_ld_path = rebase_path("//build/config/linux/sysroot_ld_path.py")

--- a/build/config/android/config.gni
+++ b/build/config/android/config.gni
@@ -97,26 +97,22 @@ if (is_android) {
   } else {
     android_api_level = 16
   }
-  x86_android_sysroot_subdir = "platforms/android-${android_api_level}/arch-x86"
-  arm_android_sysroot_subdir = "platforms/android-${android_api_level}/arch-arm"
-  mips_android_sysroot_subdir =
-      "platforms/android-${android_api_level}/arch-mips"
-  x86_64_android_sysroot_subdir =
-      "platforms/android-${android_api_level}/arch-x86_64"
-  arm64_android_sysroot_subdir =
-      "platforms/android-${android_api_level}/arch-arm64"
-  mips64_android_sysroot_subdir =
-      "platforms/android-${android_api_level}/arch-mips64"
 
   # Toolchain root directory for each build. The actual binaries are inside
   # a "bin" directory inside of these.
   _android_toolchain_version = "4.9"
+
+  llvm_android_toolchain_root = "$android_ndk_root/toolchains/llvm/prebuilt/${android_host_os}-${android_host_arch}"
+
   x86_android_toolchain_root = "$android_ndk_root/toolchains/x86-${_android_toolchain_version}/prebuilt/${android_host_os}-${android_host_arch}"
   arm_android_toolchain_root = "$android_ndk_root/toolchains/arm-linux-androideabi-${_android_toolchain_version}/prebuilt/${android_host_os}-${android_host_arch}"
-  mips_android_toolchain_root = "$android_ndk_root/toolchains/mipsel-linux-android-${_android_toolchain_version}/prebuilt/${android_host_os}-${android_host_arch}"
   x86_64_android_toolchain_root = "$android_ndk_root/toolchains/x86_64-${_android_toolchain_version}/prebuilt/${android_host_os}-${android_host_arch}"
   arm64_android_toolchain_root = "$android_ndk_root/toolchains/aarch64-linux-android-${_android_toolchain_version}/prebuilt/${android_host_os}-${android_host_arch}"
-  mips64_android_toolchain_root = "$android_ndk_root/toolchains/mips64el-${_android_toolchain_version}/prebuilt/${android_host_os}-${android_host_arch}"
+
+  x86_android_lib = "$llvm_android_toolchain_root/sysroot/usr/lib/i686-linux-android/${android_api_level}"
+  arm_android_lib = "$llvm_android_toolchain_root/sysroot/usr/lib/arm-linux-androideabi/${android_api_level}"
+  x86_64_android_lib = "$llvm_android_toolchain_root/sysroot/usr/lib/x86_64-linux-android/${android_api_level}"
+  arm64_android_lib = "$llvm_android_toolchain_root/sysroot/usr/lib/aarch64-linux-android/${android_api_level}"
 
   # Location of libgcc. This is only needed for the current GN toolchain, so we
   # only need to define the current one, rather than one for every platform
@@ -125,32 +121,22 @@ if (is_android) {
     android_prebuilt_arch = "android-x86"
     android_target_triple = "i686-linux-android"
     android_toolchain_root = "$x86_android_toolchain_root"
-    android_sysroot_subdir = "$x86_android_sysroot_subdir"
+    android_lib = "$x86_android_lib"
   } else if (current_cpu == "arm") {
     android_prebuilt_arch = "android-arm"
     android_target_triple = "arm-linux-androideabi"
     android_toolchain_root = "$arm_android_toolchain_root"
-    android_sysroot_subdir = "$arm_android_sysroot_subdir"
-  } else if (current_cpu == "mipsel") {
-    android_prebuilt_arch = "android-mips"
-    android_target_triple = "mipsel-linux-android"
-    android_toolchain_root = "$mips_android_toolchain_root"
-    android_sysroot_subdir = "$mips_android_sysroot_subdir"
+    android_lib = "$arm_android_lib"
   } else if (current_cpu == "x64") {
     android_prebuilt_arch = "android-x86_64"
     android_target_triple = "x86_64-linux-android"
     android_toolchain_root = "$x86_64_android_toolchain_root"
-    android_sysroot_subdir = "$x86_64_android_sysroot_subdir"
+    android_lib = "$x86_64_android_lib"
   } else if (current_cpu == "arm64") {
     android_prebuilt_arch = "android-arm64"
     android_target_triple = "aarch64-linux-android"
     android_toolchain_root = "$arm64_android_toolchain_root"
-    android_sysroot_subdir = "$arm64_android_sysroot_subdir"
-  } else if (current_cpu == "mips64el") {
-    android_prebuilt_arch = "android-mips64"
-    android_target_triple = "mips64el-linux-android"
-    android_toolchain_root = "$mips64_android_toolchain_root"
-    android_sysroot_subdir = "$mips64_android_sysroot_subdir"
+    android_lib = "$arm64_android_lib"
   } else {
     assert(false, "Need android libgcc support for your target arch.")
   }
@@ -189,14 +175,10 @@ if (is_android) {
     } else {
       android_app_abi = "armeabi-v7a"
     }
-  } else if (current_cpu == "mipsel") {
-    android_app_abi = "mips"
   } else if (current_cpu == "x64") {
     android_app_abi = "x86_64"
   } else if (current_cpu == "arm64") {
     android_app_abi = "arm64-v8a"
-  } else if (current_cpu == "mips64el") {
-    android_app_abi = "mips64"
   } else {
     assert(false, "Unknown Android ABI: " + current_cpu)
   }

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -579,19 +579,7 @@ config("runtime_library") {
     }
     ldflags += [ "-nostdlib" ]
 
-    # NOTE: The libc++ header include paths below are specified in cflags
-    # rather than include_dirs because they need to come after include_dirs.
-    # Think of them like system headers, but don't use '-isystem' because the
-    # arm-linux-androideabi-4.4.3 toolchain (circa Gingerbread) will exhibit
-    # strange errors. The include ordering here is important; change with
-    # caution.
     cflags += [
-      "-isystem" +
-          rebase_path("$android_ndk_root/sources/android/support/include",
-                      root_build_dir),
-      "-isystem" + rebase_path(
-              "$android_ndk_root/sysroot/usr/include/$android_target_triple",
-              root_build_dir),
       "-D__ANDROID_API__=$android_api_level",
     ]
 

--- a/build/config/sysroot.gni
+++ b/build/config/sysroot.gni
@@ -25,7 +25,7 @@ if (current_toolchain == default_toolchain && target_sysroot != "") {
   sysroot = target_sysroot
 } else if (is_android) {
   import("//build/config/android/config.gni")
-  sysroot = rebase_path("$android_ndk_root/sysroot")
+  sysroot = rebase_path("$llvm_android_toolchain_root/sysroot")
 } else if (is_linux && !is_chromeos) {
   if (current_cpu == "mipsel") {
     sysroot = rebase_path("//mipsel-sysroot/sysroot")

--- a/build/toolchain/android/BUILD.gn
+++ b/build/toolchain/android/BUILD.gn
@@ -12,10 +12,8 @@ import("//build/toolchain/gcc_toolchain.gni")
 # wrapper around gcc_toolchain to avoid duplication of logic.
 #
 # Parameters:
-#  - android_ndk_sysroot
-#      Sysroot for this architecture.
 #  - android_ndk_lib_dir
-#      Subdirectory inside of android_ndk_sysroot where libs go.
+#      Libraries for this architecture
 #  - tool_prefix
 #      Prefix to be added to the tool names.
 #  - toolchain_cpu
@@ -23,9 +21,7 @@ import("//build/toolchain/gcc_toolchain.gni")
 template("android_gcc_toolchain") {
   gcc_toolchain(target_name) {
     # Make our manually injected libs relative to the build dir.
-    android_ndk_lib = rebase_path(
-            invoker.android_ndk_sysroot + "/" + invoker.android_ndk_lib_dir,
-            root_build_dir)
+    android_ndk_lib = rebase_path(invoker.android_ndk_lib_dir, root_build_dir)
 
     libs_section_prefix = "$android_ndk_lib/crtbegin_dynamic.o"
     libs_section_postfix = "$android_ndk_lib/crtend_android.o"
@@ -101,13 +97,11 @@ template("android_gcc_toolchain") {
 
 template("android_gcc_toolchains_helper") {
   android_gcc_toolchain(target_name) {
-    android_ndk_sysroot = invoker.android_ndk_sysroot
     android_ndk_lib_dir = invoker.android_ndk_lib_dir
     tool_prefix = invoker.tool_prefix
     toolchain_cpu = invoker.toolchain_cpu
   }
   android_gcc_toolchain("clang_$target_name") {
-    android_ndk_sysroot = invoker.android_ndk_sysroot
     android_ndk_lib_dir = invoker.android_ndk_lib_dir
     tool_prefix = invoker.tool_prefix
     toolchain_cpu = invoker.toolchain_cpu
@@ -116,49 +110,29 @@ template("android_gcc_toolchains_helper") {
 }
 
 android_gcc_toolchains_helper("x86") {
-  android_ndk_sysroot = "$android_ndk_root/$x86_android_sysroot_subdir"
-  android_ndk_lib_dir = "usr/lib"
+  android_ndk_lib_dir = x86_android_lib
 
-  tool_prefix = "$x86_android_toolchain_root/bin/i686-linux-android-"
+  tool_prefix = "$llvm_android_toolchain_root/bin/i686-linux-android-"
   toolchain_cpu = "x86"
 }
 
 android_gcc_toolchains_helper("arm") {
-  android_ndk_sysroot = "$android_ndk_root/$arm_android_sysroot_subdir"
-  android_ndk_lib_dir = "usr/lib"
+  android_ndk_lib_dir = arm_android_lib
 
-  tool_prefix = "$arm_android_toolchain_root/bin/arm-linux-androideabi-"
+  tool_prefix = "$llvm_android_toolchain_root/bin/arm-linux-android-"
   toolchain_cpu = "arm"
 }
 
-android_gcc_toolchains_helper("mipsel") {
-  android_ndk_sysroot = "$android_ndk_root/$mips_android_sysroot_subdir"
-  android_ndk_lib_dir = "usr/lib"
-
-  tool_prefix = "$mips_android_toolchain_root/bin/mipsel-linux-android-"
-  toolchain_cpu = "mipsel"
-}
-
 android_gcc_toolchains_helper("x64") {
-  android_ndk_sysroot = "$android_ndk_root/$x86_64_android_sysroot_subdir"
-  android_ndk_lib_dir = "usr/lib64"
+  android_ndk_lib_dir = x86_64_android_lib
 
-  tool_prefix = "$x86_64_android_toolchain_root/bin/x86_64-linux-android-"
+  tool_prefix = "$llvm_android_toolchain_root/bin/x86_64-linux-android-"
   toolchain_cpu = "x86_64"
 }
 
 android_gcc_toolchains_helper("arm64") {
-  android_ndk_sysroot = "$android_ndk_root/$arm64_android_sysroot_subdir"
-  android_ndk_lib_dir = "usr/lib"
+  android_ndk_lib_dir = arm64_android_lib
 
-  tool_prefix = "$arm64_android_toolchain_root/bin/aarch64-linux-android-"
+  tool_prefix = "$llvm_android_toolchain_root/bin/aarch64-linux-android-"
   toolchain_cpu = "aarch64"
-}
-
-android_gcc_toolchains_helper("mips64el") {
-  android_ndk_sysroot = "$android_ndk_root/$mips64_android_sysroot_subdir"
-  android_ndk_lib_dir = "usr/lib64"
-
-  tool_prefix = "$mips64_android_toolchain_root/bin/mipsel-linux-android-"
-  toolchain_cpu = "mipsel64el"
 }

--- a/build/toolchain/android/BUILD.gn
+++ b/build/toolchain/android/BUILD.gn
@@ -119,7 +119,7 @@ android_gcc_toolchains_helper("x86") {
 android_gcc_toolchains_helper("arm") {
   android_ndk_lib_dir = arm_android_lib
 
-  tool_prefix = "$llvm_android_toolchain_root/bin/arm-linux-android-"
+  tool_prefix = "$llvm_android_toolchain_root/bin/arm-linux-androideabi-"
   toolchain_cpu = "arm"
 }
 


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/73818.

All of the platform-specific binaries were consolidated under `toolchains/llvm/sysroot` subdirs. The unified sysroot is well-structured in terms of headers, but there are no longer separate well-structured sysroots for each architecture in terms of binary placement, so I opted to just include the correct library directory at link time.

RIP MIPS. I removed some of the MIPS stuff that was in the way, but in order to keep the diff relevant, I'll go through and remove the rest of it in a follow-up. Note that MIPS was removed in NDK r17.