### PR TITLE
Initial import of coverage build files from upstream Chromium

### DIFF
--- a/build/config/coverage/BUILD.gn
+++ b/build/config/coverage/BUILD.gn
@@ -1,0 +1,23 @@
+# Copyright 2017 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//build/config/coverage/coverage.gni")
+
+config("default_coverage") {
+  if (use_clang_coverage) {
+    cflags = [
+      "-fprofile-instr-generate",
+      "-fcoverage-mapping",
+      "-fno-use-cxa-atexit",
+
+      # Following experimental flags removes unused header functions from the
+      # coverage mapping data embedded in the test binaries, and the reduction
+      # of binary size enables building Chrome's large unit test targets on
+      # MacOS. Please refer to crbug.com/796290 for more details.
+      "-mllvm",
+      "-limited-coverage-experimental=true",
+    ]
+    ldflags = [ "-fprofile-instr-generate" ]
+  }
+}

--- a/build/config/coverage/coverage.gni
+++ b/build/config/coverage/coverage.gni
@@ -1,0 +1,13 @@
+# Copyright 2017 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//build/toolchain/toolchain.gni")
+
+declare_args() {
+  # Enable Clang's Source-based Code Coverage.
+  use_clang_coverage = false
+}
+
+assert(!use_clang_coverage || is_clang,
+       "Clang Source-based Code Coverage requires clang.")


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/86385

This imports the upstream GN configs for enabling coverage instrumentation.