### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,9 @@
+# Below is a list of Flutter hackers GitHub handles who are
+# suggested reviewers for contributions to this repository.
+#
+# These names are just suggestions. It is fine to have your changes
+# reviewed by someone else.
+#
+# Use git ls-files '<pattern>' without a / prefix to see the list of matching files.
+
+/build/config/ios/** @jmagman


### PR DESCRIPTION
https://github.com/flutter/buildroot/pull/509 caused [App Store submission failures](https://github.com/flutter/flutter/issues/90209) for Flutter customers and several g3 apps.

Create a `CODEOWNERS` file.  Add myself to [`build/config/ios`](https://github.com/flutter/buildroot/tree/master/build/config/ios) so I am automatically added to any reviews of this file so I get a heads up when these settings are changed.  The codeowner is not a blocking reviewer, but is automatically added to any PRs that change the file.

```
$ git ls-files build/config/ios/
build/config/ios/BUILD.gn
build/config/ios/ios_sdk.gni
build/config/ios/ios_sdk.py
```

See also https://github.com/flutter/flutter/blob/master/CODEOWNERS.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
