### PR TITLE
Enable native Windows on Arm build

### DIFF
--- a/build/toolchain/win/BUILD.gn
+++ b/build/toolchain/win/BUILD.gn
@@ -288,6 +288,7 @@ if (target_cpu == "arm64") {
   win_toolchains("arm64") {
     toolchain_arch = "arm64"
   }
+  # Cross-compilation support for x64 hosts.
   if (host_cpu != "arm64") {
     win_toolchains(host_cpu) {
         toolchain_arch = host_cpu

--- a/build/toolchain/win/BUILD.gn
+++ b/build/toolchain/win/BUILD.gn
@@ -288,7 +288,9 @@ if (target_cpu == "arm64") {
   win_toolchains("arm64") {
     toolchain_arch = "arm64"
   }
-  win_toolchains(host_cpu) {
-    toolchain_arch = host_cpu
+  if (host_cpu != "arm64") {
+    win_toolchains(host_cpu) {
+        toolchain_arch = host_cpu
+    }
   }
 }

--- a/build/toolchain/win/setup_toolchain.py
+++ b/build/toolchain/win/setup_toolchain.py
@@ -61,12 +61,17 @@ def _SetupScript(target_cpu, sdk_dir):
     return [os.path.normpath(os.path.join(sdk_dir, 'Bin/SetEnv.Cmd')),
             '/' + target_cpu]
   else:
+    vcvars_arch = {
+        'x86': 'amd64_x86',
+        'x64': 'amd64',
+        'arm64': 'amd64_arm64',
+    }
     # We only support x64-hosted tools.
     # TODO(scottmg|dpranke): Non-depot_tools toolchain: need to get Visual
     # Studio install location from registry.
     return [os.path.normpath(os.path.join(os.environ['GYP_MSVS_OVERRIDE_PATH'],
                                           'VC/Auxiliary/Build/vcvarsall.bat')),
-            'amd64_x86' if target_cpu == 'x86' else 'amd64']
+            vcvars_arch[target_cpu]]
 
 
 def _FormatAsEnvironmentBlock(envvar_dict):

--- a/build/vs_toolchain.py
+++ b/build/vs_toolchain.py
@@ -41,6 +41,12 @@ MSVS_VERSIONS = collections.OrderedDict([
   ('2022', '17.0'),
 ])
 
+VC_VERSIONS = {
+  '2017': 'VC141',
+  '2019': 'VC142',
+  '2022': 'VC143',
+}
+
 
 def SetEnvironmentAndGetRuntimeDllDirs():
   """Sets up os.environ to use the depot_tools VS toolchain with gyp, and
@@ -247,15 +253,19 @@ def _CopyUCRTRuntime(target_dir, source_dir, target_cpu, dll_pattern, suffix):
   """Copy both the msvcp and vccorlib runtime DLLs, only if the target doesn't
   exist, but the target directory does exist."""
   if target_cpu == 'arm64':
+    env_version = GetVisualStudioVersion()
+    vc_version = VC_VERSIONS[env_version]
+    prefix = 'Microsoft.' + vc_version
+
     # Windows ARM64 VCRuntime is located at {toolchain_root}/VC/Redist/MSVC/
-    # {x.y.z}/[debug_nonredist/]arm64/Microsoft.VC141.CRT/.
+    # {x.y.z}/[debug_nonredist/]arm64/Microsoft.VC14{1,2,3}.CRT/.
     vc_redist_root = FindVCRedistRoot()
     if suffix.startswith('.'):
       source_dir = os.path.join(vc_redist_root,
-                                'arm64', 'Microsoft.VC141.CRT')
+                                'arm64', prefix + '.CRT')
     else:
       source_dir = os.path.join(vc_redist_root, 'debug_nonredist',
-                                'arm64', 'Microsoft.VC141.DebugCRT')
+                                'arm64', prefix + '.DebugCRT')
   for file_part in ('msvcp', 'vccorlib', 'vcruntime'):
     dll = dll_pattern % file_part
     target = os.path.join(target_dir, dll)


### PR DESCRIPTION
Linaro [Windows on Arm](https://www.linaro.org/windows-on-arm/) team is working to enable projects for this new platform.
Lately, we have been interested in Dart/Flutter.

This PR enables building natively flutter components (exe + dll) for windows on arm.

It solves this issue (https://github.com/flutter/flutter/issues/62597) partially, by starting with native build.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
