### PR TITLE
Revert "[Windows] Move to Visual Studio 2019"

### DIFF
--- a/build/config/mac/mac_sdk.gni
+++ b/build/config/mac/mac_sdk.gni
@@ -12,7 +12,7 @@ declare_args() {
   # Must be of the form x.x.x for Info.plist files.
   mac_deployment_target = "10.13.0"
 
-  # Path to a specific version of the Mac SDK, not including a backslash at
+  # Path to a specific version of the Mac SDKJ, not including a backslash at
   # the end. If empty, the path to the lowest version greater than or equal to
   # mac_sdk_min is used.
   mac_sdk_path = ""

--- a/build/vs_toolchain.py
+++ b/build/vs_toolchain.py
@@ -36,8 +36,8 @@ sys.path.insert(0, os.path.join(script_dir, '..', 'tools'))
 
 # VS versions are listed in descending order of priority (highest first).
 MSVS_VERSIONS = collections.OrderedDict([
-  ('2019', '16.0'),
   ('2017', '15.0'),
+  ('2019', '16.0'),
   ('2022', '17.0'),
 ])
 
@@ -421,13 +421,17 @@ def _CopyDebugger(target_dir, target_cpu):
 def _GetDesiredVsToolchainHashes():
   """Load a list of SHA1s corresponding to the toolchains that we want installed
   to build with."""
-  # VS 2019 16.61 with 10.0.20348.0 SDK, 10.0.19041 version of Debuggers
-  # with ARM64 libraries and UWP support.
-  toolchain_hash = '1023ce2e82'
-  # Third parties that do not have access to the canonical toolchain can map
-  # canonical toolchain version to their own toolchain versions.
-  toolchain_hash_mapping_key = 'GYP_MSVS_HASH_%s' % toolchain_hash
-  return [os.environ.get(toolchain_hash_mapping_key, toolchain_hash)]
+  env_version = GetVisualStudioVersion()
+  if env_version == '2017':
+    # VS 2017 Update 9 (15.9.12) with 10.0.18362 SDK, 10.0.17763 version of
+    # Debuggers, and 10.0.17134 version of d3dcompiler_47.dll, with ARM64
+    # libraries.
+    toolchain_hash = '418b3076791776573a815eb298c8aa590307af63'
+    # Third parties that do not have access to the canonical toolchain can map
+    # canonical toolchain version to their own toolchain versions.
+    toolchain_hash_mapping_key = 'GYP_MSVS_HASH_%s' % toolchain_hash
+    return [os.environ.get(toolchain_hash_mapping_key, toolchain_hash)]
+  raise Exception('Unsupported VS version %s' % env_version)
 
 
 def ShouldUpdateToolchain():


### PR DESCRIPTION
Reverts flutter/buildroot#632

After flutter/buildroot#632, the buildroot cannot be rolled to the engine without the corresponding changes in https://github.com/flutter/engine/pull/36606. However, https://github.com/flutter/engine/pull/36606 was reverted as it broke the Flutter tree. This reverts flutter/buildroot#632 to allow buildroot to engine rolls while I figure out the bug that broke the tree.

Revert issue: https://github.com/flutter/flutter/issues/112894

Failure:
1. https://ci.chromium.org/ui/p/flutter/builders/prod/Windows%20platform_channel_sample_test_windows/1804/overview
2. https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8801195816777587809/+/u/run_platform_channel_sample_test_windows/test_stdout

<details>
<summary>Logs...</summary>

```
[platform_channel_sample_test_windows] [STDOUT] stdout: [ +127 ms] executing: C:\b\s\w\ir\x\w\recipe_cleanup\tmpr1awka7t\flutter sdk\bin\cache\dart-sdk\bin\dart.exe C:\b\s\w\ir\x\w\recipe_cleanup\tmpr1awka7t\flutter sdk\examples\platform_channel\test_driver\button_tap_test.dart -rexpanded
[platform_channel_sample_test_windows] [STDOUT] stdout: [+3014 ms] 00:00 [32m+0[0m: button tap test (setUpAll)[0m
[platform_channel_sample_test_windows] [STDOUT] stderr: [  +31 ms] VMServiceFlutterDriver: Connecting to Flutter application at http://127.0.0.1:52673/c6-w7zT5-Qw=/
[platform_channel_sample_test_windows] [STDOUT] stderr: [ +179 ms] VMServiceFlutterDriver: Isolate found with number: 3990082986865311
[platform_channel_sample_test_windows] [STDOUT] stderr: [  +50 ms] VMServiceFlutterDriver: Isolate is paused at start.
[platform_channel_sample_test_windows] [STDOUT] stderr: [        ] VMServiceFlutterDriver: Attempting to resume isolate
[platform_channel_sample_test_windows] [STDOUT] stdout: [+1207 ms] 00:01 [32m+0[0m[31m -1[0m: button tap test (setUpAll) [1m[31m[E][0m[0m
[platform_channel_sample_test_windows] [STDOUT] stdout: [   +2 ms]   DriverError: Failed to fulfill GetHealth due to remote error
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   Original error: ext.flutter.driver: (112) Service has disappeared
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   Original stack trace:
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   #0      new _OutstandingRequest (package:vm_service/src/vm_service.dart:1746:45)
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   #1      VmService._call (package:vm_service/src/vm_service.dart:2262:21)
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   #2      VmService.callServiceExtension (package:vm_service/src/vm_service.dart:2233:14)
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   #3      VMServiceFlutterDriver.sendCommand (package:flutter_driver/src/driver/vmservice_driver.dart:306:66)
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   #4      FlutterDriver.checkHealth (package:flutter_driver/src/driver/driver.dart:197:34)
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   #5      VMServiceFlutterDriver.connect (package:flutter_driver/src/driver/vmservice_driver.dart:229:40)
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   <asynchronous suspension>
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   #6      main.<anonymous closure>.<anonymous closure> (file:///C:/b/s/w/ir/x/w/recipe_cleanup/tmpr1awka7t/flutter%20sdk/examples/platform_channel/test_driver/button_tap_test.dart:13:16)
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   <asynchronous suspension>
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   #7      _CustomZone.bindUnaryCallbackGuarded.<anonymous closure> (dart:async/zone.dart:1253:12)
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   <asynchronous suspension>
[platform_channel_sample_test_windows] [STDOUT] stdout: [  +14 ms]   package:flutter_driver/src/driver/vmservice_driver.dart 318:7   VMServiceFlutterDriver.sendCommand
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   ===== asynchronous gap ===========================
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   package:flutter_driver/src/driver/driver.dart 197:28            FlutterDriver.checkHealth
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   ===== asynchronous gap ===========================
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   package:flutter_driver/src/driver/vmservice_driver.dart 229:27  VMServiceFlutterDriver.connect
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   ===== asynchronous gap ===========================
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   test_driver\button_tap_test.dart 13:16                          main.<fn>.<fn>
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   ===== asynchronous gap ===========================
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/zone.dart 1253:12                                    _CustomZone.bindUnaryCallbackGuarded.<fn>
[platform_channel_sample_test_windows] [STDOUT] stdout: [  +10 ms] 00:01 [32m+0[0m[31m -1[0m: button tap test (tearDownAll)[0m
[platform_channel_sample_test_windows] [STDOUT] stdout: [   +3 ms] 00:01 [32m+0[0m[31m -2[0m: button tap test (tearDownAll) [1m[31m[E][0m[0m
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   LateInitializationError: Local 'driver' has not been initialized.
[platform_channel_sample_test_windows] [STDOUT] stdout: [   +3 ms]   dart:_internal-patch/internal_patch.dart 209:5     LateError._throwLocalNotInitialized
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   test_driver\button_tap_test.dart 17:7              main.<fn>.<fn>
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/future.dart 302:31                      new Future.sync
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   package:test_api/src/backend/invoker.dart 236:18   Invoker.runTearDowns.<fn>.<fn>
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   package:test_api/src/backend/invoker.dart 257:15   Invoker._waitForOutstandingCallbacks.<fn>
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/zone.dart 1398:13                       _rootRun
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/zone.dart 1300:19                       _CustomZone.run
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/zone.dart 1803:10                       _runZoned
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/zone.dart 1746:10                       runZoned
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   package:test_api/src/backend/invoker.dart 254:5    Invoker._waitForOutstandingCallbacks
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   package:test_api/src/backend/invoker.dart 235:9    Invoker.runTearDowns.<fn>
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/zone.dart 1398:13                       _rootRun
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/zone.dart 1300:19                       _CustomZone.run
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/zone.dart 1803:10                       _runZoned
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/zone.dart 1746:10                       runZoned
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   package:test_api/src/backend/invoker.dart 230:12   Invoker.runTearDowns
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   package:test_api/src/backend/declarer.dart 378:46  Declarer._tearDownAll.<fn>.<fn>
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/zone.dart 1398:13                       _rootRun
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/zone.dart 1300:19                       _CustomZone.run
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/zone.dart 1803:10                       _runZoned
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/zone.dart 1746:10                       runZoned
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   package:test_api/src/backend/declarer.dart 378:14  Declarer._tearDownAll.<fn>
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   package:test_api/src/backend/invoker.dart 257:15   Invoker._waitForOutstandingCallbacks.<fn>
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/zone.dart 1398:13                       _rootRun
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/zone.dart 1300:19                       _CustomZone.run
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/zone.dart 1803:10                       _runZoned
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/zone.dart 1746:10                       runZoned
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   package:test_api/src/backend/invoker.dart 254:5    Invoker._waitForOutstandingCallbacks
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   package:test_api/src/backend/invoker.dart 391:17   Invoker._onRun.<fn>.<fn>.<fn>
[platform_channel_sample_test_windows] [STDOUT] stdout: [  +11 ms] 00:01 [32m+0[0m[31m -2[0m: [31mSome tests failed.[0m
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ] Consider enabling the flag chain-stack-traces to receive more detailed exceptions.
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ] For example, 'dart test --chain-stack-traces'.
[platform_channel_sample_test_windows] [STDOUT] stderr: [   +1 ms] Unhandled exception:
[platform_channel_sample_test_windows] [STDOUT] stderr: [        ] Dummy exception to set exit code.
[platform_channel_sample_test_windows] [STDOUT] stdout: [+1044 ms] "flutter drive" took 22,339ms.
[platform_channel_sample_test_windows] [STDOUT] stderr: [   +6 ms] 
[platform_channel_sample_test_windows] [STDOUT] stderr:            #0      throwToolExit (package:flutter_tools/src/base/common.dart:10:3)
[platform_channel_sample_test_windows] [STDOUT] stderr:            #1      DriveCommand.runCommand (package:flutter_tools/src/commands/drive.dart:304:9)
[platform_channel_sample_test_windows] [STDOUT] stderr:            <asynchronous suspension>
[platform_channel_sample_test_windows] [STDOUT] stderr:            #2      FlutterCommand.run.<anonymous closure> (package:flutter_tools/src/runner/flutter_command.dart:1244:27)
[platform_channel_sample_test_windows] [STDOUT] stderr:            <asynchronous suspension>
[platform_channel_sample_test_windows] [STDOUT] stderr:            #3      AppContext.run.<anonymous closure> (package:flutter_tools/src/base/context.dart:150:19)
[platform_channel_sample_test_windows] [STDOUT] stderr:            <asynchronous suspension>
[platform_channel_sample_test_windows] [STDOUT] stderr:            #4      CommandRunner.runCommand (package:args/command_runner.dart:209:13)
[platform_channel_sample_test_windows] [STDOUT] stderr:            <asynchronous suspension>
[platform_channel_sample_test_windows] [STDOUT] stderr:            #5      FlutterCommandRunner.runCommand.<anonymous closure> (package:flutter_tools/src/runner/flutter_command_runner.dart:283:9)
[platform_channel_sample_test_windows] [STDOUT] stderr:            <asynchronous suspension>
[platform_channel_sample_test_windows] [STDOUT] stderr:            #6      AppContext.run.<anonymous closure> (package:flutter_tools/src/base/context.dart:150:19)
[platform_channel_sample_test_windows] [STDOUT] stderr:            <asynchronous suspension>
[platform_channel_sample_test_windows] [STDOUT] stderr:            #7      FlutterCommandRunner.runCommand (package:flutter_tools/src/runner/flutter_command_runner.dart:229:5)
[platform_channel_sample_test_windows] [STDOUT] stderr:            <asynchronous suspension>
[platform_channel_sample_test_windows] [STDOUT] stderr:            #8      run.<anonymous closure>.<anonymous closure> (package:flutter_tools/runner.dart:63:9)
[platform_channel_sample_test_windows] [STDOUT] stderr:            <asynchronous suspension>
[platform_channel_sample_test_windows] [STDOUT] stderr:            #9      AppContext.run.<anonymous closure> (package:flutter_tools/src/base/context.dart:150:19)
[platform_channel_sample_test_windows] [STDOUT] stderr:            <asynchronous suspension>
[platform_channel_sample_test_windows] [STDOUT] stderr:            #10     main (package:flutter_tools/executable.dart:91:3)
[platform_channel_sample_test_windows] [STDOUT] stderr:            <asynchronous suspension>
[platform_channel_sample_test_windows] [STDOUT] stderr: 
[platform_channel_sample_test_windows] [STDOUT] stderr: 
[platform_channel_sample_test_windows] [STDOUT] stdout: [   +1 ms] ensureAnalyticsSent: 0ms
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ] Running 0 shutdown hooks
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ] Shutdown hooks complete
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ] exiting with code 1
[platform_channel_sample_test_windows] [STDOUT] Checking for reboot
[platform_channel_sample_test_windows] Process terminated with exit code 0.
```

</details>