### PR TITLE
Enable symbol visibility annotations in libcxxabi on iOS

### DIFF
--- a/build/secondary/third_party/libcxxabi/BUILD.gn
+++ b/build/secondary/third_party/libcxxabi/BUILD.gn
@@ -23,8 +23,11 @@ source_set("libcxxabi") {
     "_LIBCPP_BUILDING_LIBRARY",
     "_LIBCXXABI_BUILDING_LIBRARY",
     "LIBCXXABI_SILENT_TERMINATE",
-    "_LIBCXXABI_DISABLE_VISIBILITY_ANNOTATIONS",
   ]
+
+  if (!is_ios) {
+    defines += [ "_LIBCXXABI_DISABLE_VISIBILITY_ANNOTATIONS" ]
+  }
 
   sources = []
 


### PR DESCRIPTION
This is required to fix bitcode LTO builds when building the engine
for iOS using libcxx instead of the Xcode standard library headers.

See https://github.com/flutter/flutter/issues/110140
