### PR TITLE
Add path to public headers for GLFW.

### DIFF
--- a/build/secondary/third_party/glfw/BUILD.gn
+++ b/build/secondary/third_party/glfw/BUILD.gn
@@ -5,7 +5,10 @@
 _checkout_dir = "//third_party/glfw"
 
 config("relative_glfw_headers") {
-  include_dirs = [ "$_checkout_dir/include" ]
+  include_dirs = [
+    "$_checkout_dir/include",
+    "$_checkout_dir/include/GLFW",
+  ]
 }
 
 source_set("glfw") {


### PR DESCRIPTION
In the process of adding a GN rule for the embedder example in
//flutter/examples/glfw, this include dir is necessary. Today, we provide an
example but don't actually make sure it compiles.