### PR TITLE
Don't duplicate flags to non-windows assemblers

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -427,7 +427,16 @@ config("compiler") {
     }
   }
 
-  asmflags = cflags
+  # On non-Windows, the assembler is passed both cflags and asmflags.
+  # On Windows it is passed only asmflags. This is because for the
+  # Windows assembler, not all cflags are valid asmflags. They are
+  # for this config, though, so we can gate the assignment below to
+  # avoid duplicating flags to the other toolchains. Duplicating
+  # the flags can confuse goma, in particular flags that specify the
+  # target arch. See b/27730714.
+  if (is_win) {
+    asmflags = cflags
+  }
 }
 
 config("cxx_version_default") {


### PR DESCRIPTION
Duplicating the `-arch` flag can confuse goma even when both flags specify the same architecture. The duplication was due to the line guarded in this PR. On Windows the flags are not duplicated, but rather need to be copied for the Windows toolchain specification to work correctly. The comment in the PR gives some more explanation.