### PR TITLE
Add ability to pass fuchsia api level to clang

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -16,6 +16,7 @@ if (is_win) {
 import("//build/config/c++/c++.gni")
 import("//build/config/profiler.gni")
 import("//build/config/sanitizers/sanitizers.gni")
+import("//build/fuchsia/config.gni")
 import("//build/toolchain/ccache.gni")
 import("//build/toolchain/clang.gni")
 import("//build/toolchain/wasm.gni")
@@ -415,6 +416,14 @@ config("compiler") {
         cflags += [ "--target=x86_64-linux-androideabi" ]
         ldflags += [ "--target=x86_64-linux-androideabi" ]
       }
+    }
+  }
+
+  # Fuchsia-specific flags setup.
+  # -----------------------------
+  if (is_fuchsia) {
+    if (fuchsia_target_api_level != -1) {
+      cflags +=[ "-ffuchsia-api-level=${fuchsia_target_api_level}" ]
     }
   }
 

--- a/build/fuchsia/config.gni
+++ b/build/fuchsia/config.gni
@@ -1,0 +1,9 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+declare_args() {
+  # The target API level for this repository. A value of -1
+  # means that no API level will be passed to the tools that consume it.
+  fuchsia_target_api_level = -1
+}


### PR DESCRIPTION
Adds a gn argument which will allow us to pass the fuchsia-api-level flag to clang.