### PR TITLE
Suppress warnings about unknown warnings in shaderc.

### DIFF
--- a/build/secondary/third_party/shaderc_flutter/BUILD.gn
+++ b/build/secondary/third_party/shaderc_flutter/BUILD.gn
@@ -21,7 +21,10 @@ source_set("shaderc_util_flutter") {
   defines = [ "ENABLE_HLSL=1" ]
 
   if (is_clang) {
-    cflags_cc = [ "-Wno-deprecated-copy" ]
+    cflags_cc = [
+      "-Wno-deprecated-copy",
+      "-Wno-unknown-warning-option",
+    ]
   }
 
   sources = [


### PR DESCRIPTION
This new warning was added somewhere between Xcode 12.3
(Clang-1200.0.32.28) and 12.5.1 (Clang-1205.0.22.11).

We use an identical Clang toolchain for all targets except iOS ARM 64
simulator builds. See https://github.com/flutter/flutter/issues/100085.

So, if the version of Clang is too new, TUs fail to compile because of
the missing warning. And, suppressing the warning fails on older version
of Clang because Clang doesn't recognize the warning. This is a third
party dependency and it is time consuming to fix and propagate rolls.