### PR TITLE
Upgrade default android sdk version to 32

### DIFF
--- a/build/config/android/config.gni
+++ b/build/config/android/config.gni
@@ -16,8 +16,8 @@ if (is_android) {
 
   if (!defined(default_android_sdk_root)) {
     default_android_sdk_root = "//third_party/android_tools/sdk"
-    default_android_sdk_version = "31"
-    default_android_sdk_build_tools_version = "31.0.0"
+    default_android_sdk_version = "32"
+    default_android_sdk_build_tools_version = "33.0.0-rc4"
   }
 
   declare_args() {


### PR DESCRIPTION
This bumps the buildroot config.jni to use android SDK 32 and build tools 33.0.0-rc4 in support of https://github.com/flutter/engine/pull/33524
