### PR TITLE
Update wasm_lib template to have accurate outputs.

### DIFF
--- a/build/toolchain/wasm.gni
+++ b/build/toolchain/wasm.gni
@@ -92,16 +92,10 @@ template("wasm_lib") {
 
   _lib_name = target_name
 
-  executable("${_lib_name}.js") {
+  executable("$_lib_name") {
     forward_variables_from(invoker, _vars_to_forward)
     cflags = _target_cflags
     ldflags = _target_ldflags
-    output_extension = ""
-  }
-
-  group("$_lib_name") {
-    public_deps = [
-      ":${_lib_name}.js",
-    ]
+    output_extension = "js"
   }
 }


### PR DESCRIPTION
This template should have two outputs, `{{target_name}}.js` and `{{target_name}}.wasm`. However, using this current code for my (not yet committed) skwasm module produces this set of outputs from `gn desc`:

```
outputs
  //out/wasm_release/skwasm.js
  //out/wasm_release/skwasm.js.wasm
```

As you can see, this produces a `skwasm.js.wasm` which is not correct. After this change, it looks like this:

```
outputs
  //out/wasm_release/skwasm.js
  //out/wasm_release/skwasm.wasm
```

Which is correct.