### PR TITLE
Revert "Enable symbol visibility annotations in libcxxabi on iOS (#606)"

### DIFF
--- a/build/secondary/third_party/libcxxabi/BUILD.gn
+++ b/build/secondary/third_party/libcxxabi/BUILD.gn
@@ -23,11 +23,8 @@ source_set("libcxxabi") {
     "_LIBCPP_BUILDING_LIBRARY",
     "_LIBCXXABI_BUILDING_LIBRARY",
     "LIBCXXABI_SILENT_TERMINATE",
+    "_LIBCXXABI_DISABLE_VISIBILITY_ANNOTATIONS",
   ]
-
-  if (!is_ios) {
-    defines += [ "_LIBCXXABI_DISABLE_VISIBILITY_ANNOTATIONS" ]
-  }
 
   sources = []
 


### PR DESCRIPTION
This reverts commit 0626ae6d76245e15ec31b5d8965f8ef7227a6e7e.

_LIBCXXABI_DISABLE_VISIBILITY_ANNOTATIONS will make all libcxxabi symbols
externally visible.  It would be preferable to reduce the visible symbols
to the minimal subset required to make the bitcode/LTO linker work.

See https://github.com/flutter/flutter/issues/110140
