### PR TITLE
Migrate print functions and exceptions to Python 3

### DIFF
--- a/build/apply_locales.py
+++ b/build/apply_locales.py
@@ -20,7 +20,7 @@ def main(argv):
   (options, arglist) = parser.parse_args(argv)
 
   if len(arglist) < 3:
-    print 'ERROR: need string and list of locales'
+    print('ERROR: need string and list of locales')
     return 1
 
   str_template = arglist[1]
@@ -39,7 +39,7 @@ def main(argv):
 
   # Quote each element so filename spaces don't mess up GYP's attempt to parse
   # it into a list.
-  print ' '.join(["'%s'" % x for x in results])
+  print(' '.join(["'%s'" % x for x in results]))
 
 if __name__ == '__main__':
   sys.exit(main(sys.argv))

--- a/build/check_return_value.py
+++ b/build/check_return_value.py
@@ -12,6 +12,6 @@ import sys
 
 devnull = open(os.devnull, 'wb')
 if not subprocess.call(sys.argv[1:], stdout=devnull, stderr=devnull):
-  print 1
+  print(1)
 else:
-  print 0
+  print(0)

--- a/build/compiler_version.py
+++ b/build/compiler_version.py
@@ -19,9 +19,9 @@ compiler_version_cache = {}  # Map from (compiler, tool) -> version.
 
 
 def Usage(program_name):
-  print '%s MODE TOOL' % os.path.basename(program_name)
-  print 'MODE: host or target.'
-  print 'TOOL: assembler or compiler or linker.'
+  print('%s MODE TOOL' % os.path.basename(program_name))
+  print('MODE: host or target.')
+  print('TOOL: assembler or compiler or linker.')
   return 1
 
 
@@ -91,24 +91,24 @@ def GetVersion(compiler, tool):
     result = parsed_output.group(1) + parsed_output.group(2)
     compiler_version_cache[cache_key] = result
     return result
-  except Exception, e:
+  except Exception as e:
     if tool_error:
       sys.stderr.write(tool_error)
-    print >> sys.stderr, "compiler_version.py failed to execute:", compiler
-    print >> sys.stderr, e
+    print("compiler_version.py failed to execute:", compiler, file=sys.stderr)
+    print(e, file=sys.stderr)
     return ""
 
 
 def main(args):
   try:
     (mode, tool) = ParseArgs(args[1:])
-  except Exception, e:
+  except Exception as e:
     sys.stderr.write(e.message + '\n\n')
     return Usage(args[0])
 
   ret_code, result = ExtractVersion(mode, tool)
   if ret_code == 0:
-    print result
+    print(result)
   return ret_code
 
 

--- a/build/config/linux/pkg-config.py
+++ b/build/config/linux/pkg-config.py
@@ -3,7 +3,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-from __future__ import print_function
+
 
 import json
 import os

--- a/build/copy_test_data_ios.py
+++ b/build/copy_test_data_ios.py
@@ -94,11 +94,11 @@ def DoMain(argv):
 def main(argv):
   try:
     result = DoMain(argv[1:])
-  except WrongNumberOfArgumentsException, e:
-    print >>sys.stderr, e
+  except WrongNumberOfArgumentsException as e:
+    print(e, file=sys.stderr)
     return 1
   if result:
-    print result
+    print(result)
   return 0
 
 if __name__ == '__main__':

--- a/build/detect_host_arch.py
+++ b/build/detect_host_arch.py
@@ -37,4 +37,4 @@ def DoMain(_):
   return HostArch()
 
 if __name__ == '__main__':
-  print DoMain([])
+  print(DoMain([]))

--- a/build/download_nacl_toolchains.py
+++ b/build/download_nacl_toolchains.py
@@ -21,9 +21,9 @@ def Main(args):
   package_version_dir = os.path.join(nacl_build_dir, 'package_version')
   package_version = os.path.join(package_version_dir, 'package_version.py')
   if not os.path.exists(package_version):
-    print "Can't find '%s'" % package_version
-    print 'Presumably you are intentionally building without NativeClient.'
-    print 'Skipping NativeClient toolchain download.'
+    print("Can't find '%s'" % package_version)
+    print('Presumably you are intentionally building without NativeClient.')
+    print('Skipping NativeClient toolchain download.')
     sys.exit(0)
   sys.path.insert(0, package_version_dir)
   import package_version
@@ -40,7 +40,7 @@ def Main(args):
     if 'pnacl' in buildbot_name and 'sdk' in buildbot_name:
       use_pnacl = True
     if use_pnacl:
-      print '\n*** DOWNLOADING PNACL TOOLCHAIN ***\n'
+      print('\n*** DOWNLOADING PNACL TOOLCHAIN ***\n')
     else:
       args = ['--exclude', 'pnacl_newlib'] + args
 

--- a/build/extract_from_cab.py
+++ b/build/extract_from_cab.py
@@ -17,12 +17,12 @@ def run_quiet(*args):
   out, _ = popen.communicate()
   if popen.returncode:
     # expand emits errors to stdout, so if we fail, then print that out.
-    print out
+    print(out)
   return popen.returncode
 
 def main():
   if len(sys.argv) != 4:
-    print 'Usage: extract_from_cab.py cab_path archived_file output_dir'
+    print('Usage: extract_from_cab.py cab_path archived_file output_dir')
     return 1
 
   [cab_path, archived_file, output_dir] = sys.argv[1:]

--- a/build/get_landmines.py
+++ b/build/get_landmines.py
@@ -30,7 +30,7 @@ def print_landmines():
   # dependency problems, fix the dependency problems instead of adding a
   # landmine.
 
-  print 'Lets start a new landmines file.'
+  print("Let's start a new landmines file.")
 
 
 def main():

--- a/build/get_sdk_extras_packages.py
+++ b/build/get_sdk_extras_packages.py
@@ -18,7 +18,7 @@ def main():
   for package in packages:
     out.append(package['package_id'])
 
-  print ','.join(out)
+  print(','.join(out))
 
 if __name__ == '__main__':
   sys.exit(main())

--- a/build/gn_helpers.py
+++ b/build/gn_helpers.py
@@ -15,7 +15,7 @@ def ToGNString(value, allow_dicts = True):
   allow_dicts indicates if this function will allow converting dictionaries
   to GN scopes. This is only possible at the top level, you can't nest a
   GN scope in a list, so this should be set to False for recursive calls."""
-  if isinstance(value, str) or isinstance(value, unicode):
+  if isinstance(value, str) or isinstance(value, str):
     if value.find('\n') >= 0:
       raise GNException("Trying to print a string with a newline in it.")
     return '"' + value.replace('"', '\\"') + '"'

--- a/build/install-build-deps.py
+++ b/build/install-build-deps.py
@@ -375,7 +375,7 @@ def quick_check(packages):
       'dpkg-query', '-W', '-f', '${PackageSpec}:${Status}\n'] + list(packages))
   if rc == 0 and not stderr:
     return 0
-  print stderr
+  print(stderr)
   return 1
 
 
@@ -391,8 +391,8 @@ def main(argv):
 
   lsb_codename = lsb_release_short_codename()
   if not args.unsupported and not args.quick_check:
-    if lsb_codename not in map(
-        operator.itemgetter('codename'), SUPPORTED_UBUNTU_VERSIONS):
+    if lsb_codename not in list(map(
+        operator.itemgetter('codename'), SUPPORTED_UBUNTU_VERSIONS)):
       supported_ubuntus = ['%(number)s (%(codename)s)' % v
                            for v in SUPPORTED_UBUNTU_VERSIONS]
       write_error('Only Ubuntu %s are currently supported.' %
@@ -404,10 +404,10 @@ def main(argv):
       return 1
 
   if os.geteuid() != 0 and not args.quick_check:
-    print 'Running as non-root user.'
-    print 'You might have to enter your password one or more times'
-    print 'for \'sudo\'.'
-    print
+    print('Running as non-root user.')
+    print('You might have to enter your password one or more times')
+    print('for \'sudo\'.')
+    print()
 
   compute_dynamic_package_lists()
 

--- a/build/inverse_depth.py
+++ b/build/inverse_depth.py
@@ -14,9 +14,9 @@ def DoMain(argv):
 
 def main(argv):
   if len(argv) < 2:
-    print "USAGE: inverse_depth.py depth"
+    print("USAGE: inverse_depth.py depth")
     return 1
-  print DoMain(argv[1:])
+  print(DoMain(argv[1:]))
   return 0
 
 

--- a/build/linux/dump_app_syms.py
+++ b/build/linux/dump_app_syms.py
@@ -10,8 +10,8 @@ import subprocess
 import sys
 
 if len(sys.argv) != 5:
-  print "dump_app_syms.py <dump_syms_exe> <strip_binary>"
-  print "                 <binary_with_symbols> <symbols_output>"
+  print("dump_app_syms.py <dump_syms_exe> <strip_binary>")
+  print("                 <binary_with_symbols> <symbols_output>")
   sys.exit(1)
 
 dumpsyms = sys.argv[1]

--- a/build/linux/install-chromeos-fonts.py
+++ b/build/linux/install-chromeos-fonts.py
@@ -20,15 +20,15 @@ FONTS_DIR = '/usr/local/share/fonts'
 
 def main(args):
   if not sys.platform.startswith('linux'):
-    print "Error: %s must be run on Linux." % __file__
+    print("Error: %s must be run on Linux." % __file__)
     return 1
 
   if os.getuid() != 0:
-    print "Error: %s must be run as root." % __file__
+    print("Error: %s must be run as root." % __file__)
     return 1
 
   if not os.path.isdir(FONTS_DIR):
-    print "Error: Destination directory does not exist: %s" % FONTS_DIR
+    print("Error: Destination directory does not exist: %s" % FONTS_DIR)
     return 1
 
   dest_dir = os.path.join(FONTS_DIR, 'chromeos')
@@ -37,15 +37,15 @@ def main(args):
   if os.path.exists(stamp):
     with open(stamp) as s:
       if s.read() == URL:
-        print "Chrome OS fonts already up-to-date in %s." % dest_dir
+        print("Chrome OS fonts already up-to-date in %s." % dest_dir)
         return 0
 
   if os.path.isdir(dest_dir):
     shutil.rmtree(dest_dir)
   os.mkdir(dest_dir)
-  os.chmod(dest_dir, 0755)
+  os.chmod(dest_dir, 0o755)
 
-  print "Installing Chrome OS fonts to %s." % dest_dir
+  print("Installing Chrome OS fonts to %s." % dest_dir)
   tarball = os.path.join(dest_dir, os.path.basename(URL))
   subprocess.check_call(['curl', '-L', URL, '-o', tarball])
   subprocess.check_call(['tar', '--no-same-owner', '--no-same-permissions',
@@ -63,9 +63,9 @@ def main(args):
 
   for base, dirs, files in os.walk(dest_dir):
     for dir in dirs:
-      os.chmod(os.path.join(base, dir), 0755)
+      os.chmod(os.path.join(base, dir), 0o755)
     for file in files:
-      os.chmod(os.path.join(base, file), 0644)
+      os.chmod(os.path.join(base, file), 0o644)
 
   return 0
 

--- a/build/linux/rewrite_dirs.py
+++ b/build/linux/rewrite_dirs.py
@@ -63,7 +63,7 @@ def main(argv):
 
   for line in sys.stdin.readlines():
     line = RewriteLine(line.strip(), opts)
-    print line
+    print(line)
   return 0
 
 

--- a/build/linux/unbundle/remove_bundled_libraries.py
+++ b/build/linux/unbundle/remove_bundled_libraries.py
@@ -21,8 +21,8 @@ def DoMain(argv):
     os.path.join(my_dirname, '..', '..', '..'))
 
   if os.path.join(source_tree_root, 'build', 'linux', 'unbundle') != my_dirname:
-    print ('Sanity check failed: please run this script from ' +
-           'build/linux/unbundle directory.')
+    print(('Sanity check failed: please run this script from ' +
+           'build/linux/unbundle directory.'))
     return 1
 
   parser = optparse.OptionParser()
@@ -80,20 +80,20 @@ def DoMain(argv):
         os.remove(path)
       else:
         # By default just print paths that would be removed.
-        print path
+        print(path)
 
   exit_code = 0
 
   # Fail if exclusion list contains stale entries - this helps keep it
   # up to date.
-  for exclusion, used in exclusion_used.iteritems():
+  for exclusion, used in exclusion_used.items():
     if not used:
-      print '%s does not exist' % exclusion
+      print('%s does not exist' % exclusion)
       exit_code = 1
 
   if not options.do_remove:
-    print ('To actually remove files printed above, please pass ' +
-           '--do-remove flag.')
+    print(('To actually remove files printed above, please pass ' +
+           '--do-remove flag.'))
 
   return exit_code
 

--- a/build/mac/find_sdk.py
+++ b/build/mac/find_sdk.py
@@ -98,4 +98,4 @@ def main():
 if __name__ == '__main__':
   if sys.platform != 'darwin':
     raise Exception("This script only runs on Mac")
-  print(main())
+  print((main()))

--- a/build/mac/tweak_info_plist.py
+++ b/build/mac/tweak_info_plist.py
@@ -68,7 +68,7 @@ def _AddVersionKeys(plist, version=None):
   if version:
     match = re.match('\d+\.\d+\.(\d+\.\d+)$', version)
     if not match:
-      print >>sys.stderr, 'Invalid version string specified: "%s"' % version
+      print('Invalid version string specified: "%s"' % version, file=sys.stderr)
       return False
 
     full_version = match.group(0)
@@ -127,7 +127,7 @@ def _DoSCMKeys(plist, add_keys):
   if scm_revision != None:
     plist['SCMRevision'] = scm_revision
   elif add_keys:
-    print >>sys.stderr, 'Could not determine SCM revision.  This may be OK.'
+    print('Could not determine SCM revision.  This may be OK.', file=sys.stderr)
 
   return True
 
@@ -165,9 +165,9 @@ def _TagSuffixes():
   components_len = len(components)
   combinations = 1 << components_len
   tag_suffixes = []
-  for combination in xrange(0, combinations):
+  for combination in range(0, combinations):
     tag_suffix = ''
-    for component_index in xrange(0, components_len):
+    for component_index in range(0, components_len):
       if combination & (1 << component_index):
         tag_suffix += '-' + components[component_index]
     tag_suffixes.append(tag_suffix)
@@ -221,7 +221,7 @@ def Main(argv):
   (options, args) = parser.parse_args(argv)
 
   if len(args) > 0:
-    print >>sys.stderr, parser.get_usage()
+    print(parser.get_usage(), file=sys.stderr)
     return 1
 
   # Read the plist into its parsed format.
@@ -235,7 +235,7 @@ def Main(argv):
   # Add Breakpad if configured to do so.
   if options.use_breakpad:
     if options.branding is None:
-      print >>sys.stderr, 'Use of Breakpad requires branding.'
+      print('Use of Breakpad requires branding.', file=sys.stderr)
       return 1
     _AddBreakpadKeys(plist, options.branding)
     if options.breakpad_uploads:
@@ -254,7 +254,7 @@ def Main(argv):
   # Only add Keystone in Release builds.
   if options.use_keystone and env['CONFIGURATION'] == 'Release':
     if options.bundle_identifier is None:
-      print >>sys.stderr, 'Use of Keystone requires the bundle id.'
+      print('Use of Keystone requires the bundle id.', file=sys.stderr)
       return 1
     _AddKeystoneKeys(plist, options.bundle_identifier)
   else:

--- a/build/protoc_java.py
+++ b/build/protoc_java.py
@@ -37,7 +37,7 @@ def main(argv):
 
   build_utils.CheckOptions(options, parser, ['protoc', 'proto_path'])
   if not options.java_out_dir and not options.srcjar:
-    print 'One of --java-out-dir or --srcjar must be specified.'
+    print('One of --java-out-dir or --srcjar must be specified.')
     return 1
 
   with build_utils.TempDir() as temp_dir:

--- a/build/win/importlibs/filter_export_list.py
+++ b/build/win/importlibs/filter_export_list.py
@@ -77,7 +77,7 @@ def main():
     found_exports = set(master_mapping.values()) - set(found_exports)
 
   # Sort the found exports for tidy output.
-  print '\n'.join(sorted(found_exports))
+  print('\n'.join(sorted(found_exports)))
   return 0
 
 

--- a/build/win/use_ansi_codes.py
+++ b/build/win/use_ansi_codes.py
@@ -7,4 +7,4 @@
 import os
 
 # Add more terminals here as needed.
-print 'ANSICON' in os.environ
+print('ANSICON' in os.environ)

--- a/build/win_is_xtree_patched.py
+++ b/build/win_is_xtree_patched.py
@@ -23,4 +23,4 @@ def DoMain(_):
 
 
 if __name__ == '__main__':
-  print DoMain([])
+  print(DoMain([]))

--- a/tools/find_depot_tools.py
+++ b/tools/find_depot_tools.py
@@ -36,7 +36,7 @@ def add_depot_tools_to_path():
       return i
     previous_dir = root_dir
     root_dir = os.path.dirname(root_dir)
-  print >> sys.stderr, 'Failed to find depot_tools'
+  print('Failed to find depot_tools', file=sys.stderr)
   return None
 
 add_depot_tools_to_path()


### PR DESCRIPTION
Migrates print statements and exception syntax to Python 3 in scripts
involved in gclient runhooks.

Also fixes a missing apostrophe in "Let's".

Issue: flutter/flutter#83043