### PR TITLE
[fuchsia] Fix zx fidl bindings conflicting w/ SDK.

### DIFF
--- a/build/fuchsia/sdk.gni
+++ b/build/fuchsia/sdk.gni
@@ -101,10 +101,15 @@ template("_fuchsia_fidl_library") {
     ]
 
     outputs = [
-      "$target_gen_dir/$library_name_slashes/cpp/fidl.h",
-      "$target_gen_dir/$library_name_slashes/cpp/fidl.cc",
       "$target_gen_dir/$library_name_slashes/cpp/tables.c",
     ]
+    # TODO(https://fxbug.dev/90838): Make zx library less special-cased.
+    if (library_name != "zx") {
+      outputs += [
+        "$target_gen_dir/$library_name_slashes/cpp/fidl.h",
+        "$target_gen_dir/$library_name_slashes/cpp/fidl.cc",
+      ]
+    }
 
     args = [
       "--fidlc-bin",


### PR DESCRIPTION
The ZX FIDL library is special. Unlike regular FIDL libraries
which define IPC, they define the interface between
Zircon kernel and Fuchsia userspace. fidlgen
doesn't produce useful output when dealing with this
library. See fxb/90838.

We're seeing a conflict between zx_rights_t from
the SDK and zx_rights_t from ZX's FIDL bindings. To
fix this, we apply a similar change to https://fuchsia-review.googlesource.com/c/fuchsia/+/623061/13/scripts/sdk/gn/base/build/fidl_library.gni#192.