### PR TITLE
Override the WASM toolchain to use CanvasKit-specific args

### DIFF
--- a/build/toolchain/gcc_toolchain.gni
+++ b/build/toolchain/gcc_toolchain.gni
@@ -280,16 +280,20 @@ template("gcc_toolchain") {
 
     # When invoking this toolchain not as the default one, these args will be
     # passed to the build. They are ignored when this is the default toolchain.
-    toolchain_args = {
-      current_cpu = invoker.toolchain_cpu
-      current_os = invoker.toolchain_os
+    if (defined(invoker.toolchain_args)) {
+      toolchain_args = invoker.toolchain_args
+    } else {
+      toolchain_args = {
+        current_cpu = invoker.toolchain_cpu
+        current_os = invoker.toolchain_os
 
-      # These values need to be passed through unchanged.
-      target_os = target_os
-      target_cpu = target_cpu
+        # These values need to be passed through unchanged.
+        target_os = target_os
+        target_cpu = target_cpu
 
-      if (defined(invoker.is_clang)) {
-        is_clang = invoker.is_clang
+        if (defined(invoker.is_clang)) {
+          is_clang = invoker.is_clang
+        }
       }
     }
 

--- a/build/toolchain/gcc_toolchain.gni
+++ b/build/toolchain/gcc_toolchain.gni
@@ -297,7 +297,6 @@ template("gcc_toolchain") {
       }
     }
 
-
     if (defined(invoker.deps)) {
       deps = invoker.deps
     }

--- a/build/toolchain/gcc_toolchain.gni
+++ b/build/toolchain/gcc_toolchain.gni
@@ -280,22 +280,23 @@ template("gcc_toolchain") {
 
     # When invoking this toolchain not as the default one, these args will be
     # passed to the build. They are ignored when this is the default toolchain.
-    if (defined(invoker.toolchain_args)) {
-      toolchain_args = invoker.toolchain_args
-    } else {
-      toolchain_args = {
-        current_cpu = invoker.toolchain_cpu
-        current_os = invoker.toolchain_os
+    toolchain_args = {
+      current_cpu = invoker.toolchain_cpu
+      current_os = invoker.toolchain_os
 
-        # These values need to be passed through unchanged.
-        target_os = target_os
-        target_cpu = target_cpu
+      # These values need to be passed through unchanged.
+      target_os = target_os
+      target_cpu = target_cpu
 
-        if (defined(invoker.is_clang)) {
-          is_clang = invoker.is_clang
-        }
+      if (defined(invoker.is_clang)) {
+        is_clang = invoker.is_clang
+      }
+
+      if (defined(invoker.extra_toolchain_args)) {
+        forward_variables_from(invoker.extra_toolchain_args, "*")
       }
     }
+
 
     if (defined(invoker.deps)) {
       deps = invoker.deps

--- a/build/toolchain/wasm/BUILD.gn
+++ b/build/toolchain/wasm/BUILD.gn
@@ -26,17 +26,14 @@ gcc_toolchain("wasm") {
   readelf = "readelf"
   nm = "nm"
 
+  is_clang = true
+
   toolchain_cpu = "wasm"
   toolchain_os = "wasm"
 
   link_outputs = [ "{{root_out_dir}}/{{target_output_name}}.wasm" ]
 
-  toolchain_args = {
-    is_clang = true
-    target_os = target_os
-    target_cpu = target_cpu
-    current_cpu = toolchain_cpu
-    current_os = toolchain_os
+  extra_toolchain_args = {
     skia_use_angle = false
     skia_use_dng_sdk = false
     skia_use_dawn = false

--- a/build/toolchain/wasm/BUILD.gn
+++ b/build/toolchain/wasm/BUILD.gn
@@ -26,10 +26,10 @@ gcc_toolchain("wasm") {
   readelf = "readelf"
   nm = "nm"
 
-  is_clang = true
-
   toolchain_cpu = "wasm"
   toolchain_os = "wasm"
+
+  is_clang = true
 
   link_outputs = [ "{{root_out_dir}}/{{target_output_name}}.wasm" ]
 

--- a/build/toolchain/wasm/BUILD.gn
+++ b/build/toolchain/wasm/BUILD.gn
@@ -37,6 +37,7 @@ gcc_toolchain("wasm_for_canvaskit") {
   link_outputs = [ "{{root_out_dir}}/{{target_output_name}}.wasm" ]
 
   extra_toolchain_args = {
+    skia_use_vulkan = false
     skia_use_webgpu = false
     skia_use_libheif = false
     skia_use_libjpeg_turbo_decode = true
@@ -48,6 +49,7 @@ gcc_toolchain("wasm_for_canvaskit") {
     skia_use_lua = false
     skia_use_wuffs = true
     skia_use_zlib = true
+    skia_gl_standard = "webgl"
     skia_enable_gpu = true
     skia_enable_sksl_tracing = false
     skia_use_icu = true

--- a/build/toolchain/wasm/BUILD.gn
+++ b/build/toolchain/wasm/BUILD.gn
@@ -17,7 +17,10 @@ if (use_goma) {
   compiler_prefix = ""
 }
 
-gcc_toolchain("wasm") {
+# This toolchain is specifically for building CanvasKit.
+#
+# It overrides many Skia args in order to facilitate building CanvasKit.
+gcc_toolchain("wasm_for_canvaskit") {
   # emsdk_dir and em_config are defined in wasm.gni.
   ar = "$compiler_prefix$emsdk_dir/upstream/emscripten/emar --em-config $em_config_path"
   cc = "$compiler_prefix$emsdk_dir/upstream/emscripten/emcc --em-config $em_config_path"

--- a/build/toolchain/wasm/BUILD.gn
+++ b/build/toolchain/wasm/BUILD.gn
@@ -29,7 +29,62 @@ gcc_toolchain("wasm") {
   toolchain_cpu = "wasm"
   toolchain_os = "wasm"
 
-  is_clang = true
-
   link_outputs = [ "{{root_out_dir}}/{{target_output_name}}.wasm" ]
+
+  toolchain_args = {
+    is_clang = true
+    target_os = target_os
+    target_cpu = target_cpu
+    current_cpu = toolchain_cpu
+    current_os = toolchain_os
+    skia_use_angle = false
+    skia_use_dng_sdk = false
+    skia_use_dawn = false
+    skia_use_webgl = true
+    skia_use_webgpu = false
+    skia_use_expat = false
+    skia_use_fontconfig = false
+    skia_use_freetype = true
+    skia_use_libheif = false
+    skia_use_libjpeg_turbo_decode = true
+    skia_use_libjpeg_turbo_encode = false
+    skia_use_libpng_decode = true
+    skia_use_libpng_encode = true
+    skia_use_libwebp_decode = true
+    skia_use_libwebp_encode = false
+    skia_use_lua = false
+    skia_use_piex = false
+    skia_use_vulkan = false
+    skia_use_wuffs = true
+    skia_use_zlib = true
+    skia_enable_gpu = true
+    skia_build_for_debugger = false
+    skia_enable_sksl_tracing = false
+    skia_use_icu = true
+    skia_use_harfbuzz = true
+    skia_enable_fontmgr_custom_directory = false
+    skia_enable_fontmgr_custom_embedded = true
+    skia_enable_fontmgr_custom_empty = false
+    skia_enable_skshaper = true
+    skia_enable_skparagraph = true
+    skia_enable_pdf = false
+    skia_canvaskit_force_tracing = false
+    skia_canvaskit_enable_skp_serialization = true
+    skia_canvaskit_enable_effects_deserialization = false
+    skia_canvaskit_enable_skottie = false
+    skia_canvaskit_include_viewer = false
+    skia_canvaskit_enable_particles = false
+    skia_canvaskit_enable_pathops= true
+    skia_canvaskit_enable_rt_shader = true
+    skia_canvaskit_enable_matrix_helper = false
+    skia_canvaskit_enable_canvas_bindings = false
+    skia_canvaskit_enable_font = true
+    skia_canvaskit_enable_embedded_font = true
+    skia_canvaskit_enable_alias_font = true
+    skia_canvaskit_legacy_draw_vertices_blend_mode = false
+    skia_canvaskit_enable_debugger = false
+    skia_canvaskit_enable_paragraph = true
+    skia_canvaskit_enable_webgl = true
+    skia_canvaskit_enable_webgpu = false
+  }
 }

--- a/build/toolchain/wasm/BUILD.gn
+++ b/build/toolchain/wasm/BUILD.gn
@@ -37,14 +37,7 @@ gcc_toolchain("wasm_for_canvaskit") {
   link_outputs = [ "{{root_out_dir}}/{{target_output_name}}.wasm" ]
 
   extra_toolchain_args = {
-    skia_use_angle = false
-    skia_use_dng_sdk = false
-    skia_use_dawn = false
-    skia_use_webgl = true
     skia_use_webgpu = false
-    skia_use_expat = false
-    skia_use_fontconfig = false
-    skia_use_freetype = true
     skia_use_libheif = false
     skia_use_libjpeg_turbo_decode = true
     skia_use_libjpeg_turbo_encode = false
@@ -53,12 +46,9 @@ gcc_toolchain("wasm_for_canvaskit") {
     skia_use_libwebp_decode = true
     skia_use_libwebp_encode = false
     skia_use_lua = false
-    skia_use_piex = false
-    skia_use_vulkan = false
     skia_use_wuffs = true
     skia_use_zlib = true
     skia_enable_gpu = true
-    skia_build_for_debugger = false
     skia_enable_sksl_tracing = false
     skia_use_icu = true
     skia_use_harfbuzz = true
@@ -67,14 +57,13 @@ gcc_toolchain("wasm_for_canvaskit") {
     skia_enable_fontmgr_custom_empty = false
     skia_enable_skshaper = true
     skia_enable_skparagraph = true
-    skia_enable_pdf = false
     skia_canvaskit_force_tracing = false
     skia_canvaskit_enable_skp_serialization = true
     skia_canvaskit_enable_effects_deserialization = false
     skia_canvaskit_enable_skottie = false
     skia_canvaskit_include_viewer = false
     skia_canvaskit_enable_particles = false
-    skia_canvaskit_enable_pathops= true
+    skia_canvaskit_enable_pathops = true
     skia_canvaskit_enable_rt_shader = true
     skia_canvaskit_enable_matrix_helper = false
     skia_canvaskit_enable_canvas_bindings = false


### PR DESCRIPTION
Causes the WASM toolchain to use CanvasKit specific arguments.

This allows us to build CanvasKit cross-compiled as part of the normal "host_debug" build, without affecting the normal
Skia build used for Flutter on mobile devices and desktop.

This enables https://github.com/flutter/engine/pull/32510

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
