### PR TITLE
Allow new FIDL syntax

### DIFF
--- a/build/fuchsia/fidl_gen_cpp.py
+++ b/build/fuchsia/fidl_gen_cpp.py
@@ -54,7 +54,7 @@ def main():
   fidlc_command = [
     args.fidlc_bin,
     '--experimental',
-    'old_syntax_only',
+    'allow_new_syntax',
     '--tables',
     args.output_c_tables,
     '--json',


### PR DESCRIPTION
Sets a flag on the fidlc compiler invocation that accepts the
new syntax, in preparation for converting all SDK FIDL files
to the new syntax.