### PR TITLE
Add third_party to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ Thumbs.db
 /gradle/
 /ios_tools/
 /out/
+/third_party/
 
 # This is where the gclient hook downloads the Fuchsia SDK and toolchain.
 /fuchsia/


### PR DESCRIPTION
This should have been part of the previous commit. I only noticed it after
running gclient sync and popping back up one directory to buildroot.