### PR TITLE
Support iOS ARM64 simulator builds

### DIFF
--- a/build/config/BUILDCONFIG.gn
+++ b/build/config/BUILDCONFIG.gn
@@ -543,7 +543,11 @@ if (custom_toolchain != "") {
   import("//build/config/ios/ios_sdk.gni")  # For use_ios_simulator
   host_toolchain = "//build/toolchain/mac:clang_$host_cpu"
   if (use_ios_simulator) {
-    set_default_toolchain("//build/toolchain/mac:ios_clang_x64")
+    if (target_cpu == "arm" || target_cpu == "arm64") {
+      set_default_toolchain("//build/toolchain/mac:ios_clang_arm_sim")
+    } else {
+      set_default_toolchain("//build/toolchain/mac:ios_clang_x64_sim")
+    }
   } else {
     set_default_toolchain("//build/toolchain/mac:ios_clang_arm")
   }

--- a/build/config/BUILDCONFIG.gn
+++ b/build/config/BUILDCONFIG.gn
@@ -543,7 +543,7 @@ if (custom_toolchain != "") {
   import("//build/config/ios/ios_sdk.gni")  # For use_ios_simulator
   host_toolchain = "//build/toolchain/mac:clang_$host_cpu"
   if (use_ios_simulator) {
-    if (target_cpu == "arm" || target_cpu == "arm64") {
+    if (target_cpu == "arm64") {
       set_default_toolchain("//build/toolchain/mac:ios_clang_arm_sim")
     } else {
       set_default_toolchain("//build/toolchain/mac:ios_clang_x64_sim")

--- a/build/toolchain/clang.gni
+++ b/build/toolchain/clang.gni
@@ -47,7 +47,7 @@ declare_args() {
   # TODO(gw280): Once our own copy of clang 12 is capable of building for arm64 simulator,
   # we can safely remove the requirement that we use xcode for arm64 simulator builds.
   if (is_mac || is_ios) {
-    use_xcode = (enable_bitcode && !bitcode_marker) || (use_ios_simulator && (target_cpu == "arm" || target_cpu == "arm64"))
+    use_xcode = (enable_bitcode && !bitcode_marker) || (use_ios_simulator && target_cpu == "arm64")
   } else {
     use_xcode = false
   }

--- a/build/toolchain/clang.gni
+++ b/build/toolchain/clang.gni
@@ -2,6 +2,10 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+if (is_mac || is_ios) {
+  import("//build/config/ios/ios_sdk.gni") # For use_ios_simulator
+}
+
 declare_args() {
   # Enable the optional type profiler in Clang, which will tag heap allocations
   # with the allocation type.
@@ -39,5 +43,12 @@ declare_args() {
   # bitcode_marker which is intrinsically faster to build and does not introduce
   # compatibility concerns between toolchains, meaning we can use
   # a GOMA enabled Clang.
-  use_xcode = enable_bitcode && !bitcode_marker
+  #
+  # TODO(gw280): Once our own copy of clang 12 is capable of building for arm64 simulator,
+  # we can safely remove the requirement that we use xcode for arm64 simulator builds.
+  if (is_mac || is_ios) {
+    use_xcode = (enable_bitcode && !bitcode_marker) || (use_ios_simulator && (target_cpu == "arm" || target_cpu == "arm64"))
+  } else {
+    use_xcode = false
+  }
 }

--- a/build/toolchain/mac/BUILD.gn
+++ b/build/toolchain/mac/BUILD.gn
@@ -245,8 +245,27 @@ mac_toolchain("ios_clang_arm") {
   sysroot_flags = "-isysroot $ios_device_sdk_path -miphoneos-version-min=$ios_deployment_target"
 }
 
-# Toolchain used for iOS simulator targets.
-mac_toolchain("ios_clang_x64") {
+# Toolchain used for iOS simulator targets (arm64).
+mac_toolchain("ios_clang_arm_sim") {
+  toolchain_cpu = "arm"
+  toolchain_os = "mac"
+  if (!use_xcode) {
+    prefix = rebase_path(llvm_bin_path, root_build_dir)
+    ar = "$prefix/llvm-ar"
+    cc = "$prefix/clang"
+    cxx = "$prefix/clang++"
+  } else {
+    ar = "ar"
+    cc = "clang"
+    cxx = "clang++"
+  }
+  ld = cxx
+  is_clang = true
+  sysroot_flags = "-isysroot $ios_simulator_sdk_path -mios-simulator-version-min=$ios_deployment_target"
+}
+
+# Toolchain used for iOS simulator targets (x64).
+mac_toolchain("ios_clang_x64_sim") {
   toolchain_cpu = "x64"
   toolchain_os = "mac"
   prefix = rebase_path(llvm_bin_path, root_build_dir)


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/84670

This was previously landed and backed out for this failure: https://ci.chromium.org/ui/p/flutter/builders/prod/Mac%20iOS%20Engine%20Release/7004/overview

I have done a full CI pre-submit run here: https://github.com/flutter/engine/pull/26784 and manually triggered a `Mac iOS Engine Release` run here: https://luci-milo.appspot.com/raw/build/logs.chromium.org/flutter/led/wrightgeorge_google.com/714c2f7d1c809fcbdd78d87e13fe2665d166438b0676ac67ea88cde200e6ff6e/+/build.proto

Both are passing (with the exception of failing to upload artifacts, due to being run on a try job), so I think we can merge this now.