### PR TITLE
Remove -Wno-unused-but-set-variable.

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -646,7 +646,6 @@ if (is_win) {
     # Disables.
     "-Wno-missing-field-initializers",  # "struct foo f = {0};"
     "-Wno-unused-parameter",  # Unused function parameters.
-    "-Wno-unused-but-set-variable",  # libpng
   ]
 
   if (is_wasm) {


### PR DESCRIPTION
Whatever toolchain is running on the "Mac iOS Engine" bot doesn't understand this.

Cf. 76a47ff948a26da06b16cd3edb84d30a51d51a5e.