### PR TITLE
Don't pass new -Wno flags to Xcode

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -626,8 +626,6 @@ if (is_win) {
     # Disables.
     "-Wno-missing-field-initializers",  # "struct foo f = {0};"
     "-Wno-unused-parameter",  # Unused function parameters.
-    # Unqualified std::move is pretty common.
-    "-Wno-unqualified-std-cast-call",
   ]
 
   if (is_wasm) {
@@ -649,6 +647,8 @@ if (is_win) {
       "-Wno-deprecated-copy",
       # Needed for compiling Skia with clang-12
       "-Wno-psabi",
+      # Unqualified std::move is pretty common.
+      "-Wno-unqualified-std-cast-call",
     ]
     if (!is_fuchsia) {
       default_warning_flags += [
@@ -720,7 +720,9 @@ config("no_chromium_code") {
 
   # TODO(zra): Remove when zlib no longer needs this.
   # https://github.com/flutter/flutter/issues/103568
-  cflags += [ "-Wno-deprecated-non-prototype" ]
+  if (!use_xcode) {
+    cflags += [ "-Wno-deprecated-non-prototype" ]
+  }
 
   cflags += default_warning_flags
   cflags_cc += default_warning_flags_cc


### PR DESCRIPTION
Xcode uses an older clang that does not yet have these flags. This is a follow-up for https://github.com/flutter/buildroot/commit/8a1cf1585c74083389274dacdb3510778e0c8486 to unblock the toolchain roll.