### PR TITLE
Exclude new warning flags from xcode's toolchain, which doesn't support them

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -659,8 +659,6 @@ if (is_win) {
     # Disables.
     "-Wno-missing-field-initializers",  # "struct foo f = {0};"
     "-Wno-unused-parameter",  # Unused function parameters.
-    "-Wno-unused-but-set-parameter",  # Unused but set function parameters.
-    "-Wno-unused-but-set-variable",  # Unused but set variables.
   ]
 
   if (is_wasm) {
@@ -675,6 +673,8 @@ if (is_win) {
 
   if (!use_xcode) {
     default_warning_flags += [
+      "-Wno-unused-but-set-parameter",
+      "-Wno-unused-but-set-variable",
       "-Wno-implicit-int-float-conversion",
       "-Wno-c99-designator",
       "-Wno-deprecated-copy",


### PR DESCRIPTION
Next step to unblock https://github.com/flutter/engine/pull/27056