### PR TITLE
Remove transitive includes in libcpp

### DIFF
--- a/build/secondary/third_party/libcxx/config/__config_site
+++ b/build/secondary/third_party/libcxx/config/__config_site
@@ -27,6 +27,8 @@
 /* #undef _LIBCPP_HAS_NO_RANDOM_DEVICE */
 /* #undef _LIBCPP_HAS_NO_LOCALIZATION */
 
+#define _LIBCPP_REMOVE_TRANSITIVE_INCLUDES
+
 // This is a workaround for BoringSSL, which is compiled in C11 mode
 // and includes stdatomic.h.  Defining this macro will cause stdatomic.h
 // to redirect to the next version of that header in the include path.


### PR DESCRIPTION
This should make it easier to spot missing includes causing problems on internal builds such has  https://github.com/flutter/engine/pull/38332.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
