### PR TITLE
Update SDK regex to find macOS 12

### DIFF
--- a/build/mac/find_sdk.py
+++ b/build/mac/find_sdk.py
@@ -60,7 +60,7 @@ def main():
     sdk_dir = xcode43_sdk_path
   else:
     sdk_dir = os.path.join(out.rstrip(), 'SDKs')
-  sdks = [re.findall('^MacOSX(1[0|1]\.\d+)\.sdk$', s) for s in os.listdir(sdk_dir)]
+  sdks = [re.findall('^MacOSX(1[0-2]\.\d+)\.sdk$', s) for s in os.listdir(sdk_dir)]
   sdks = [s[0] for s in sdks if s]  # [['10.5'], ['10.6']] => ['10.5', '10.6']
   sdks = [s for s in sdks  # ['10.5', '10.6'] => ['10.6']
           if parse_version(s) >= parse_version(min_sdk_version)]


### PR DESCRIPTION
I can't build the engine on Xcode 13.
```
ERROR at //build/config/mac/mac_sdk.gni:38:7: Script returned non-zero exit code.
      exec_script("//build/mac/find_sdk.py", find_sdk_args, "list lines")
      ^----------
...
Traceback (most recent call last):
  File "/Users/m/Projects/engine/src/build/mac/find_sdk.py", line 101, in <module>
    print(main())
  File "/Users/m/Projects/engine/src/build/mac/find_sdk.py", line 68, in main
    raise Exception('No %s+ SDK found' % min_sdk_version)
Exception: No 10.12+ SDK found
```

The same issue as https://github.com/flutter/buildroot/pull/393.