### PR TITLE
Buildroot side of change to narrow Windows Android arm hack

### DIFF
--- a/build/config/BUILDCONFIG.gn
+++ b/build/config/BUILDCONFIG.gn
@@ -531,7 +531,11 @@ if (custom_toolchain != "") {
   } else if (host_os == "mac") {
     host_toolchain = "//build/toolchain/mac:clang_$host_cpu"
   } else if (host_os == "win") {
-    host_toolchain = "//build/toolchain/win:$current_cpu"
+    if (is_clang) {
+      host_toolchain = "//build/toolchain/win:clang_$host_cpu"
+    } else {
+      host_toolchain = "//build/toolchain/win:$host_cpu"
+    }
   } else {
     assert(false, "Unknown host for android cross compile")
   }

--- a/build/toolchain/win/BUILD.gn
+++ b/build/toolchain/win/BUILD.gn
@@ -61,7 +61,7 @@ if (current_toolchain == default_toolchain) {
                 "copy_dlls",
                 rebase_path(root_build_dir),
                 configuration,
-                target_cpu,
+                current_cpu,
               ])
 }
 
@@ -281,6 +281,13 @@ if (target_cpu == "x86") {
 if (target_cpu == "x64") {
   win_toolchains("x64") {
     toolchain_arch = "x64"
+  }
+}
+
+if (target_cpu == "arm") {
+  # When the target cpu is "arm", we use the 32-bit intel toolchain "x86".
+  win_toolchains("x86") {
+    toolchain_arch = "x86"
   }
 }
 


### PR DESCRIPTION
This is the buildroot side of https://github.com/flutter/engine/pull/37125, which will narrow the hack we use to build `gen_snapshot` to target 32-bit Android on Windows. In particular, along with 37125, this patch adjusts so that `current_cpu` and `host_cpu` will always be the host architecture (x86), and `target_cpu`, and `dart_target_arch` will be the target architecture (arm). This confusing state will only exist for this one configuration following these patches.