### PR TITLE
Disallow usages of old FIDL syntax

### DIFF
--- a/build/fuchsia/fidl_gen_cpp.py
+++ b/build/fuchsia/fidl_gen_cpp.py
@@ -54,7 +54,7 @@ def main():
   fidlc_command = [
     args.fidlc_bin,
     '--experimental',
-    'allow_new_syntax',
+    'new_syntax_only',
     '--tables',
     args.output_c_tables,
     '--json',


### PR DESCRIPTION
As the penultimate step of the FIDL syntax migration,
block new usages of the old syntax. This will allow
us to remove support for the old syntax and
remove the experimental flag as the final cleanup
step.