### PR TITLE
Remove no-op flag from fidlc compiler

### DIFF
--- a/build/fuchsia/fidl_gen_cpp.py
+++ b/build/fuchsia/fidl_gen_cpp.py
@@ -53,8 +53,6 @@ def main():
 
   fidlc_command = [
     args.fidlc_bin,
-    '--experimental',
-    'new_syntax_only',
     '--tables',
     args.output_c_tables,
     '--json',


### PR DESCRIPTION
This change removes the dead flag for the now-completed FIDL syntax
migration.