### PR TITLE
Build arm iOS simulator with Fuchsia toolchain and not Xcode

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -643,28 +643,26 @@ if (is_win) {
     ]
   }
 
-  if (!use_xcode) {
+  default_warning_flags += [
+    "-Wno-unused-but-set-parameter",
+    "-Wno-unused-but-set-variable",
+    "-Wno-implicit-int-float-conversion",
+    "-Wno-c99-designator",
+    "-Wno-deprecated-copy",
+    # Needed for compiling Skia with clang-12
+    "-Wno-psabi",
+  ]
+  if (!is_wasm) {
     default_warning_flags += [
-      "-Wno-unused-but-set-parameter",
-      "-Wno-unused-but-set-variable",
-      "-Wno-implicit-int-float-conversion",
-      "-Wno-c99-designator",
-      "-Wno-deprecated-copy",
-      # Needed for compiling Skia with clang-12
-      "-Wno-psabi",
+      # Unqualified std::move is pretty common.
+      "-Wno-unqualified-std-cast-call",
     ]
-    if (!is_wasm) {
-      default_warning_flags += [
-        # Unqualified std::move is pretty common.
-        "-Wno-unqualified-std-cast-call",
-      ]
-    }
-    if (!is_fuchsia) {
-      default_warning_flags += [
-        "-Wno-non-c-typedef-for-linkage",
-        "-Wno-range-loop-construct",
-      ]
-    }
+  }
+  if (!is_fuchsia) {
+    default_warning_flags += [
+      "-Wno-non-c-typedef-for-linkage",
+      "-Wno-range-loop-construct",
+    ]
   }
 
   if (is_mac || is_ios) {
@@ -729,7 +727,7 @@ config("no_chromium_code") {
 
   # TODO(zra): Remove when zlib no longer needs this.
   # https://github.com/flutter/flutter/issues/103568
-  if (!use_xcode && !is_wasm) {
+  if (!is_wasm) {
     cflags += [ "-Wno-deprecated-non-prototype" ]
   }
 

--- a/build/toolchain/clang.gni
+++ b/build/toolchain/clang.gni
@@ -21,13 +21,3 @@ declare_args() {
   # Set this flag to strip .so files.
   stripped_symbols = !is_debug
 }
-
-declare_args() {
-  # TODO(gw280): Once our own copy of clang 12 is capable of building for arm64 simulator,
-  # we can safely remove the requirement that we use xcode for arm64 simulator builds.
-  if (is_mac || is_ios) {
-    use_xcode = (use_ios_simulator && target_cpu == "arm64")
-  } else {
-    use_xcode = false
-  }
-}

--- a/build/toolchain/mac/BUILD.gn
+++ b/build/toolchain/mac/BUILD.gn
@@ -228,16 +228,10 @@ template("mac_toolchain") {
 mac_toolchain("ios_clang_arm") {
   toolchain_cpu = "arm"
   toolchain_os = "mac"
-  if (!use_xcode) {
-    prefix = rebased_clang_dir
-    ar = "$prefix/llvm-ar"
-    cc = "$prefix/clang"
-    cxx = "$prefix/clang++"
-  } else {
-    ar = "ar"
-    cc = "clang"
-    cxx = "clang++"
-  }
+  prefix = rebased_clang_dir
+  ar = "$prefix/llvm-ar"
+  cc = "$prefix/clang"
+  cxx = "$prefix/clang++"
   ld = cxx
   is_clang = true
   sysroot_flags = "-isysroot $ios_device_sdk_path -miphoneos-version-min=$ios_deployment_target"
@@ -247,16 +241,10 @@ mac_toolchain("ios_clang_arm") {
 mac_toolchain("ios_clang_arm_sim") {
   toolchain_cpu = "arm"
   toolchain_os = "mac"
-  if (!use_xcode) {
-    prefix = rebased_clang_dir
-    ar = "$prefix/llvm-ar"
-    cc = "$prefix/clang"
-    cxx = "$prefix/clang++"
-  } else {
-    ar = "ar"
-    cc = "clang"
-    cxx = "clang++"
-  }
+  prefix = rebased_clang_dir
+  ar = "$prefix/llvm-ar"
+  cc = "$prefix/clang"
+  cxx = "$prefix/clang++"
   ld = cxx
   is_clang = true
   sysroot_flags = "-isysroot $ios_simulator_sdk_path -mios-simulator-version-min=$ios_deployment_target"
@@ -279,16 +267,10 @@ mac_toolchain("ios_clang_x64_sim") {
 mac_toolchain("clang_x64") {
   toolchain_cpu = "x64"
   toolchain_os = "mac"
-  if (!use_xcode) {
-    prefix = rebased_clang_dir
-    ar = "$prefix/llvm-ar"
-    cc = "$prefix/clang"
-    cxx = "$prefix/clang++"
-  } else {
-    ar = "ar"
-    cc = "clang"
-    cxx = "clang++"
-  }
+  prefix = rebased_clang_dir
+  ar = "$prefix/llvm-ar"
+  cc = "$prefix/clang"
+  cxx = "$prefix/clang++"
   ld = cxx
   is_clang = true
   sysroot_flags = "-isysroot $mac_sdk_path -mmacosx-version-min=$mac_deployment_target"
@@ -298,16 +280,10 @@ mac_toolchain("clang_x64") {
 mac_toolchain("clang_arm64") {
   toolchain_cpu = "arm64"
   toolchain_os = "mac"
-  if (!use_xcode) {
-    prefix = rebased_clang_dir
-    ar = "$prefix/llvm-ar"
-    cc = "$prefix/clang"
-    cxx = "$prefix/clang++"
-  } else {
-    ar = "ar"
-    cc = "clang"
-    cxx = "clang++"
-  }
+  prefix = rebased_clang_dir
+  ar = "$prefix/llvm-ar"
+  cc = "$prefix/clang"
+  cxx = "$prefix/clang++"
   ld = cxx
   is_clang = true
   sysroot_flags = "-isysroot $mac_sdk_path -mmacosx-version-min=$mac_deployment_target"


### PR DESCRIPTION
The Fuchsia toolchain version of clang (version 16.0.0) happily builds and runs `--simulator-cpu=arm64` on this patch.
```
$ ./flutter/tools/gn --no-goma --ios --simulator --unoptimized  --simulator-cpu=arm64 && ninja -C out/ios_debug_sim_unopt_arm64
```

```
$ flutter run --local-engine ios_debug_sim_unopt_arm64 
```
![Screen Shot 2022-10-05 at 6 48 54 PM](https://user-images.githubusercontent.com/682784/194196312-e9dc46e5-79c0-462f-aded-9bafa7da54dd.png)


Will remove engine usage during roll:
https://github.com/flutter/engine/blob/1c232b584c57fcb43dadc1602b4b202ace80645a/BUILD.gn#L36

Fixes https://github.com/flutter/flutter/issues/112992

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
