### PR TITLE
Apply the -stdlib=libc++ flag only to C++ sources on Mac/iOS platforms

### DIFF
--- a/build/config/ios/BUILD.gn
+++ b/build/config/ios/BUILD.gn
@@ -3,8 +3,5 @@
 # found in the LICENSE file.
 
 config("sdk") {
-  common_flags = [ "-stdlib=libc++" ]
-
-  cflags = common_flags
-  ldflags = common_flags
+  cflags_cc = [ "-stdlib=libc++" ]
 }

--- a/build/config/mac/BUILD.gn
+++ b/build/config/mac/BUILD.gn
@@ -5,10 +5,7 @@
 import("//build/config/sysroot.gni")
 
 config("sdk") {
-  common_flags = [ "-stdlib=libc++" ]
-
-  cflags = common_flags
-  ldflags = common_flags
+  cflags_cc = [ "-stdlib=libc++" ]
 }
 
 # On Mac, this is used for everything except static libraries.


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/119170
