### PR TITLE
Don't export libcxxabi symbols

### DIFF
--- a/build/secondary/third_party/libcxxabi/BUILD.gn
+++ b/build/secondary/third_party/libcxxabi/BUILD.gn
@@ -3,7 +3,10 @@
 # found in the LICENSE file.
 
 config("libcxxabi_config") {
-  common_cc_flags = [ "-nostdinc++" ]
+  common_cc_flags = [
+    "-nostdinc++",
+    "-fvisibility=hidden",
+  ]
 
   cflags_cc = common_cc_flags
   cflags_objcc = common_cc_flags
@@ -20,6 +23,7 @@ source_set("libcxxabi") {
     "_LIBCXXABI_NO_EXCEPTIONS",
     "_LIBCXXABI_BUILDING_LIBRARY",
     "LIBCXXABI_SILENT_TERMINATE",
+    "_LIBCXXABI_DISABLE_VISIBILITY_ANNOTATIONS",
   ]
 
   sources = []


### PR DESCRIPTION
These symbols end up getting included in the export tables of both libEGL and libGLESv2, which results in an ODR violation when both of these libs are linked by swiftshader.

Fixes flutter/flutter#86727.