### PR TITLE
Silence Java deprecation warnings

### DIFF
--- a/build/android/gyp/javac.py
+++ b/build/android/gyp/javac.py
@@ -79,11 +79,9 @@ def DoJavac(
       '-encoding', 'UTF-8',
       '-classpath', ':'.join(classpath),
       '-d', classes_dir,
-      # TODO(camsim99): Make deprecation warnings fatal and remove limit 
-      # when all 123 (at the time of this comment) deprecations are fixed:
+      # TODO(camsim99): Fix deprecations:
       # https://github.com/flutter/flutter/issues/98602.
-      '-Xlint:deprecation',
-      '-Xmaxwarns', '123']
+      '-Xlint:-deprecation']
 
   if bootclasspath:
     javac_args.extend([


### PR DESCRIPTION
This PR silences deprecation warnings that are currently emitted while building Java sources for the Android embedder. In general, a successful GN/Ninja build should produce no output. The issue filed in the tracker, and the TODO() in the source will have to serve as sufficient reminder that these deprecations will need to be addressed.

Related https://github.com/flutter/flutter/issues/98602.