### PR TITLE
Fix GLFW GN rule to add missing Mac dependencies.

### DIFF
--- a/build/secondary/third_party/glfw/BUILD.gn
+++ b/build/secondary/third_party/glfw/BUILD.gn
@@ -93,7 +93,15 @@ source_set("glfw") {
 
     defines = [ "_GLFW_COCOA" ]
 
-    cflags = [ "-Wno-deprecated-declarations" ]
+    cflags = [
+      "-Wno-deprecated-declarations",
+      "-Wno-objc-multiple-method-names",
+    ]
+
+    frameworks = [
+      "CoreVideo.framework",
+      "IOKit.framework",
+    ]
   }
 
   configs -= [ "//build/config/compiler:chromium_code" ]


### PR DESCRIPTION
Not including CoreVideo and IOKit here yields linker errors when the
final executable is linked. This required executable targets that have
no knowledge of CoreVideo or IOKit explicitly specify a dependency.

With this change, these dependencies will be implicitly added if the
target depends on GLFW.

The suppression -Wno-objc-multiple-method-names is necessary after
updating GLFW to the latest (which landing this patch will unblock).