### PR TITLE
Drop support for iOS 8.0.

### DIFF
--- a/build/config/ios/ios_sdk.gni
+++ b/build/config/ios/ios_sdk.gni
@@ -16,7 +16,7 @@ declare_args() {
   use_ios_simulator = true
 
   # Version of iOS that we're targeting.
-  ios_deployment_target = "8.0"
+  ios_deployment_target = "9.0"
 
   # The path to the iOS device SDK.
   ios_device_sdk_path = ""


### PR DESCRIPTION
A presubmit with this rolled in has already been tried and passed in https://github.com/flutter/engine/pull/28572.