### PR TITLE
Remove top-level target for archives

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -16,11 +16,3 @@ group("dist") {
     "//flutter:dist",
   ]
 }
-
-group("archives") {
-  testonly = true
-
-  deps = [
-    "//flutter/build/archives:artifacts"
-  ]
-}


### PR DESCRIPTION
This target should be under `//flutter` so that it can be guarded as needed e.g. by `build_engine_artifacts`.