### PR TITLE
Add build rules for inja and libtess2.

### DIFF
--- a/build/secondary/third_party/inja/BUILD.gn
+++ b/build/secondary/third_party/inja/BUILD.gn
@@ -1,0 +1,44 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+source_root = "//third_party/inja"
+
+config("inja_public_config") {
+  include_dirs = [
+    "$source_root/include",
+    "$source_root/third_party/include",
+  ]
+
+  if (is_clang) {
+    cflags_cc = [
+      "-Wno-unused-variable",
+      "-Wno-newline-eof",
+    ]
+  }
+
+  defines = [ "INJA_NOEXCEPTION=1" ]
+}
+
+source_set("inja") {
+  public_configs = [ ":inja_public_config" ]
+
+  public = [ "$source_root/include/inja/inja.hpp" ]
+
+  sources = [
+    "$source_root/include/inja/config.hpp",
+    "$source_root/include/inja/environment.hpp",
+    "$source_root/include/inja/exceptions.hpp",
+    "$source_root/include/inja/function_storage.hpp",
+    "$source_root/include/inja/inja.hpp",
+    "$source_root/include/inja/lexer.hpp",
+    "$source_root/include/inja/node.hpp",
+    "$source_root/include/inja/parser.hpp",
+    "$source_root/include/inja/renderer.hpp",
+    "$source_root/include/inja/statistics.hpp",
+    "$source_root/include/inja/string_view.hpp",
+    "$source_root/include/inja/template.hpp",
+    "$source_root/include/inja/token.hpp",
+    "$source_root/include/inja/utils.hpp",
+  ]
+}

--- a/build/secondary/third_party/libtess2/BUILD.gn
+++ b/build/secondary/third_party/libtess2/BUILD.gn
@@ -1,0 +1,26 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+source_set("libtess2") {
+  public = [ "//third_party/libtess2/Include/tesselator.h" ]
+
+  include_dirs = [ "//third_party/libtess2/Include/" ]
+
+  sources = [
+    "//third_party/libtess2/Source/bucketalloc.c",
+    "//third_party/libtess2/Source/bucketalloc.h",
+    "//third_party/libtess2/Source/dict.c",
+    "//third_party/libtess2/Source/dict.h",
+    "//third_party/libtess2/Source/geom.c",
+    "//third_party/libtess2/Source/geom.h",
+    "//third_party/libtess2/Source/mesh.c",
+    "//third_party/libtess2/Source/mesh.h",
+    "//third_party/libtess2/Source/priorityq.c",
+    "//third_party/libtess2/Source/priorityq.h",
+    "//third_party/libtess2/Source/sweep.c",
+    "//third_party/libtess2/Source/sweep.h",
+    "//third_party/libtess2/Source/tess.c",
+    "//third_party/libtess2/Source/tess.h",
+  ]
+}


### PR DESCRIPTION
Mirrors for [inja](https://github.com/flutter/flutter/issues/94824) and [libtess2](https://github.com/flutter/flutter/issues/94823) are being setup.

Inja is a template engine used to generate headers from reflected shader information. This dependency will not be used any targets shipping as engine artifacts.

libtess2 is used for triangulation.

Impeller needs one more dependency in [sqlite3](https://github.com/flutter/flutter/issues/94773) which will only be used in debug and profile modes to capture a sequence of scenes and instrumentation information. This file can then be exported from the device and used to playback those animations for debugging and instrumentation. There are no build rules in this patch for sqlite3 because those are part of the mirrored repo itself.

This is the final patch preparing the buildroot for Impeller as the others have landed and rolled in.