### PR TITLE
GN toolchain setup for host-arm64 Mac and Linux.

### DIFF
--- a/build/config/clang/BUILD.gn
+++ b/build/config/clang/BUILD.gn
@@ -28,8 +28,8 @@ group("llvm-symbolizer_data") {
   if (is_win) {
     data = [ "//buildtools/windows-x64/bin/llvm-symbolizer.exe" ]
   } else if (is_mac) {
-    data = [ "//buildtools/mac-x64/clang/bin/llvm-symbolizer" ]
+    data = [ "//buildtools/mac-${host_cpu}/clang/bin/llvm-symbolizer" ]
   } else if (is_linux) {
-    data = [ "//buildtools/linux-x64/clang/bin/llvm-symbolizer" ]
+    data = [ "//buildtools/linux-${host_cpu}/clang/bin/llvm-symbolizer" ]
   }
 }

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -646,6 +646,7 @@ if (is_win) {
     # Disables.
     "-Wno-missing-field-initializers",  # "struct foo f = {0};"
     "-Wno-unused-parameter",  # Unused function parameters.
+    "-Wno-unused-but-set-variable",  # libpng
   ]
 
   if (is_wasm) {

--- a/build/toolchain/linux/BUILD.gn
+++ b/build/toolchain/linux/BUILD.gn
@@ -4,9 +4,13 @@
 
 import("//build/config/sysroot.gni")
 import("//build/toolchain/ccache.gni")
-import("//build/toolchain/clang.gni")
 import("//build/toolchain/gcc_toolchain.gni")
 import("//build/toolchain/goma.gni")
+
+declare_args() {
+  toolchain_prefix = ""
+  # TODO(zra): Add an argument for overriding the host toolchain.
+}
 
 if (use_goma) {
   assert(!use_ccache, "Goma and ccache can't be used together.")
@@ -17,29 +21,90 @@ if (use_goma) {
   compiler_prefix = ""
 }
 
-gcc_toolchain("arm") {
-  cc = "${compiler_prefix}arm-linux-gnueabi-gcc"
-  cxx = "${compiler_prefix}arm-linux-gnueabi-g++"
+if (host_cpu == "arm64") {
+  rebased_clang_dir =
+      rebase_path("//buildtools/linux-arm64/clang/bin", root_build_dir)
+} else {
+  rebased_clang_dir =
+      rebase_path("//buildtools/linux-x64/clang/bin", root_build_dir)
+}
 
-  ar = "arm-linux-gnueabi-ar"
+gcc_toolchain("arm") {
+  prefix = "arm-linux-gnueabihf-"
+  if (toolchain_prefix != "") {
+    prefix = toolchain_prefix
+  }
+
+  cc = "${compiler_prefix}${prefix}gcc"
+  cxx = "${compiler_prefix}${prefix}g++"
+
+  ar = "${prefix}ar"
   ld = cxx
-  readelf = "arm-linux-gnueabi-readelf"
-  nm = "arm-linux-gnueabi-nm"
+  readelf = "${prefix}readelf"
+  nm = "${prefix}nm"
+  strip = "${prefix}strip"
 
   toolchain_cpu = "arm"
   toolchain_os = "linux"
   is_clang = false
 }
 
-gcc_toolchain("clang_x86") {
-  if (use_clang_type_profiler) {
-    prefix = rebase_path("//third_party/llvm-allocated-type/Linux_ia32/bin",
-                         root_build_dir)
-  } else {
-    prefix = rebase_path("//buildtools/linux-x64/clang/bin", root_build_dir)
+gcc_toolchain("clang_arm") {
+  prefix = rebased_clang_dir
+  cc = "${compiler_prefix}${prefix}/clang"
+  cxx = "${compiler_prefix}${prefix}/clang++"
+
+  readelf = "${prefix}/llvm-readelf"
+  nm = "${prefix}/llvm-nm"
+  ar = "${prefix}/llvm-ar"
+  ld = cxx
+  llvm_objcopy = "${prefix}/llvm-objcopy"
+
+  toolchain_cpu = "arm"
+  toolchain_os = "linux"
+  is_clang = true
+}
+
+gcc_toolchain("arm64") {
+  prefix = "aarch64-linux-gnu-"
+  if (toolchain_prefix != "") {
+    prefix = toolchain_prefix
   }
-  cc = "${compiler_prefix}$prefix/clang"
-  cxx = "${compiler_prefix}$prefix/clang++"
+
+  cc = "${compiler_prefix}${prefix}gcc"
+  cxx = "${compiler_prefix}${prefix}g++"
+
+  ar = "${prefix}ar"
+  ld = cxx
+  readelf = "${prefix}readelf"
+  nm = "${prefix}nm"
+  strip = "${prefix}strip"
+
+  toolchain_cpu = "arm64"
+  toolchain_os = "linux"
+  is_clang = false
+}
+
+gcc_toolchain("clang_arm64") {
+  prefix = rebased_clang_dir
+  cc = "${compiler_prefix}${prefix}/clang"
+  cxx = "${compiler_prefix}${prefix}/clang++"
+
+  readelf = "readelf"
+  nm = "${prefix}/llvm-nm"
+  ar = "${prefix}/llvm-ar"
+  ld = cxx
+  llvm_objcopy = "${prefix}/llvm-objcopy"
+
+  toolchain_cpu = "arm64"
+  toolchain_os = "linux"
+  is_clang = true
+}
+
+gcc_toolchain("clang_x86") {
+  prefix = rebased_clang_dir
+  cc = "${compiler_prefix}${prefix}/clang"
+  cxx = "${compiler_prefix}${prefix}/clang++"
 
   readelf = "${prefix}/llvm-readelf"
   nm = "${prefix}/llvm-nm"
@@ -69,14 +134,9 @@ gcc_toolchain("x86") {
 }
 
 gcc_toolchain("clang_x64") {
-  if (use_clang_type_profiler) {
-    prefix = rebase_path("//third_party/llvm-allocated-type/Linux_x64/bin",
-                         root_build_dir)
-  } else {
-    prefix = rebase_path("//buildtools/linux-x64/clang/bin", root_build_dir)
-  }
-  cc = "${compiler_prefix}$prefix/clang"
-  cxx = "${compiler_prefix}$prefix/clang++"
+  prefix = rebased_clang_dir
+  cc = "${compiler_prefix}${prefix}/clang"
+  cxx = "${compiler_prefix}${prefix}/clang++"
 
   readelf = "${prefix}/llvm-readelf"
   nm = "${prefix}/llvm-nm"
@@ -85,27 +145,6 @@ gcc_toolchain("clang_x64") {
   llvm_objcopy = "${prefix}/llvm-objcopy"
 
   toolchain_cpu = "x64"
-  toolchain_os = "linux"
-  is_clang = true
-}
-
-gcc_toolchain("clang_arm64") {
-  if (use_clang_type_profiler) {
-    prefix = rebase_path("//third_party/llvm-allocated-type/Linux_x64/bin",
-                         root_build_dir)
-  } else {
-    prefix = rebase_path("//buildtools/linux-x64/clang/bin", root_build_dir)
-  }
-  cc = "${compiler_prefix}$prefix/clang"
-  cxx = "${compiler_prefix}$prefix/clang++"
-
-  readelf = "readelf"
-  nm = "${prefix}/llvm-nm"
-  ar = "${prefix}/llvm-ar"
-  ld = cxx
-  llvm_objcopy = "${prefix}/llvm-objcopy"
-
-  toolchain_cpu = "arm64"
   toolchain_os = "linux"
   is_clang = true
 }
@@ -124,4 +163,76 @@ gcc_toolchain("x64") {
   toolchain_cpu = "x64"
   toolchain_os = "linux"
   is_clang = false
+}
+
+gcc_toolchain("riscv32") {
+  prefix = "riscv32-linux-gnu-"
+  if (toolchain_prefix != "") {
+    prefix = toolchain_prefix
+  }
+
+  cc = "${compiler_prefix}${prefix}gcc"
+  cxx = "${compiler_prefix}${prefix}g++"
+
+  ar = "${prefix}ar"
+  ld = cxx
+  readelf = "${prefix}readelf"
+  nm = "${prefix}nm"
+  strip = "${prefix}strip"
+
+  toolchain_cpu = "riscv32"
+  toolchain_os = "linux"
+  is_clang = false
+}
+
+gcc_toolchain("clang_riscv32") {
+  prefix = rebased_clang_dir
+  cc = "${compiler_prefix}${prefix}/clang"
+  cxx = "${compiler_prefix}${prefix}/clang++"
+
+  readelf = "readelf"
+  nm = "${prefix}/llvm-nm"
+  ar = "${prefix}/llvm-ar"
+  ld = cxx
+  llvm_objcopy = "${prefix}/llvm-objcopy"
+
+  toolchain_cpu = "riscv32"
+  toolchain_os = "linux"
+  is_clang = true
+}
+
+gcc_toolchain("riscv64") {
+  prefix = "riscv64-linux-gnu-"
+  if (toolchain_prefix != "") {
+    prefix = toolchain_prefix
+  }
+
+  cc = "${compiler_prefix}${prefix}gcc"
+  cxx = "${compiler_prefix}${prefix}g++"
+
+  ar = "${prefix}ar"
+  ld = cxx
+  readelf = "${prefix}readelf"
+  nm = "${prefix}nm"
+  strip = "${prefix}strip"
+
+  toolchain_cpu = "riscv64"
+  toolchain_os = "linux"
+  is_clang = false
+}
+
+gcc_toolchain("clang_riscv64") {
+  prefix = rebased_clang_dir
+  cc = "${compiler_prefix}${prefix}/clang"
+  cxx = "${compiler_prefix}${prefix}/clang++"
+
+  readelf = "readelf"
+  nm = "${prefix}/llvm-nm"
+  ar = "${prefix}/llvm-ar"
+  ld = cxx
+  llvm_objcopy = "${prefix}/llvm-objcopy"
+
+  toolchain_cpu = "riscv64"
+  toolchain_os = "linux"
+  is_clang = true
 }

--- a/build/toolchain/mac/BUILD.gn
+++ b/build/toolchain/mac/BUILD.gn
@@ -26,6 +26,15 @@ if (use_goma) {
   goma_prefix = ""
 }
 
+# Goma doesn't support the host-arm64 toolchain, so continue using Rosetta.
+if (host_cpu == "arm64" && !use_goma) {
+  rebased_clang_dir =
+      rebase_path("//buildtools/mac-arm64/clang/bin", root_build_dir)
+} else {
+  rebased_clang_dir =
+      rebase_path("//buildtools/mac-x64/clang/bin", root_build_dir)
+}
+
 # Shared toolchain definition. Invocations should set toolchain_os to set the
 # build args in this definition.
 template("mac_toolchain") {
@@ -218,14 +227,12 @@ template("mac_toolchain") {
   }
 }
 
-llvm_bin_path = "//buildtools/mac-x64/clang/bin"
-
 # Toolchain used for iOS device targets.
 mac_toolchain("ios_clang_arm") {
   toolchain_cpu = "arm"
   toolchain_os = "mac"
   if (!use_xcode) {
-    prefix = rebase_path(llvm_bin_path, root_build_dir)
+    prefix = rebased_clang_dir
     ar = "$prefix/llvm-ar"
     cc = "$prefix/clang"
     cxx = "$prefix/clang++"
@@ -244,7 +251,7 @@ mac_toolchain("ios_clang_arm_sim") {
   toolchain_cpu = "arm"
   toolchain_os = "mac"
   if (!use_xcode) {
-    prefix = rebase_path(llvm_bin_path, root_build_dir)
+    prefix = rebased_clang_dir
     ar = "$prefix/llvm-ar"
     cc = "$prefix/clang"
     cxx = "$prefix/clang++"
@@ -262,7 +269,7 @@ mac_toolchain("ios_clang_arm_sim") {
 mac_toolchain("ios_clang_x64_sim") {
   toolchain_cpu = "x64"
   toolchain_os = "mac"
-  prefix = rebase_path(llvm_bin_path, root_build_dir)
+  prefix = rebased_clang_dir
   ar = "$prefix/llvm-ar"
   cc = "$prefix/clang"
   cxx = "$prefix/clang++"
@@ -276,7 +283,7 @@ mac_toolchain("clang_x64") {
   toolchain_cpu = "x64"
   toolchain_os = "mac"
   if (!use_xcode) {
-    prefix = rebase_path(llvm_bin_path, root_build_dir)
+    prefix = rebased_clang_dir
     ar = "$prefix/llvm-ar"
     cc = "$prefix/clang"
     cxx = "$prefix/clang++"
@@ -295,7 +302,7 @@ mac_toolchain("clang_arm64") {
   toolchain_cpu = "arm64"
   toolchain_os = "mac"
   if (!use_xcode) {
-    prefix = rebase_path(llvm_bin_path, root_build_dir)
+    prefix = rebased_clang_dir
     ar = "$prefix/llvm-ar"
     cc = "$prefix/clang"
     cxx = "$prefix/clang++"


### PR DESCRIPTION
This toolchain is enabled only for non-Goma builds.

Copy missing Linux toolchain setup from Dart.

Bug: https://github.com/flutter/flutter/issues/103386