### PR TITLE
Enable cross-compilation of WASM targets

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -2,10 +2,6 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-# If building for WASM, we only want to build CanvasKit. The flutter build
-# is ignored.
-if (target_cpu != "wasm") {
-# This target will be built if no target is specified when invoking ninja.
 group("default") {
   testonly = true
   deps = [
@@ -21,17 +17,10 @@ group("dist") {
   ]
 }
 
-  group("archives") {
-    testonly = true
+group("archives") {
+  testonly = true
 
-    deps = [
-      "//flutter/build/archives:artifacts"
-    ]
-  }
-} else {
-  group("default") {
-    deps = [
-      "//flutter/lib/web_ui:canvaskit"
-    ]
-  }
+  deps = [
+    "//flutter/build/archives:artifacts"
+  ]
 }

--- a/build/config/BUILDCONFIG.gn
+++ b/build/config/BUILDCONFIG.gn
@@ -2,9 +2,6 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-# define is_wasm
-import("//build/toolchain/wasm.gni")
-
 # =============================================================================
 # PLATFORM SELECTION
 # =============================================================================
@@ -196,6 +193,7 @@ if (current_os == "win") {
   is_mac = false
   is_posix = false
   is_win = true
+  is_wasm = false
 } else if (current_os == "mac") {
   is_android = false
   is_chromeos = false
@@ -206,6 +204,7 @@ if (current_os == "win") {
   is_mac = true
   is_posix = true
   is_win = false
+  is_wasm = false
 } else if (current_os == "android") {
   is_android = true
   is_chromeos = false
@@ -216,6 +215,7 @@ if (current_os == "win") {
   is_mac = false
   is_posix = true
   is_win = false
+  is_wasm = false
 } else if (current_os == "chromeos") {
   is_android = false
   is_chromeos = true
@@ -226,6 +226,7 @@ if (current_os == "win") {
   is_mac = false
   is_posix = true
   is_win = false
+  is_wasm = false
 } else if (current_os == "nacl") {
   # current_os == "nacl" will be passed by the nacl toolchain definition.
   # It is not set by default or on the command line. We treat is as a
@@ -239,6 +240,7 @@ if (current_os == "win") {
   is_mac = false
   is_posix = true
   is_win = false
+  is_wasm = false
 } else if (current_os == "ios") {
   is_android = false
   is_chromeos = false
@@ -249,6 +251,7 @@ if (current_os == "win") {
   is_mac = false
   is_posix = true
   is_win = false
+  is_wasm = false
 } else if (current_os == "linux") {
   is_android = false
   is_chromeos = false
@@ -259,6 +262,7 @@ if (current_os == "win") {
   is_mac = false
   is_posix = true
   is_win = false
+  is_wasm = false
 } else if (current_os == "fuchsia" || target_os == "fuchsia") {
   is_android = false
   is_chromeos = false
@@ -269,7 +273,8 @@ if (current_os == "win") {
   is_mac = false
   is_posix = true
   is_win = false
-} else if (target_os == "wasm") {
+  is_wasm = false
+} else if (current_os == "wasm") {
   is_android = false
   is_chromeos = false
   is_fuchsia = false
@@ -279,6 +284,7 @@ if (current_os == "win") {
   is_mac = false
   is_posix = false
   is_win = false
+  is_wasm = true
 }
 
 is_apple = is_ios || is_mac

--- a/build/toolchain/gcc_toolchain.gni
+++ b/build/toolchain/gcc_toolchain.gni
@@ -238,7 +238,7 @@ template("gcc_toolchain") {
       }
 
       build_id = "-Wl,--build-id=sha1"
-      if (is_wasm) {
+      if (invoker.toolchain_cpu == "wasm") {
         build_id = ""
       }
       command = "$ld {{ldflags}} $coverage_flags -o $unstripped_outfile $build_id -Wl,--start-group @$rspfile {{solibs}} -Wl,--end-group $libs_section_prefix {{libs}} $libs_section_postfix"

--- a/build/toolchain/wasm.gni
+++ b/build/toolchain/wasm.gni
@@ -64,8 +64,8 @@ template("wasm_lib") {
   }
 
   group("$_lib_name") {
-    deps = [
-      ":${_lib_name}.js($wasm_toolchain)",
+    public_deps = [
+      ":${_lib_name}.js",
     ]
   }
 }

--- a/build/toolchain/wasm.gni
+++ b/build/toolchain/wasm.gni
@@ -10,7 +10,6 @@ declare_args() {
 }
 
 wasm_toolchain = "//build/toolchain/wasm"
-is_wasm = target_cpu == "wasm"
 
 em_config_path = "$emsdk_dir/.emscripten"
 

--- a/build/toolchain/wasm/BUILD.gn
+++ b/build/toolchain/wasm/BUILD.gn
@@ -30,4 +30,6 @@ gcc_toolchain("wasm") {
   toolchain_os = "wasm"
 
   is_clang = true
+
+  link_outputs = [ "{{root_out_dir}}/{{target_output_name}}.wasm" ]
 }


### PR DESCRIPTION
Switch to using `current_cpu` where appropriate and correctly setting `is_wasm` in `BUILDCONFIG.gn`.

Also correctly declare that the link step in Emscripten builds produces both a `.js` and a `.wasm` file.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
