### PR TITLE
Allow enabling LTO for macOS builds

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -880,7 +880,7 @@ config("optimize") {
   }
 
   lto_flags = []
-  if (enable_lto && (is_ios || is_android || is_fuchsia || is_wasm)) {
+  if (enable_lto && (is_ios || is_mac || is_android || is_fuchsia || is_wasm)) {
     lto_flags += [ "-flto" ]
   }
 


### PR DESCRIPTION
This will be a no-op because our CI recipes currently explicitly disable LTO. See https://flutter.googlesource.com/recipes/+/refs/heads/main/recipes/engine/engine.py#1085.

After this rolls into flutter/engine, I'll do some `led` runs to gauge the impact to CI cycle time. 