### PR TITLE
[fuchsia] Use the proper version of fidlc

### DIFF
--- a/build/fuchsia/sdk.gni
+++ b/build/fuchsia/sdk.gni
@@ -104,7 +104,7 @@ template("_fuchsia_fidl_library") {
 
     args = [
       "--fidlc-bin",
-      rebase_path("$_fuchsia_sdk_path/tools/fidlc"),
+      rebase_path("$_fuchsia_sdk_path/tools/$host_cpu/fidlc"),
       "--sdk-base",
       rebase_path(_fuchsia_sdk_path),
       "--root",


### PR DESCRIPTION
build/fuchsia/sdk.gni currently uses the tools from the SDK's top level tools directory (/tools). These tools will soon be removed as they are a simple copy of the tools in the architecture-specific subdirectory (e.g. /tools/x64).