### PR TITLE
Checkout emsdk to //buildtools instead of //third_party

### DIFF
--- a/build/toolchain/wasm.gni
+++ b/build/toolchain/wasm.gni
@@ -6,7 +6,7 @@
 
 declare_args() {
   # The location of an activated embedded emsdk.
-  emsdk_dir = rebase_path("//third_party/emsdk")
+  emsdk_dir = rebase_path("//buildtools/emsdk")
 }
 
 wasm_toolchain = "//build/toolchain/wasm"


### PR DESCRIPTION
This checks out the Emscripten SDK to `//buildtools` rather than `//third_party` since `//third_party` is for source code.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
