### PR TITLE
Remove unused iOS armv7 support

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -165,16 +165,6 @@ config("compiler") {
         "-arch",
         "i386",
       ]
-    } else if (current_cpu == "arm") {
-      common_mac_flags += [
-        "-arch",
-        "armv7",
-      ]
-
-      # Aligned allocation are only available on iOS 11 or above on armv7.
-      # Till we support older iOS version, disabled aligned allocations for this
-      # target architecture.
-      common_mac_flags += [ "-fno-aligned-allocation" ]
     } else if (current_cpu == "arm64") {
       common_mac_flags += [
         "-arch",


### PR DESCRIPTION
iOS `arm7v` is no longer built as of https://github.com/flutter/flutter/issues/97342. Fixes https://github.com/flutter/flutter/issues/97345

See also #262

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
