### PR TITLE
Build libtess2 with less strict warning flags to fix build

### DIFF
--- a/build/secondary/third_party/libtess2/BUILD.gn
+++ b/build/secondary/third_party/libtess2/BUILD.gn
@@ -7,6 +7,9 @@ source_set("libtess2") {
 
   include_dirs = [ "//third_party/libtess2/Include/" ]
 
+  configs -= [ "//build/config/compiler:chromium_code" ]
+  configs += [ "//build/config/compiler:no_chromium_code" ]
+
   sources = [
     "//third_party/libtess2/Source/bucketalloc.c",
     "//third_party/libtess2/Source/bucketalloc.h",


### PR DESCRIPTION
Without this, the `impeller_unittests` target fails to build, giving the error:
```
../../third_party/libtess2/Source/sweep.c:1138:6: error: unused variable 'fixedEdges' [-Werror,-Wunused-variable]
        int fixedEdges = 0;
            ^
1 error generated.
```