### PR TITLE
Remove use of deprecated fidlgen arguments in fuchsia build script

### DIFF
--- a/build/fuchsia/fidl_gen_cpp.py
+++ b/build/fuchsia/fidl_gen_cpp.py
@@ -40,8 +40,7 @@ def main():
   parser.add_argument('--sdk-base', dest='sdk_base', action='store', required=True)
   parser.add_argument('--root', dest='root', action='store', required=True)
   parser.add_argument('--json', dest='json', action='store', required=True)
-  parser.add_argument('--include-base', dest='include_base', action='store', required=True)
-  parser.add_argument('--output-base-cc', dest='output_base_cc', action='store', required=True)
+  parser.add_argument('--fidlgen-root', dest='fidlgen_root', action='store', required=True)
   parser.add_argument('--output-c-tables', dest='output_c_tables', action='store', required=True)
 
   args = parser.parse_args()
@@ -79,14 +78,10 @@ def main():
 
   fidlgen_command = [
     args.fidlgen_bin,
-    '-generators',
-    'cpp',
-    '-include-base',
-    args.include_base,
     '-json',
     args.json,
-    '-output-base',
-    args.output_base_cc
+    '-root',
+    args.fidlgen_root
   ]
 
   subprocess.check_call(fidlgen_command)

--- a/build/fuchsia/sdk.gni
+++ b/build/fuchsia/sdk.gni
@@ -117,10 +117,8 @@ template("_fuchsia_fidl_library") {
       rebase_path(invoker.meta),
       "--json",
       rebase_path("$target_gen_dir/$library_name_json"),
-      "--include-base",
+      "--fidlgen-root",
       rebase_path("$target_gen_dir"),
-      "--output-base-cc",
-      rebase_path("$target_gen_dir/$library_name_slashes/cpp/fidl"),
       "--output-c-tables",
       rebase_path("$target_gen_dir/$library_name_slashes/cpp/tables.c"),
     ]


### PR DESCRIPTION
The tools/fuchsia/build_fuchsia_artifacts.py script is currently broken because of removal of deprecated arguments in the fidlgen binary. This PR removes use of the deprecated arguments to fix the script.