### PR TITLE
Update clang_static_analyzer_wrapper.py

### DIFF
--- a/build/toolchain/clang_static_analyzer_wrapper.py
+++ b/build/toolchain/clang_static_analyzer_wrapper.py
@@ -49,10 +49,10 @@ def main():
         interleave_args(analyzer_option_flags, prefix)
   returncode, stderr = wrapper_utils.CaptureCommandStderr(
       wrapper_utils.CommandToRun(cmd))
-  sys.stderr.write(stderr)
+  sys.stderr.write(stderr.decode())
   returncode, stderr = wrapper_utils.CaptureCommandStderr(
     wrapper_utils.CommandToRun(parsed_args.args))
-  sys.stderr.write(stderr)
+  sys.stderr.write(stderr.decode())
   return returncode
 if __name__ == '__main__':
   sys.exit(main())


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/91860

Compiling with this enabled still spits a bunch of stuff out to stderr though.

@jmagman @cbracken 