### PR TITLE
Override the top level default target in the case of WASM

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -6,7 +6,7 @@ group("default") {
   testonly = true
   if (target_os == "wasm") {
     deps = [
-      "//flutter/wasm:wasm_artifacts"
+      "//flutter/wasm"
     ]
   } else {
     deps = [
@@ -20,7 +20,7 @@ group("dist") {
 
   if (target_os == "wasm") {
     deps = [
-      "//flutter/wasm:wasm_artifacts"
+      "//flutter/wasm"
     ]
   } else {
     deps = [

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -6,7 +6,7 @@ group("default") {
   testonly = true
   if (target_os == "wasm") {
     deps = [
-      "//flutter/web_sdk/wasm:wasm_artifacts"
+      "//flutter/wasm:wasm_artifacts"
     ]
   } else {
     deps = [
@@ -20,7 +20,7 @@ group("dist") {
 
   if (target_os == "wasm") {
     deps = [
-      "//flutter/web_sdk/wasm:wasm_artifacts"
+      "//flutter/wasm:wasm_artifacts"
     ]
   } else {
     deps = [

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -4,15 +4,27 @@
 
 group("default") {
   testonly = true
-  deps = [
-    "//flutter",
-  ]
+  if (target_os == "wasm") {
+    deps = [
+      "//flutter/web_sdk/wasm:wasm_artifacts"
+    ]
+  } else {
+    deps = [
+      "//flutter",
+    ]
+  }
 }
 
 group("dist") {
   testonly = true
 
-  deps = [
-    "//flutter:dist",
-  ]
+  if (target_os == "wasm") {
+    deps = [
+      "//flutter/web_sdk/wasm:wasm_artifacts"
+    ]
+  } else {
+    deps = [
+      "//flutter:dist",
+    ]
+  }
 }


### PR DESCRIPTION
If building for WASM, change the default target to build the WASM artifacts needed by the Web SDK.

This change is necessary for `gn gen` to work when `target_cpu = "wasm"` since the imports from `//flutter/BUILD.gn` lead to a check in `//flutter/shell/platform/BUILD.gn` which throws if the target CPU is not recognized.

We do not (currently?) want to compile the Flutter SDK to WASM. Our only current use case is building CanvasKit for the Flutter Web SDK.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
