### PR TITLE
[Impeller] Enable X11 and Wayland support for Vulkan

### DIFF
--- a/build_overrides/vulkan_headers.gni
+++ b/build_overrides/vulkan_headers.gni
@@ -4,3 +4,8 @@
 
 # This file is needed by the vulkan-headers build, but doesn't need to actually
 # set anything.
+
+if (is_linux) {
+  vulkan_use_x11 = true
+  vulkan_use_wayland = true
+}


### PR DESCRIPTION
This is needed for valid surface extensions to be detected.
