### PR TITLE
Update to a current version of libcxx and libcxxabi

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -480,6 +480,16 @@ config("cxx_version_17") {
   cflags_objcc = cc_std
 }
 
+config("cxx_version_20") {
+  if (is_win) {
+    cc_std = [ "/std:c++20" ]
+  } else {
+    cc_std = [ "-std=c++20" ]
+  }
+  cflags_cc = cc_std
+  cflags_objcc = cc_std
+}
+
 config("compiler_arm_fpu") {
   if (current_cpu == "arm" && !is_ios) {
     cflags = [ "-mfpu=$arm_fpu" ]

--- a/build/config/mac/mac_sdk.gni
+++ b/build/config/mac/mac_sdk.gni
@@ -6,11 +6,11 @@ import("//build/toolchain/goma.gni")
 
 declare_args() {
   # Minimum supported version of the Mac SDK.
-  mac_sdk_min = "10.12"
+  mac_sdk_min = "10.13"
 
   # The MACOSX_DEPLOYMENT_TARGET variable used when compiling.
   # Must be of the form x.x.x for Info.plist files.
-  mac_deployment_target = "10.11.0"
+  mac_deployment_target = "10.13.0"
 
   # Path to a specific version of the Mac SDKJ, not including a backslash at
   # the end. If empty, the path to the lowest version greater than or equal to

--- a/build/secondary/third_party/libcxx/BUILD.gn
+++ b/build/secondary/third_party/libcxx/BUILD.gn
@@ -4,9 +4,15 @@
 
 config("libcxx_config") {
   defines = [ "_LIBCPP_DISABLE_AVAILABILITY=1" ]
+  include_dirs = [ "//build/secondary/third_party/libcxx/config" ]
+}
+
+config("src_include") {
+  include_dirs = [ "src" ]
 }
 
 source_set("libcxx") {
+
   sources = [
     "src/algorithm.cpp",
     "src/any.cpp",
@@ -25,6 +31,7 @@ source_set("libcxx") {
     "src/future.cpp",
     "src/hash.cpp",
     "src/ios.cpp",
+    "src/ios.instantiations.cpp",
     "src/iostream.cpp",
     "src/locale.cpp",
     "src/memory.cpp",
@@ -45,6 +52,9 @@ source_set("libcxx") {
     "src/valarray.cpp",
     "src/variant.cpp",
     "src/vector.cpp",
+    "src/ryu/d2fixed.cpp",
+    "src/ryu/d2s.cpp",
+    "src/ryu/f2s.cpp",
   ]
 
   deps = [ "//third_party/libcxxabi" ]
@@ -72,6 +82,12 @@ source_set("libcxx") {
   # libcxxabi.
   configs -= [ "//build/config/compiler:no_rtti" ]
   configs += [ "//build/config/compiler:rtti" ]
+
+  # libcxx requires C++20
+  configs -= [ "//build/config/compiler:cxx_version_default" ]
+  configs += [ "//build/config/compiler:cxx_version_20" ]
+
+  configs += [ ":src_include" ]
 
   if (is_clang) {
     # shared_mutex.cpp and debug.cpp are purposefully in violation.

--- a/build/secondary/third_party/libcxx/config/__config_site
+++ b/build/secondary/third_party/libcxx/config/__config_site
@@ -1,0 +1,37 @@
+#ifndef _LIBCPP_CONFIG_SITE
+#define _LIBCPP_CONFIG_SITE
+
+/* #undef _LIBCPP_ABI_VERSION */
+/* #undef _LIBCPP_ABI_UNSTABLE */
+/* #undef _LIBCPP_ABI_FORCE_ITANIUM */
+/* #undef _LIBCPP_ABI_FORCE_MICROSOFT */
+/* #undef _LIBCPP_HIDE_FROM_ABI_PER_TU_BY_DEFAULT */
+/* #undef _LIBCPP_HAS_NO_GLOBAL_FILESYSTEM_NAMESPACE */
+/* #undef _LIBCPP_HAS_NO_STDIN */
+/* #undef _LIBCPP_HAS_NO_STDOUT */
+/* #undef _LIBCPP_HAS_NO_THREADS */
+/* #undef _LIBCPP_HAS_NO_MONOTONIC_CLOCK */
+/* #undef _LIBCPP_HAS_NO_THREAD_UNSAFE_C_FUNCTIONS */
+/* #undef _LIBCPP_HAS_MUSL_LIBC */
+/* #undef _LIBCPP_HAS_THREAD_API_PTHREAD */
+/* #undef _LIBCPP_HAS_THREAD_API_EXTERNAL */
+/* #undef _LIBCPP_HAS_THREAD_API_WIN32 */
+/* #undef _LIBCPP_HAS_THREAD_LIBRARY_EXTERNAL */
+/* #undef _LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS */
+#define _LIBCPP_HAS_NO_VENDOR_AVAILABILITY_ANNOTATIONS
+/* #undef _LIBCPP_NO_VCRUNTIME */
+/* #undef _LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION */
+/* #undef _LIBCPP_ABI_NAMESPACE */
+/* #undef _LIBCPP_HAS_NO_FILESYSTEM_LIBRARY */
+/* #undef _LIBCPP_HAS_PARALLEL_ALGORITHMS */
+/* #undef _LIBCPP_HAS_NO_RANDOM_DEVICE */
+/* #undef _LIBCPP_HAS_NO_LOCALIZATION */
+
+// This is a workaround for BoringSSL, which is compiled in C11 mode
+// and includes stdatomic.h.  Defining this macro will cause stdatomic.h
+// to redirect to the next version of that header in the include path.
+#if !defined(__cplusplus) && defined(__clang__)
+#define _LIBCPP_COMPILER_CLANG_BASED
+#endif
+
+#endif // _LIBCPP_CONFIG_SITE

--- a/build/secondary/third_party/libcxxabi/BUILD.gn
+++ b/build/secondary/third_party/libcxxabi/BUILD.gn
@@ -20,7 +20,7 @@ source_set("libcxxabi") {
   public_configs = [ ":libcxxabi_config" ]
 
   defines = [
-    "_LIBCXXABI_NO_EXCEPTIONS",
+    "_LIBCPP_BUILDING_LIBRARY",
     "_LIBCXXABI_BUILDING_LIBRARY",
     "LIBCXXABI_SILENT_TERMINATE",
     "_LIBCXXABI_DISABLE_VISIBILITY_ANNOTATIONS",
@@ -31,7 +31,9 @@ source_set("libcxxabi") {
   # Compile libcxx ABI using C++11. This replicates the rule in the
   # CMakeLists on the "cxx_abiobjects" target.
   configs -= [ "//build/config/compiler:cxx_version_default" ]
-  configs += [ "//build/config/compiler:cxx_version_11" ]
+  configs += [ "//build/config/compiler:cxx_version_20" ]
+
+  configs += [ "//third_party/libcxx:src_include" ]
 
   # No translation units in the engine are built with exceptions. But, using
   # Objective-C exceptions requires some infrastructure setup for exceptions.
@@ -60,7 +62,6 @@ source_set("libcxxabi") {
     "src/cxa_demangle.cpp",
     "src/cxa_exception_storage.cpp",
     "src/cxa_handlers.cpp",
-    "src/cxa_unexpected.cpp",
     "src/cxa_vector.cpp",
     "src/cxa_virtual.cpp",
     "src/fallback_malloc.cpp",


### PR DESCRIPTION
This also updates the engine's minimum required version of macOS to 10.13
