### PR TITLE
More changes required for the GN updates.

### DIFF
--- a/build/secondary/third_party/swiftshader_flutter/BUILD.gn
+++ b/build/secondary/third_party/swiftshader_flutter/BUILD.gn
@@ -33,7 +33,10 @@ config("internal_config") {
       "/wd5030",
     ]
 
-    libs = [ "user32.lib", "gdi32.lib" ]
+    libs = [
+      "user32.lib",
+      "gdi32.lib",
+    ]
   } else {
     cflags = [
       "-Wno-header-hygiene",
@@ -305,16 +308,12 @@ source_set("wsi") {
   }
 
   if (is_win) {
-    sources += [
-      "$source_root/src/WSI/Win32SurfaceKHR.cpp",
-    ]
+    sources += [ "$source_root/src/WSI/Win32SurfaceKHR.cpp" ]
   }
 
   if (is_mac) {
-    sources += [
-      "$source_root/src/WSI/MetalSurface.mm",
-    ]
-    libs = [
+    sources += [ "$source_root/src/WSI/MetalSurface.mm" ]
+    frameworks = [
       "Cocoa.framework",
       "QuartzCore.framework",
     ]
@@ -343,9 +342,7 @@ source_set("reactor") {
     "$source_root/src/Reactor/Reactor.cpp",
   ]
 
-  deps = [
-    ":subzero",
-  ]
+  deps = [ ":subzero" ]
 }
 
 source_set("renderer") {
@@ -379,9 +376,7 @@ source_set("renderer") {
     "$source_root/src/Renderer/VertexProcessor.cpp",
   ]
 
-  deps = [
-    ":shader",
-  ]
+  deps = [ ":shader" ]
 }
 
 source_set("marl") {
@@ -552,9 +547,7 @@ source_set("opengl_compiler") {
     sources += [ "$source_root/src/OpenGL/compiler/ossource_posix.cpp" ]
   }
 
-  deps = [
-    ":opengl_preprocessor",
-  ]
+  deps = [ ":opengl_preprocessor" ]
 }
 
 source_set("shader") {
@@ -584,9 +577,7 @@ source_set("shader") {
     "$source_root/src/Shader/VertexShader.cpp",
   ]
 
-  deps = [
-    ":main",
-  ]
+  deps = [ ":main" ]
 }
 
 source_set("system") {
@@ -618,11 +609,8 @@ source_set("system") {
   ]
 
   if (is_linux || is_android) {
-    sources += [
-      "$source_root/src/System/Linux/MemFd.cpp",
-    ]
+    sources += [ "$source_root/src/System/Linux/MemFd.cpp" ]
   }
-
 }
 
 source_set("device") {
@@ -636,8 +624,10 @@ source_set("device") {
     configs -= [ "//build/config/win:unicode" ]
   }
 
-  include_dirs = [ "$source_root/third_party/SPIRV-Headers/include",
-  "$source_root/third_party/marl/include", ]
+  include_dirs = [
+    "$source_root/third_party/SPIRV-Headers/include",
+    "$source_root/third_party/marl/include",
+  ]
 
   sources = [
     "$source_root/src/Device/Blitter.cpp",
@@ -690,9 +680,7 @@ source_set("main") {
     ]
   }
 
-  deps = [
-    ":common",
-  ]
+  deps = [ ":common" ]
 }
 
 shared_library("egl") {
@@ -741,7 +729,7 @@ shared_library("egl") {
   }
 
   if (is_mac) {
-    libs = [
+    frameworks = [
       "IOSurface.framework",
       "QuartzCore.framework",
       "AppKit.framework",
@@ -815,9 +803,10 @@ shared_library("gles") {
 
   libs = []
   ldflags = []
+  frameworks = []
 
   if (is_mac) {
-    libs += [
+    frameworks += [
       "IOSurface.framework",
       "QuartzCore.framework",
       "ImageIO.framework",
@@ -873,17 +862,21 @@ shared_library("vulkan") {
     output_name = "libvk_swiftshader"
   }
 
-  configs += [ ":internal_config",
-               ":swiftshader_libvulkan_private_config", ]
+  configs += [
+    ":internal_config",
+    ":swiftshader_libvulkan_private_config",
+  ]
   configs -= [ "//build/config/compiler:cxx_version_default" ]
   configs += [ "//build/config/compiler:cxx_version_14" ]
 
   public_configs = [ ":swiftshader_config" ]
 
-  include_dirs = [ "$source_root/src/Vulkan",
-                   "$source_root/third_party/marl/include",
-    "$source_root/third_party/SPIRV-Headers/include", 
-    "$source_root/third_party/SPIRV-Tools/include",]
+  include_dirs = [
+    "$source_root/src/Vulkan",
+    "$source_root/third_party/marl/include",
+    "$source_root/third_party/SPIRV-Headers/include",
+    "$source_root/third_party/SPIRV-Tools/include",
+  ]
 
   public = []
 
@@ -924,13 +917,13 @@ shared_library("vulkan") {
   ]
 
   deps = [
-    ":marl",
+    ":SPIRV-Tools",
     ":device",
+    ":marl",
     ":pipeline",
     ":reactor",
-    ":wsi",
     ":system",
-    ":SPIRV-Tools",
+    ":wsi",
   ]
 
   libs = []
@@ -940,14 +933,14 @@ shared_library("vulkan") {
     ldflags = [
       "-Wl,-install_name,@rpath/libvk_swiftshader.dylib",
       "-Wl,-exported_symbols_list," +
-          rebase_path("$source_root/src/Vulkan/vk_swiftshader.exports", root_build_dir),
+          rebase_path("$source_root/src/Vulkan/vk_swiftshader.exports",
+                      root_build_dir),
     ]
   } else if (is_linux || is_fuchsia) {
-    inputs = [
-      "$source_root/src/Vulkan/vk_swiftshader.lds",
-    ]
+    inputs = [ "$source_root/src/Vulkan/vk_swiftshader.lds" ]
     ldflags = [ "-Wl,--version-script=" +
-                rebase_path("$source_root/src/Vulkan/vk_swiftshader.lds", root_build_dir) ]
+                rebase_path("$source_root/src/Vulkan/vk_swiftshader.lds",
+                            root_build_dir) ]
   }
 }
 
@@ -967,9 +960,7 @@ group("swiftshader_gl") {
 }
 
 group("swiftshader_vulkan") {
-  deps = [
-    ":vulkan",
-  ]
+  deps = [ ":vulkan" ]
 }
 
 spirv_headers = "//third_party/swiftshader/third_party/SPIRV-Headers"
@@ -989,9 +980,7 @@ template("spvtools_core_tables") {
     operand_kinds_file = "${target_gen_dir}/operand.kinds-$version.inc"
     extinst_file = "$spirv_tools/source/extinst.debuginfo.grammar.json"
 
-    sources = [
-      core_json_file,
-    ]
+    sources = [ core_json_file ]
     outputs = [
       core_insts_file,
       operand_kinds_file,
@@ -1033,9 +1022,7 @@ template("spvtools_core_enums") {
       "--enum-string-mapping-output",
       rebase_path(extension_map_file, root_build_dir),
     ]
-    inputs = [
-      core_json_file,
-    ]
+    inputs = [ core_json_file ]
     outputs = [
       extension_enum_file,
       extension_map_file,
@@ -1071,9 +1058,7 @@ template("spvtools_glsl_tables") {
       core_json_file,
       glsl_json_file,
     ]
-    outputs = [
-      glsl_insts_file,
-    ]
+    outputs = [ glsl_insts_file ]
   }
 }
 
@@ -1105,9 +1090,7 @@ template("spvtools_opencl_tables") {
       core_json_file,
       opengl_json_file,
     ]
-    outputs = [
-      opencl_insts_file,
-    ]
+    outputs = [ opencl_insts_file ]
   }
 }
 
@@ -1129,12 +1112,8 @@ template("spvtools_language_header") {
       "--extinst-output-base",
       rebase_path(extinst_output_base, root_build_dir),
     ]
-    inputs = [
-      debug_insts_file,
-    ]
-    outputs = [
-      "${extinst_output_base}.h",
-    ]
+    inputs = [ debug_insts_file ]
+    outputs = [ "${extinst_output_base}.h" ]
   }
 }
 
@@ -1154,12 +1133,8 @@ template("spvtools_vendor_table") {
       "--vendor-insts-output",
       rebase_path(extinst_file, root_build_dir),
     ]
-    inputs = [
-      extinst_vendor_grammar,
-    ]
-    outputs = [
-      extinst_file,
-    ]
+    inputs = [ extinst_vendor_grammar ]
+    outputs = [ extinst_file ]
   }
 }
 
@@ -1170,12 +1145,8 @@ action("spvtools_generators_inc") {
   xml_file = "${spirv_headers}/include/spirv/spir-v.xml"
   inc_file = "${target_gen_dir}/generators.inc"
 
-  sources = [
-    xml_file,
-  ]
-  outputs = [
-    inc_file,
-  ]
+  sources = [ xml_file ]
+  outputs = [ inc_file ]
   args = [
     "--xml",
     rebase_path(xml_file, root_build_dir),
@@ -1190,9 +1161,7 @@ action("spvtools_build_version") {
   src_dir = "."
   inc_file = "${target_gen_dir}/build-version.inc"
 
-  outputs = [
-    inc_file,
-  ]
+  outputs = [ inc_file ]
   args = [
     rebase_path(src_dir, root_build_dir),
     rebase_path(inc_file, root_build_dir),
@@ -1243,8 +1212,10 @@ config("spvtools_internal_config") {
   configs = [ ":spvtools_public_config" ]
 
   if (is_clang) {
-    cflags = [ "-Wno-implicit-fallthrough",
-    "-Wno-newline-eof" ]
+    cflags = [
+      "-Wno-implicit-fallthrough",
+      "-Wno-newline-eof",
+    ]
   }
 }
 
@@ -1319,9 +1290,7 @@ source_set("spvtools") {
     "$spirv_tools/source/util/timer.h",
   ]
 
-  public_deps = [
-    ":spvtools_core_enums_unified1",
-  ]
+  public_deps = [ ":spvtools_core_enums_unified1" ]
 
   configs += [ ":spvtools_internal_config" ]
 }
@@ -1372,9 +1341,7 @@ source_set("spvtools_val") {
     "$spirv_tools/source/val/validation_state.cpp",
   ]
 
-  deps = [
-    ":spvtools",
-  ]
+  deps = [ ":spvtools" ]
   configs += [ ":spvtools_internal_config" ]
 }
 
@@ -1598,9 +1565,7 @@ source_set("spvtools_opt") {
 }
 
 source_set("spvtools_link") {
-  sources = [
-    "$spirv_tools/source/link/linker.cpp",
-  ]
+  sources = [ "$spirv_tools/source/link/linker.cpp" ]
   deps = [
     ":spvtools",
     ":spvtools_opt",


### PR DESCRIPTION
These should have been a part of 647c7f8935017e00bcabe82f0bc3a8aa327521f5. But the switfshader targets are apparently not built on non-x64 hosts. So running the updated GN was not failing on M1 hosts.