### PR TITLE
Add configurations required for compatibility with Chromium's third_party/zlib/BUILD.gn

### DIFF
--- a/build/config/BUILDCONFIG.gn
+++ b/build/config/BUILDCONFIG.gn
@@ -375,6 +375,9 @@ if (is_debug) {
 }
 _native_compiler_configs += [ _default_optimization_config ]
 
+# zlib's BUILD.gn expects to have this config among default configs.
+_native_compiler_configs += [ "//build/config/compiler:default_optimization" ]
+
 # If it wasn't manually set, set to an appropriate default.
 if (symbol_level == -1) {
   # Linux is slowed by having symbols as part of the target binary, whereas

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -887,6 +887,13 @@ config("optimize_max") {
   }
 }
 
+# These are two named configs that zlib's BUILD.gn expects to exist.
+config("default_optimization") {
+}
+
+config("optimize_speed") {
+}
+
 # Symbols ----------------------------------------------------------------------
 
 config("symbols") {

--- a/build/config/compiler/compiler.gni
+++ b/build/config/compiler/compiler.gni
@@ -1,0 +1,13 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# This is a subset of Chromium's build/config/compiler/compiler.gni
+# required for compatibility with Chromium packages such as zlib.
+
+declare_args() {
+  build_with_chromium = false
+  use_libfuzzer = false
+  is_apple = is_ios || is_mac
+  use_thin_lto = false
+}

--- a/build/secondary/third_party/android_ndk/BUILD.gn
+++ b/build/secondary/third_party/android_ndk/BUILD.gn
@@ -1,0 +1,10 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+source_set("cpu_features") {
+  public_configs = [ "//third_party/android_tools:cpu_features_include" ]
+  deps = [
+    "//third_party/android_tools:cpu_features",
+  ]
+}


### PR DESCRIPTION
These are based on the setup used in Dart's build scripts.

See https://github.com/flutter/flutter/issues/101709
