### PR TITLE
Fix tinygltf build

### DIFF
--- a/build/secondary/third_party/tinygltf/BUILD.gn
+++ b/build/secondary/third_party/tinygltf/BUILD.gn
@@ -7,6 +7,10 @@ source_root = "//third_party/tinygltf"
 source_set("tinygltf") {
   public = [ "$source_root/tiny_gltf.h" ]
 
+  if (is_clang) {
+    cflags_cc = [ "-Wno-sign-compare" ]
+  }
+
   include_dirs = [
     "$source_root",
     "$source_root/third_party/include",


### PR DESCRIPTION
Get rid of a new warning-error after the recent clang config updates.