### PR TITLE
Pass -fno-aligned-allocation for mac/arm64

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -183,6 +183,11 @@ config("compiler") {
         "-arch",
         "arm64",
       ]
+      if (is_mac) {
+        # Aligned allocations are only supported on arm64 after macOS 10.14,
+        # however our deployment target is currently 10.11.
+        common_mac_flags += [ "-fno-aligned-allocation" ]
+      }
     }
 
     cflags += common_mac_flags


### PR DESCRIPTION
We currently set the deployment target to 10.11, and aligned allocation is only supported on 10.14 and newer.