### PR TITLE
Respect depfile specifications for compiled_action templates.

### DIFF
--- a/build/compiled_action.gni
+++ b/build/compiled_action.gni
@@ -121,11 +121,12 @@ template("compiled_action") {
     # Add the executable itself as an input.
     inputs += [ host_executable ]
 
-    deps = [
-      host_tool,
-    ]
+    deps = [ host_tool ]
     if (defined(invoker.deps)) {
       deps += invoker.deps
+    }
+    if (defined(invoker.depfile)) {
+      depfile = invoker.depfile
     }
 
     # The script takes as arguments the binary to run, and then the arguments
@@ -174,11 +175,12 @@ template("compiled_action_foreach") {
     # Add the executable itself as an input.
     inputs += [ host_executable ]
 
-    deps = [
-      host_tool,
-    ]
+    deps = [ host_tool ]
     if (defined(invoker.deps)) {
       deps += invoker.deps
+    }
+    if (defined(invoker.depfile)) {
+      depfile = invoker.depfile
     }
 
     # The script takes as arguments the binary to run, and then the arguments


### PR DESCRIPTION
The more accurate way of implementing this template would be to use
`forward_variables_from` with an allowlist. But that functionality
was likely not available in GN when this template was written.

The case could be made that his should now be re-written to use
`forward_variables_from` to be as forward compatible as possible.

For now, I just needed to the template to respect the depfile
specification. This is to be used by the offline shader compiler which
is a C++ tool on the host (not vended).

Also runs a `gn format` pass over the document.