### PR TITLE
[fuchsia] Enable building with --embedder-for-target.

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -354,6 +354,13 @@ config("compiler") {
     }
   }
 
+  # Fuchsia-specific compiler flags setup.
+  if (is_fuchsia) {
+    # The embedder requires position-independent code to compile.
+    cflags += [ "-fPIC" ]
+    ldflags += [ "-fPIC" ]
+  }
+
   # Clang-specific compiler flags setup.
   # ------------------------------------
   if (is_clang) {


### PR DESCRIPTION
Without these flags, building for Fuchsia with `--embedder_for_target` complains about position-independent code being required for the embedder.

I'm not sure if there will be undesired side-effects to this change for regular Fuchsia builds?