### PR TITLE
Buildroot fixes for the Windows arm64 build

### DIFF
--- a/build/config/win/BUILD.gn
+++ b/build/config/win/BUILD.gn
@@ -93,7 +93,8 @@ config("common_linker_setup") {
   # typically changes with each launch. This in turn means that breakpoints in
   # Chrome.dll don't stick from one launch to the next. For this reason, we
   # turn ASLR off in debug builds.
-  if (is_debug) {
+  # /DYNAMICBASE:NO isn't compatible with arm64.
+  if (is_debug && current_cpu != "arm64") {
     ldflags += [ "/DYNAMICBASE:NO" ]
   } else {
     ldflags += [ "/DYNAMICBASE" ]

--- a/build/toolchain/win/BUILD.gn
+++ b/build/toolchain/win/BUILD.gn
@@ -141,7 +141,7 @@ template("msvc_toolchain") {
       } else if (toolchain_args.current_cpu == "arm64") {
         is_msvc_assembler = false
         prefix = rebase_path("$clang_base_path/bin", root_build_dir)
-        ml = "${goma_prefix}${prefix}/clang_cl.exe --target=arm64-windows"
+        ml = "${goma_prefix}${prefix}/clang-cl.exe --target=arm64-windows"
         x64 = ""
       } else {
         ml = "ml.exe"


### PR DESCRIPTION
Excludes an unsupported linker flag, and fixes a typo.