### PR TITLE
Update gn_run_binary.py

### DIFF
--- a/build/gn_run_binary.py
+++ b/build/gn_run_binary.py
@@ -20,7 +20,7 @@ path = './' + sys.argv[1]
 args = [path] + sys.argv[2:]
 
 try:
-  subprocess.check_output(args, stderr=subprocess.STDOUT, text=True)
+  subprocess.check_output(args, stderr=subprocess.STDOUT, universal_newlines=True)
 except subprocess.CalledProcessError as ex:
   print(ex.output)
   sys.exit(ex.returncode)


### PR DESCRIPTION
Cirrus does not run a sufficiently new version of python for `subprocess.check_output(text=True)`.