### PR TITLE
[win32] Disable swiftshader iterator warnings

### DIFF
--- a/build/secondary/third_party/swiftshader_flutter/BUILD.gn
+++ b/build/secondary/third_party/swiftshader_flutter/BUILD.gn
@@ -27,6 +27,22 @@ config("internal_config") {
   ]
 
   if (is_win) {
+    cflags += [
+      # Silence warnings about redeclaration of vk_icdGetInstanceProcAddr,
+      # vk_icdNegotiateLoaderICDInterfaceVersion, vkGetInstanceProcAddr in
+      # //third_party/swiftshader/src/Vulkan/libVulkan.cpp.
+      "-Wno-dll-attribute-on-redeclaration",
+      # Silence warnings about strings (ab)used in assertions in
+      # FrameBufferDD.cpp. e.g. assert(!"Failed to initialize graphics:...")
+      "-Wno-string-conversion",
+    ]
+
+    defines += [
+      # std::iterator is deprecated as a base class, but used in
+      # third_party/swiftshader/third_party/llvm-subzero/include/llvm/ADT/iterator.h
+      "_SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING",
+    ]
+
     libs = [
       "user32.lib",
       "gdi32.lib",


### PR DESCRIPTION
Suppresses several Windows-specific warnings emitted during swiftshader
builds:

* On swiftshader builds against Win32 C++ headers, warnings are emitted
  about subclassing std::iterator, which was deprecated in C++17. This
  affects a header file in swiftshader's third-party directory:
  third_party/swiftshader/third_party/llvm-subzero/include/llvm/ADT/iterator.h

* Three functions in libVulkan.cpp are re-declared with a difference in
  dllexport attribute only.

* Silence implicit string conversion warnings in two places in
  swiftshader where asserts of the form assert(!"Error msg") are used.

Issue: https://github.com/flutter/flutter/issues/59199

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
