### PR TITLE
Disable new clang warnings for wasm builds.

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -644,9 +644,13 @@ if (is_win) {
       "-Wno-deprecated-copy",
       # Needed for compiling Skia with clang-12
       "-Wno-psabi",
-      # Unqualified std::move is pretty common.
-      "-Wno-unqualified-std-cast-call",
     ]
+    if (!is_wasm) {
+      default_warning_flags += [
+        # Unqualified std::move is pretty common.
+        "-Wno-unqualified-std-cast-call",
+      ]
+    }
     if (!is_fuchsia) {
       default_warning_flags += [
         "-Wno-non-c-typedef-for-linkage",
@@ -717,7 +721,7 @@ config("no_chromium_code") {
 
   # TODO(zra): Remove when zlib no longer needs this.
   # https://github.com/flutter/flutter/issues/103568
-  if (!use_xcode) {
+  if (!use_xcode && !is_wasm) {
     cflags += [ "-Wno-deprecated-non-prototype" ]
   }
 


### PR DESCRIPTION
The emscripten toolchain we use is using an older version of clang
which doesn't have these flags.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
