### PR TITLE
[Win32] Don't warn on #pragma optimize

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -605,6 +605,12 @@ if (is_win) {
       "-Wno-nonportable-system-include-path",
     ]
   }
+  if (is_clang) {
+    default_warning_flags += [
+      # No support for #pragma optimize. https://crbug.com/505314#c13
+      "-Wno-ignored-pragma-optimize",
+    ]
+  }
 } else {
   # Common GCC warning setup.
   default_warning_flags += [


### PR DESCRIPTION
Disable this warning when building with clang on Windows, which has no
support for #pragma optimize. This affects ICU and the Dart VM.

See: https://crbug.com/505314#c13

Issue: https://github.com/flutter/flutter/issues/59199

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
