### PR TITLE
Re-land vpython3 in .gn from depot_tools 

### DIFF
--- a/.gn
+++ b/.gn
@@ -1,9 +1,9 @@
 # This file is used by the experimental meta-buildsystem in src/tools/gn to
 # find the root of the source tree and to set startup options.
 
-# Use Python 3 for exec_script() calls.
+# Use vpython3 from depot_tools for exec_script() calls.
 # See `gn help dotfile` for details.
-script_executable = "python3"
+script_executable = "vpython3"
 
 # The location of the build configuration file.
 buildconfig = "//build/config/BUILDCONFIG.gn"


### PR DESCRIPTION
This reverts commit https://github.com/flutter/buildroot/commit/6ef1bf72e34e572f469386732a05de7c8495f874.

Rolling the revert in #507 breaks the Fuchsia build, which requires a Python 3 distribution that includes the yaml module. Instead, @cbracken landed flutter/engine#28314, which enables vpython3 for runs of the gn wrapper on Windows, via the [gn.bat](https://github.com/cbracken/flutter_engine/blob/b58cbb47fe2abeae49674ff1b8c9d688453cd07b/tools/gn.bat) batch script. That seems to have eliminated the flakiness we were seeing on the engine Windows bots.

Issue: https://github.com/flutter/flutter/issues/88719

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
