### PR TITLE
Print Xcode output when macOS SDKs are not found

### DIFF
--- a/build/mac/find_sdk.py
+++ b/build/mac/find_sdk.py
@@ -76,9 +76,11 @@ def main():
       sdk_output = properties['sdkPath']
 
   if not best_sdk:
+    print(sdk_json_output)
     raise Exception('No %s+ SDK found' % min_sdk_version)
 
   if options.verify and best_sdk != min_sdk_version and not options.sdk_path:
+    print(sdk_json_output)
     sys.stderr.writelines([
       '',
       '                                           vvvvvvv',


### PR DESCRIPTION
https://github.com/flutter/buildroot/pull/528 [didn't work](https://github.com/flutter/engine/pull/30066) when I ran it in the engine and I'm not sure why--the same Xcode bundle works for me locally.  Add some print statements to diagnose.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
