### PR TITLE
add arm64 to list of cpus for android_host_arch

### DIFF
--- a/build/config/android/config.gni
+++ b/build/config/android/config.gni
@@ -49,7 +49,7 @@ if (is_android) {
 
   # Defines the name the Android build gives to the current host CPU
   # architecture, which is different than the names GN uses.
-  if (host_cpu == "x64" || host_cpu == "x86") {
+  if (host_cpu == "x64" || host_cpu == "x86" || host_cpu == "arm64") {
     android_host_arch = "x86_64"
   } else {
     assert(false, "Need Android toolchain support for your build CPU arch.")


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/108395

After this fix and other fixes already merged, gn should now complete successfully for Apple Silicon Macs.