### PR TITLE
Allow references to undefined symbols in linker scripts

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -351,6 +351,12 @@ config("compiler") {
     cflags += [ "-fcolor-diagnostics" ]
   }
 
+  # TODO(crbug.com/1374347): Cleanup undefined symbol errors caught by
+  # --no-undefined-version.
+  if (is_clang && !is_win && !is_mac && !is_ios) {
+    ldflags += [ "-Wl,--undefined-version" ]
+  }
+
   # C++ compiler flags setup.
   # -------------------------
 


### PR DESCRIPTION
This is needed in order to link SwiftShader with the latest version of Clang/lld.

See https://github.com/flutter/flutter/issues/119170
