### PR TITLE
Use C++ standard library regexes in the benchmark library

### DIFF
--- a/build/secondary/third_party/benchmark/BUILD.gn
+++ b/build/secondary/third_party/benchmark/BUILD.gn
@@ -54,7 +54,7 @@ static_library("benchmark") {
   ]
   public_configs = [ ":benchmark_config" ]
   defines = [
-    "HAVE_POSIX_REGEX",
+    "HAVE_STD_REGEX",
     "HAVE_THREAD_SAFETY_ATTRIBUTES",
   ]
 }


### PR DESCRIPTION
This enables use of the benchmark library on Windows.

See https://github.com/flutter/engine/pull/38993
