### PR TITLE
[gn] add forward variables to compiled_action

### DIFF
--- a/build/compiled_action.gni
+++ b/build/compiled_action.gni
@@ -81,18 +81,15 @@ template("compiled_action") {
          "compiled_action doesn't take a sources arg. Use inputs instead.")
 
   action(target_name) {
-    if (defined(invoker.visibility)) {
-      visibility = invoker.visibility
-    }
-    if (defined(invoker.testonly)) {
-      testonly = invoker.testonly
-    }
-    if (defined(invoker.pool)) {
-      pool = invoker.pool
-    }
-
-    forward_variables_from(invoker, ["metadata"])
-
+    forward_variables_from(invoker,
+                           [
+                             "visibility",
+                             "metadata",
+                             "testonly",
+                             "pool",
+                             "outputs",
+                           ])
+                           
     script = "//build/gn_run_binary.py"
 
     if (defined(invoker.inputs)) {
@@ -100,7 +97,6 @@ template("compiled_action") {
     } else {
       inputs = []
     }
-    outputs = invoker.outputs
 
     if (defined(invoker.toolchain)) {
       toolchain = invoker.toolchain

--- a/build/compiled_action.gni
+++ b/build/compiled_action.gni
@@ -91,6 +91,8 @@ template("compiled_action") {
       pool = invoker.pool
     }
 
+    forward_variables_from(invoker, ["metadata"])
+
     script = "//build/gn_run_binary.py"
 
     if (defined(invoker.inputs)) {


### PR DESCRIPTION
context: https://github.com/flutter/engine/pull/34216#issuecomment-1165154820

This commit forwards the metadata variable in `generate_snapshot_bin template`, which is used to generate the `gen_snapshot` engine artifact. Together with the PR on flutter/engine side, this PR eventually aims to embed entitlement metadata in the leaf build targets.
