### PR TITLE
[win32] Use clang cflags on Windows builds

### DIFF
--- a/build/secondary/third_party/swiftshader_flutter/BUILD.gn
+++ b/build/secondary/third_party/swiftshader_flutter/BUILD.gn
@@ -11,49 +11,29 @@ config("internal_config") {
     "$source_root/src/OpenGL",
   ]
 
-  if (is_win) {
-    cflags = [
-      "/wd4005",
-      "/wd4018",
-      "/wd4141",
-      "/wd4146",
-      "/wd4201",
-      "/wd4245",
-      "/wd4267",
-      "/wd4291",
-      "/wd4310",
-      "/wd4324",
-      "/wd4334",
-      "/wd4389",
-      "/wd4701",
-      "/wd4702",
-      "/wd4703",
-      "/wd4706",
-      "/wd4800",
-      "/wd5030",
-    ]
+  defines = [ "NO_SANITIZE_FUNCTION=" ]
 
+  cflags = [
+    "-Wno-header-hygiene",
+    "-Wno-newline-eof",
+    "-Wno-nonportable-include-path",
+    "-Wno-range-loop-construct",
+    "-Wno-thread-safety-analysis",
+    "-Wno-undefined-var-template",
+    "-Wno-unneeded-internal-declaration",
+    "-Wno-c++17-extensions",
+    "-Wno-unused-variable",
+    "-Wno-deprecated-declarations",
+  ]
+
+  if (is_win) {
     libs = [
       "user32.lib",
       "gdi32.lib",
     ]
   } else {
-    cflags = [
-      "-fPIC",
-      "-Wno-header-hygiene",
-      "-Wno-newline-eof",
-      "-Wno-nonportable-include-path",
-      "-Wno-range-loop-construct",
-      "-Wno-thread-safety-analysis",
-      "-Wno-undefined-var-template",
-      "-Wno-unneeded-internal-declaration",
-      "-Wno-c++17-extensions",
-      "-Wno-unused-variable",
-      "-Wno-deprecated-declarations",
-    ]
+    cflags += [ "-fPIC" ]
   }
-
-  defines = [ "NO_SANITIZE_FUNCTION=" ]
 }
 
 config("swiftshader_config") {


### PR DESCRIPTION
Since we're now using the clang toolchain for engine builds, use the
same set of warning cflags on Windows as we do on macOS, Linux.

This significantly reduces the set of compiler warning spam on Windows
builds.

Issue: https://github.com/flutter/flutter/issues/59199

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
