### PR TITLE
Increase minimum macOS SDK from 10.13 to 10.14

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -176,11 +176,6 @@ config("compiler") {
         "-arch",
         "arm64",
       ]
-      if (is_mac) {
-        # Aligned allocations are only supported on arm64 after macOS 10.14,
-        # however our deployment target is currently 10.11.
-        common_mac_flags += [ "-fno-aligned-allocation" ]
-      }
     }
 
     cflags += common_mac_flags

--- a/build/config/mac/mac_sdk.gni
+++ b/build/config/mac/mac_sdk.gni
@@ -6,11 +6,11 @@ import("//build/toolchain/goma.gni")
 
 declare_args() {
   # Minimum supported version of the Mac SDK.
-  mac_sdk_min = "10.13"
+  mac_sdk_min = "10.14"
 
   # The MACOSX_DEPLOYMENT_TARGET variable used when compiling.
   # Must be of the form x.x.x for Info.plist files.
-  mac_deployment_target = "10.13.0"
+  mac_deployment_target = "10.14.0"
 
   # Path to a specific version of the Mac SDK, not including a backslash at
   # the end. If empty, the path to the lowest version greater than or equal to


### PR DESCRIPTION
Increases the minimum macOS SDK and the macOS deployment target from 10.13 to 10.14.

Also enables aligned allocations on macOS. We previously set `-fno-aligned-allocation` on macOS since it was unsupported for arm64 prior to macOS 10.14.

Issue: https://github.com/flutter/flutter/issues/114445

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
