### PR TITLE
Sort macOS SDK paths to keep order stable between runs

### DIFF
--- a/build/mac/find_sdk.py
+++ b/build/mac/find_sdk.py
@@ -64,7 +64,10 @@ def main():
 
   best_sdk = None
   sdk_output = None
-  for properties in list(sdk_json):
+
+  # Xcode can return the same version for different symlinked paths.
+  # Sort by path to keep the list stable between runs.
+  for properties in sorted(list(sdk_json), key=lambda d: d['sdkPath']):
     # Filter out macOS DriverKit, watchOS, AppleTV, and other SDKs.
     if properties.get('platform') != 'macosx' or 'driver' in properties.get('canonicalName'):
       continue


### PR DESCRIPTION
`xcodebuild -showsdks -json` is returning the same `sdkVersion` for different `sdkPath`s on > Xcode 14
```
  {
    "canonicalName" : "macosx13.0",
...
    "sdkPath" : "/Users/m/Applications/Xcode-14-1_beta3.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.sdk",
    "sdkVersion" : "13.0"
  },
  {
    "canonicalName" : "macosx13.0",
...
    "sdkPath" : "/Users/m/Applications/Xcode-14-1_beta3.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.0.sdk",
    "sdkVersion" : "13.0"
  },
```
The order it's returning these isn't stable, so it keeps swapping which path is listed last on different runs which is causing `-isysroot` to be different between ninja runs, which is unnecessaryly dirtying and causing huge recompiles.

Sort the SDKs returned by `xcodebuild -showsdks` so that duplicated `sdkVersion`s mapped to different paths always chooses the same path between runs.

Fixes https://github.com/flutter/flutter/issues/112928


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
