### PR TITLE
Re-land "Use vpython3 from depot_tools (#501)"

### DIFF
--- a/.gn
+++ b/.gn
@@ -1,9 +1,9 @@
 # This file is used by the experimental meta-buildsystem in src/tools/gn to
 # find the root of the source tree and to set startup options.
 
-# Use Python 3 for exec_script() calls.
+# Use vython3 from depot_tools for exec_script() calls.
 # See `gn help dotfile` for details.
-script_executable = "python3"
+script_executable = "vpython3"
 
 # The location of the build configuration file.
 buildconfig = "//build/config/BUILDCONFIG.gn"


### PR DESCRIPTION
This reverts commit 6ef1bf72e34e572f469386732a05de7c8495f874.

Rolling the revert in flutter/buildroot#507 breaks the Fuchsia build,
which requires a Python 3 distribution that includes the `yaml` module.
Instead, I landed https://github.com/flutter/engine/pull/28314, which
enables vpython3 for runs of the `gn` wrapper on Windows, via the
`gn.bat` batch script. That seems to have eliminated the flakiness we
were seeing on the engine Windows bots.

Issue: https://github.com/flutter/flutter/issues/88719