### PR TITLE
Add new is_castos definition to prepare for ANGLE roll

### DIFF
--- a/build/config/BUILDCONFIG.gn
+++ b/build/config/BUILDCONFIG.gn
@@ -293,6 +293,7 @@ is_apple = is_ios || is_mac
 is_nacl = false
 
 # Needed for //third_party/angle.
+is_castos = false
 is_chromecast = false
 is_chromeos_lacros = false
 ozone_platform_headless = false


### PR DESCRIPTION
ANGLE renamed `is_chromecast` to `is_castos`: https://chromium-review.googlesource.com/c/angle/angle/+/3782573

This adds the new definition so that we can prepare for the ANGLE roll. Once the roll is complete, we should consider removing the `is_chromecast` definition.

Part of: https://github.com/flutter/flutter/issues/110948

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
