### PR TITLE
Use the framework label to import frameworks on Mac and iOS.

### DIFF
--- a/build/secondary/third_party/ocmock/BUILD.gn
+++ b/build/secondary/third_party/ocmock/BUILD.gn
@@ -101,7 +101,7 @@ source_set("ocmock_src") {
     "$ocmock_path/OCMock/OCProtocolMockObject.m",
   ]
 
-  libs = [ "Foundation.framework" ]
+  frameworks = [ "Foundation.framework" ]
 }
 
 shared_library("ocmock_shared") {


### PR DESCRIPTION
This is required in the latest versions of GN (which I am updating
to).