### PR TITLE
Remove iOS bitcode properties, stop using Xcode toolchain

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -159,21 +159,6 @@ config("compiler") {
     # These flags are shared between the C compiler and linker.
     common_mac_flags = []
 
-    if (enable_bitcode) {
-      if (bitcode_marker) {
-        # lld, which is the default, does not support the -bitcode_process_mode
-        # flag that gets plumbed to it as a result of -fembed-bitcode-marker, so
-        # we fall back on ld64.
-        # See: https://github.com/llvm/llvm-project/issues/55415
-        if (!use_xcode) {
-          ldflags += [ "-fuse-ld=ld" ]
-        }
-        common_mac_flags += [ "-fembed-bitcode-marker" ]
-      } else {
-        common_mac_flags += [ "-fembed-bitcode" ]
-      }
-    }
-
     # CPU architecture.
     if (current_cpu == "x64") {
       common_mac_flags += [
@@ -833,16 +818,11 @@ if (is_win) {
     # Don't emit the GCC version ident directives, they just end up in the
     # .comment section taking up binary size.
     "-fno-ident",
+    # Put data and code in their own sections, so that unused symbols
+    # can be removed at link time with --gc-sections.
+    "-fdata-sections",
+    "-ffunction-sections",
   ]
-
-  if (!enable_bitcode || bitcode_marker) {
-    common_optimize_on_cflags += [
-      # Put data and code in their own sections, so that unused symbols
-      # can be removed at link time with --gc-sections.
-      "-fdata-sections",
-      "-ffunction-sections",
-    ]
-  }
   common_optimize_on_ldflags = []
 
   if (is_android) {

--- a/build/toolchain/clang.gni
+++ b/build/toolchain/clang.gni
@@ -18,36 +18,15 @@ declare_args() {
   # Generate code with instrumentation for code coverage generation using LLVM.
   enable_coverage = false
 
-  # Set this flag to enable bitcode. Only valid for iOS ARM builds.
-  enable_bitcode = false
-
-  # Set this flag to cause bitcode to be marker only.
-  bitcode_marker = false
-
   # Set this flag to strip .so files.
   stripped_symbols = !is_debug
 }
 
 declare_args() {
-  # The version of Xcode used to archive a release application with embedded
-  # bitcode must be greater than or equal to the version of the toolchain
-  # that created the bitcode in Flutter.framework. This means that when we build
-  # the framework with embedded bitcode, we must use the Xcode toolchain and
-  # its version must be less than or equal to what we expect our developers to be using.
-  # Unfortunately, using the Xcode toolchain is not compatible with GOMA.
-  #
-  # The failure mode for this arises when a developer attempts to archive an application
-  # for publication to the store with embedded bitcode.
-  #
-  # Since we do not support publishing debug or profile builds, we use 
-  # bitcode_marker which is intrinsically faster to build and does not introduce
-  # compatibility concerns between toolchains, meaning we can use
-  # a GOMA enabled Clang.
-  #
   # TODO(gw280): Once our own copy of clang 12 is capable of building for arm64 simulator,
   # we can safely remove the requirement that we use xcode for arm64 simulator builds.
   if (is_mac || is_ios) {
-    use_xcode = (enable_bitcode && !bitcode_marker) || (use_ios_simulator && target_cpu == "arm64")
+    use_xcode = (use_ios_simulator && target_cpu == "arm64")
   } else {
     use_xcode = false
   }

--- a/build/toolchain/mac/BUILD.gn
+++ b/build/toolchain/mac/BUILD.gn
@@ -17,9 +17,6 @@ import("//build/toolchain/clang.gni")
 import("//build/toolchain/clang_static_analyzer.gni")
 import("//build/toolchain/goma.gni")
 
-assert(!enable_bitcode || !use_ios_simulator)
-assert(!enable_bitcode || (use_xcode || bitcode_marker))
-
 if (use_goma) {
   goma_prefix = "$goma_dir/gomacc "
 } else {


### PR DESCRIPTION
Bitcode has been deprecated.  Remove `enable_bitcode` and `bitcode_marker` properties.  Usage removed in engine with https://github.com/flutter/engine/pull/36596.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
