### PR TITLE
Update matcher contents post bump in dart sdk.

### DIFF
--- a/build/secondary/third_party/dart/third_party/pkg/matcher/BUILD.gn
+++ b/build/secondary/third_party/dart/third_party/pkg/matcher/BUILD.gn
@@ -19,6 +19,7 @@ dart_library("matcher") {
   deps = [ "//third_party/dart/third_party/pkg/stack_trace" ]
 
   sources = [
+    "expect.dart",
     "matcher.dart",
     "mirror_matchers.dart",
     "src/core_matchers.dart",
@@ -26,6 +27,18 @@ dart_library("matcher") {
     "src/description.dart",
     "src/equals_matcher.dart",
     "src/error_matchers.dart",
+    "src/expect/async_matcher.dart",
+    "src/expect/expect.dart",
+    "src/expect/expect_async.dart",
+    "src/expect/future_matchers.dart",
+    "src/expect/never_called.dart",
+    "src/expect/prints_matcher.dart",
+    "src/expect/stream_matcher.dart",
+    "src/expect/stream_matchers.dart",
+    "src/expect/throws_matcher.dart",
+    "src/expect/throws_matchers.dart",
+    "src/expect/util/placeholder.dart",
+    "src/expect/util/pretty_print.dart",
     "src/feature_matcher.dart",
     "src/having_matcher.dart",
     "src/interfaces.dart",


### PR DESCRIPTION
https://dart.googlesource.com/sdk/+/6f45c8534ee65e05f8aea53a80339d0a0a7056e4 introduced more files, so list in BUILD.gn had to be manually updated.