### PR TITLE
Fix vs_toolchain.py for Python 3

### DIFF
--- a/build/vs_toolchain.py
+++ b/build/vs_toolchain.py
@@ -295,17 +295,16 @@ def _CopyUCRTRuntime(target_dir, source_dir, target_cpu, dll_pattern, suffix):
     if not suffix.startswith('.'):
       # ucrtbased.dll is located at {win_sdk_dir}/bin/{a.b.c.d}/{target_cpu}/
       # ucrt/.
-      sdk_redist_root = os.path.join(win_sdk_dir, 'bin')
-      sdk_bin_sub_dirs = os.listdir(sdk_redist_root)
+      sdk_bin_root = os.path.join(win_sdk_dir, 'bin')
+      sdk_bin_sub_dirs = glob.glob(os.path.join(sdk_bin_root, '10.*'))
       # Select the most recent SDK if there are multiple versions installed.
       _SortByHighestVersionNumberFirst(sdk_bin_sub_dirs)
       for directory in sdk_bin_sub_dirs:
-        sdk_redist_root_version = os.path.join(sdk_redist_root, directory)
+        sdk_redist_root_version = os.path.join(sdk_bin_root, directory)
         if not os.path.isdir(sdk_redist_root_version):
           continue
-        if re.match(r'10\.\d+\.\d+\.\d+', directory):
-          source_dir = os.path.join(sdk_redist_root_version, target_cpu, 'ucrt')
-          break
+        source_dir = os.path.join(sdk_redist_root_version, target_cpu, 'ucrt')
+        break
     _CopyRuntimeImpl(os.path.join(target_dir, 'ucrtbase' + suffix),
                      os.path.join(source_dir, 'ucrtbase' + suffix))
 


### PR DESCRIPTION
vs_toolchain.py gets a directory listing for win_sdk_dir\bin and then
sorts it by converting the 10.x.x.x directory names to tuples of
integers. This fails on Python 3 because int and str types are not
comparable so directories with non-integral (non-version) names caused
comparison failures when compared against integral (version) names. This
change filters out the unwanted names before sorting instead of after
sorting, which lets this work on Python 3 (tested by running manually).

A misleading variable name was also changed.

Ported from Chromium patch:
https://chromium-review.googlesource.com/c/chromium/src/+/2309454