### PR TITLE
[windows] Support detecting VS2022 64-bit install path

### DIFF
--- a/build/vs_toolchain.py
+++ b/build/vs_toolchain.py
@@ -38,6 +38,7 @@ sys.path.insert(0, os.path.join(script_dir, '..', 'tools'))
 MSVS_VERSIONS = collections.OrderedDict([
   ('2017', '15.0'),
   ('2019', '16.0'),
+  ('2022', '17.0'),
 ])
 
 
@@ -164,6 +165,8 @@ def GetVisualStudioVersion():
     for path in (
         os.environ.get('vs%s_install' % version),
         os.path.expandvars('%ProgramFiles(x86)%' +
+                           '/Microsoft Visual Studio/%s' % version),
+        os.path.expandvars('%ProgramFiles%' +
                            '/Microsoft Visual Studio/%s' % version)):
       if path and os.path.exists(path):
         available_versions.append(version)
@@ -187,20 +190,13 @@ def DetectVisualStudioPath():
   # the registry. For details see:
   # https://blogs.msdn.microsoft.com/heaths/2016/09/15/changes-to-visual-studio-15-setup/
   # For now we use a hardcoded default with an environment variable override.
+  possible_install_paths = (
+      os.path.expandvars('%s/Microsoft Visual Studio/%s/%s' %
+                         (program_path_var, version_as_year, product))
+      for program_path_var in ('%ProgramFiles%', '%ProgramFiles(x86)%')
+      for product in ('Enterprise', 'Professional', 'Community', 'Preview'))
   for path in (
-      os.environ.get('vs%s_install' % version_as_year),
-      os.path.expandvars('%ProgramFiles(x86)%' +
-                         '/Microsoft Visual Studio/%s/Enterprise' %
-                         version_as_year),
-      os.path.expandvars('%ProgramFiles(x86)%' +
-                         '/Microsoft Visual Studio/%s/Professional' %
-                         version_as_year),
-      os.path.expandvars('%ProgramFiles(x86)%' +
-                         '/Microsoft Visual Studio/%s/Community' %
-                         version_as_year),
-      os.path.expandvars('%ProgramFiles(x86)%' +
-                         '/Microsoft Visual Studio/%s/Preview' %
-                         version_as_year)):
+      os.environ.get('vs%s_install' % version_as_year), *possible_install_paths):
     if path and os.path.exists(path):
       return path
 


### PR DESCRIPTION
Fixed:
* https://github.com/flutter/flutter/issues/100026

* Add VS2022 version in `MSVS_VERSIONS`
* Include 64-bit installing path

Because since Visual Studio 2022, it's a 64-bit version and it's installing path is in "C:\Program Files\Microsoft Visual Studio" not in "Program Files(x86)". So when the `GYP_MSVS_OVERRIDE_PATH` is not provided in environment, the auto detecting will fail.

![image](https://user-images.githubusercontent.com/922837/158067717-9339df0c-d512-425b-8dfe-af6c252f8fa5.png)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
