### PR TITLE
Add src/gradle to the gitignore in the buildroot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ Thumbs.db
 # directories pulled in via deps or hooks
 /buildtools/
 /flutter/
+/gradle/
 /ios_tools/
 /out/
 


### PR DESCRIPTION
Gradle is now a dependency in flutter/DEPS
(see https://github.com/flutter/engine/commit/22af55c9349759db81c9577cec25a58ae2d81c4f)