### PR TITLE
Parse both macOS and Mac OS X SDK names

### DIFF
--- a/build/mac/find_sdk.py
+++ b/build/mac/find_sdk.py
@@ -65,8 +65,8 @@ def main():
   best_sdk = None
   sdk_output = None
   for properties in list(sdk_json):
-    # Filter out macOS DriverKit, watchOS, and other SDKs.
-    if properties.get('productName') != 'macOS':
+    # Filter out macOS DriverKit, watchOS, AppleTV, and other SDKs.
+    if properties.get('platform') != 'macosx' or 'driver' in properties.get('canonicalName'):
       continue
     sdk_version = properties['sdkVersion']
     parsed_version = parse_version(sdk_version)


### PR DESCRIPTION
In older Xcode bundles the SDK productName is `Mac OS X`, not `macOS`.  Instead of parsing `productName`, parse `platform`, but filter out `DriverKit`.  Regressed in https://github.com/flutter/buildroot/pull/528.

Needs to handle these:
```
  {
    "canonicalName" : "driverkit.macosx19.0",
    "displayName" : "DriverKit 19.0",
    "isBaseSdk" : true,
    "platform" : "macosx",
    "platformPath" : "/Users/m/xcode-cipd/Xcode-12A7209.app/Contents/Developer/Platforms/MacOSX.platform",
    "platformVersion" : "10.15.6",
    "sdkPath" : "/Users/m/xcode-cipd/Xcode-12A7209.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/DriverKit19.0.sdk",
    "sdkVersion" : "19.0"
  },
  {
    "canonicalName" : "macosx11.1",
    "displayName" : "macOS 11.1",
    "iOSSupportVersion" : "14.3",
    "isBaseSdk" : true,
    "platform" : "macosx",
    "platformPath" : "/Users/m/xcode-cipd/Xcode-12A7209.app/Contents/Developer/Platforms/MacOSX.platform",
    "platformVersion" : "10.15.6",
    "productBuildVersion" : "20C63",
    "productCopyright" : "1983-2020 Apple Inc.",
    "productName" : "macOS",
    "productUserVisibleVersion" : "11.1",
    "productVersion" : "11.1",
    "sdkPath" : "/Users/m/xcode-cipd/Xcode-12A7209.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk",
    "sdkVersion" : "11.1"
  },
  {
    "canonicalName" : "macosx10.15",
    "displayName" : "macOS 10.15",
    "iOSSupportVersion" : "13.6",
    "isBaseSdk" : true,
    "platform" : "macosx",
    "platformPath" : "/opt/s/w/ir/cache/osx_sdk/XCode.app/Contents/Developer/Platforms/MacOSX.platform",
    "platformVersion" : "10.15.6",
    "productBuildVersion" : "19G68",
    "productCopyright" : "1983-2020 Apple Inc.",
    "productName" : "Mac OS X",
    "productUserVisibleVersion" : "10.15.6",
    "productVersion" : "10.15.6",
    "sdkPath" : "/opt/s/w/ir/cache/osx_sdk/XCode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
    "sdkVersion" : "10.15.6"
  },
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
