### PR TITLE
Unblock clang rollers by suppressing new warnings

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -659,6 +659,8 @@ if (is_win) {
     # Disables.
     "-Wno-missing-field-initializers",  # "struct foo f = {0};"
     "-Wno-unused-parameter",  # Unused function parameters.
+    "-Wno-unused-but-set-parameter",  # Unused but set function parameters.
+    "-Wno-unused-but-set-variable",  # Unused but set variables.
   ]
 
   if (is_wasm) {


### PR DESCRIPTION
Most of these are in third-party deps. This suppresses all of them except for one in harfbuzz that I'm still trying to suppress:

```
../../third_party/harfbuzz/src/hb-subset-cff1.cc:405:33: error: variable 'supp_size' set but not used [-Werror,-Wunused-but-set-variable]
    unsigned int  size0, size1, supp_size;
                                ^
1 error generated.
```