### PR TITLE
Exit with status 0 from the cp.py copy file script on success

### DIFF
--- a/build/cp.py
+++ b/build/cp.py
@@ -17,7 +17,8 @@ import sys
 
 def Main(src, dst):
   # Use copy instead of copyfile to ensure the executable bit is copied.
-  return shutil.copy(src, os.path.normpath(dst))
+  shutil.copy(src, os.path.normpath(dst))
+  return 0
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This utility script to copy a file was always exiting with status 1.

The shutil.copy call returns the destination path as a string, so this was printed to stderr and
converted to the exit code 1.

