### PR TITLE
Revert "Use vpython3 from depot_tools (#501)"

### DIFF
--- a/.gn
+++ b/.gn
@@ -1,9 +1,9 @@
 # This file is used by the experimental meta-buildsystem in src/tools/gn to
 # find the root of the source tree and to set startup options.
 
-# Use vython3 from depot_tools for exec_script() calls.
+# Use Python 3 for exec_script() calls.
 # See `gn help dotfile` for details.
-script_executable = "vpython3"
+script_executable = "python3"
 
 # The location of the build configuration file.
 buildconfig = "//build/config/BUILDCONFIG.gn"


### PR DESCRIPTION
This reverts commit 8b8c0c7524bab7a84c437644a4a786150bcfab4b.

We've seen flakiness with the following error on Windows since this
patch landed:

```
Using base prefix 'C:\\b\\s\\w\\ir\\cipd_bin_packages\\cpython3\\bin'
Traceback (most recent call last):
  File "virtualenv.py", line 2642, in <module>
    main()
  File "virtualenv.py", line 859, in main
    create_environment(
  File "virtualenv.py", line 1161, in create_environment
    install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages=site_packages, clear=clear, symlink=symlink)
  File "virtualenv.py", line 1450, in install_python
    copy_required_modules(home_dir, symlink)
  File "virtualenv.py", line 1342, in copy_required_modules
    copyfile(filename, dst_filename, symlink)
  File "virtualenv.py", line 425, in copyfile
    copy_file_or_folder(src, dest, symlink)
  File "virtualenv.py", line 400, in copy_file_or_folder
    shutil.copytree(src, dest, symlink)
  File "C:\b\s\w\ir\cipd_bin_packages\cpython3\bin\lib\shutil.py", line 557, in copytree
    return _copytree(entries=entries, src=src, dst=dst, symlinks=symlinks,
  File "C:\b\s\w\ir\cipd_bin_packages\cpython3\bin\lib\shutil.py", line 513, in _copytree
    raise Error(errors)
shutil.Error: [('C:\\b\\s\\w\\ir\\cipd_bin_packages\\cpython3\\bin\\lib\\encodings\\__pycache__\\utf_8.cpython-38.pyc.2398892502592', 'C:\\b\\s\\w\\ir\\cache\\vpython\\51ae26\\lib\\encodings\\__pycache__\\utf_8.cpython-38.pyc.2398892502592', "[Errno 2] No such file or directory: 'C:\\\\b\\\\s\\\\w\\\\ir\\\\cipd_bin_packages\\\\cpython3\\\\bin\\\\lib\\\\encodings\\\\__pycache__\\\\utf_8.cpython-38.pyc.2398892502592'")]
```

Issue: https://github.com/flutter/flutter/issues/88719