### PR TITLE
Filter None out of module_paths for android build_utils.py

### DIFF
--- a/build/android/gyp/util/build_utils.py
+++ b/build/android/gyp/util/build_utils.py
@@ -316,7 +316,7 @@ def GetPythonDependencies():
   _ForceLazyModulesToLoad()
   module_paths = (m.__file__ for m in sys.modules.values()
                   if m is not None and hasattr(m, '__file__'))
-  abs_module_paths = map(os.path.abspath, module_paths)
+  abs_module_paths = map(os.path.abspath, filter(lambda p: p is not None, module_paths))
 
   assert os.path.isabs(DIR_SOURCE_ROOT)
   non_system_module_paths = [


### PR DESCRIPTION
The `abspath` of Python3.8 can't process `None` as input parameter, and it
will throw the following exception if it is None:

```
Traceback (most recent call last):
  File "../../build/android/gyp/javac.py", line 345, in <module>
    sys.exit(main(sys.argv[1:]))
  File "../../build/android/gyp/javac.py", line 338, in main
    input_files + build_utils.GetPythonDependencies())
  File "/home/dev/workspace/flutter/src/build/android/gyp/util/build_utils.py", line 322, in GetPythonDependencies
    non_system_module_paths = [
  File "/home/dev/workspace/flutter/src/build/android/gyp/util/build_utils.py", line 322, in <listcomp>
    non_system_module_paths = [
  File "/usr/lib/python3.8/posixpath.py", line 374, in abspath
    path = os.fspath(path)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

There are two related Python issues:
https://bugs.python.org/issue36777
https://bugs.python.org/issue33399

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
