### PR TITLE
Add deprecation warnings when compiling Android engine

### DIFF
--- a/build/android/gyp/javac.py
+++ b/build/android/gyp/javac.py
@@ -80,7 +80,8 @@ def DoJavac(
       '-classpath', ':'.join(classpath),
       '-d', classes_dir,
       # TODO(camsim99): Make deprecation warnings fatal and remove limit 
-      # when all 123 (at the time of this comment) deprecations are fixed.
+      # when all 123 (at the time of this comment) deprecations are fixed:
+      # https://github.com/flutter/flutter/issues/98602.
       '-Xlint:deprecation',
       '-Xmaxwarns', '123']
 

--- a/build/android/gyp/javac.py
+++ b/build/android/gyp/javac.py
@@ -78,7 +78,11 @@ def DoJavac(
       # javac pulling a default encoding from the user's environment.
       '-encoding', 'UTF-8',
       '-classpath', ':'.join(classpath),
-      '-d', classes_dir]
+      '-d', classes_dir,
+      # TODO(camsim99): Make deprecation warnings fatal and remove limit 
+      # when all 123 (at the time of this comment) deprecations are fixed.
+      '-Xlint:deprecation',
+      '-Xmaxwarns', '123']
 
   if bootclasspath:
     javac_args.extend([
@@ -88,7 +92,6 @@ def DoJavac(
         ])
 
   if chromium_code:
-    # TODO(aurimas): re-enable '-Xlint:deprecation' checks once they are fixed.
     javac_args.extend(['-Xlint:unchecked'])
   else:
     # XDignore.symbol.file makes javac compile against rt.jar instead of


### PR DESCRIPTION
This PR adds a compiler option to show the deprecation warnings when building the Android engine and a reminder to make these warnings fatal once the current ones are fixed.

As per [this comment](https://github.com/flutter/engine/pull/31246#issuecomment-1034280351), I can confirm that this does not affect running `flutter run`/`flutter create`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
