### PR TITLE
Do not export symbols for the new and delete operators in libcxxabi on iOS

### DIFF
--- a/build/secondary/third_party/libcxxabi/BUILD.gn
+++ b/build/secondary/third_party/libcxxabi/BUILD.gn
@@ -12,6 +12,10 @@ config("libcxxabi_config") {
   cflags_objcc = common_cc_flags
 
   include_dirs = [ "include" ]
+
+  if (is_ios) {
+    ldflags = [ "-Wl,-unexported_symbols_list," + rebase_path("lib/new-delete.exp", root_build_dir) ]
+  }
 }
 
 source_set("libcxxabi") {


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/110140
