### PR TITLE
Revert "Don't duplicate flags to non-windows assemblers"

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -427,16 +427,7 @@ config("compiler") {
     }
   }
 
-  # On non-Windows, the assembler is passed both cflags and asmflags.
-  # On Windows it is passed only asmflags. This is because for the
-  # Windows assembler, not all cflags are valid asmflags. They are
-  # for this config, though, so we can gate the assignment below to
-  # avoid duplicating flags to the other toolchains. Duplicating
-  # the flags can confuse goma, in particular flags that specify the
-  # target arch. See b/27730714.
-  if (is_win) {
-    asmflags = cflags
-  }
+  asmflags = cflags
 }
 
 config("cxx_version_default") {


### PR DESCRIPTION
Reverts flutter/buildroot#546

Build failures https://github.com/flutter/engine/pull/31350