### PR TITLE
Properly support .worker.js outputs from emscripten.

### DIFF
--- a/build/config/BUILDCONFIG.gn
+++ b/build/config/BUILDCONFIG.gn
@@ -408,7 +408,9 @@ _native_compiler_configs += [ "//build/config/compiler:default_optimization" ]
 if (symbol_level == -1) {
   # Linux is slowed by having symbols as part of the target binary, whereas
   # Mac and Windows have them separate, so in Release Linux, default them off.
-  if (is_debug || !is_linux) {
+  # Wasm we definitely want to strip symbols in release mode because binary
+  # size is tantamount.
+  if (is_debug || is_mac || is_win) {
     symbol_level = 2
   } else if (is_asan || is_lsan || is_tsan || is_msan) {
     # Sanitizers require symbols for filename suppressions to work.

--- a/build/toolchain/wasm.gni
+++ b/build/toolchain/wasm.gni
@@ -26,11 +26,12 @@ if (use_goma) {
 
 template("wasm_toolchain") {
   gcc_toolchain(target_name) {
+    worker_js_file = "{{root_out_dir}}/{{target_output_name}}.worker.js"
     # emsdk_dir and em_config are defined in wasm.gni.
     ar = "$compiler_prefix$emsdk_dir/upstream/emscripten/emar --em-config $em_config_path"
     cc = "$compiler_prefix$emsdk_dir/upstream/emscripten/emcc --em-config $em_config_path"
     cxx = "$compiler_prefix$emsdk_dir/upstream/emscripten/em++ --em-config $em_config_path"
-    ld = cxx
+    ld = "touch $worker_js_file && $cxx"
     readelf = "readelf"
     nm = "nm"
 
@@ -39,7 +40,10 @@ template("wasm_toolchain") {
 
     is_clang = true
 
-    link_outputs = [ "{{root_out_dir}}/{{target_output_name}}.wasm" ]
+    link_outputs = [ 
+      "{{root_out_dir}}/{{target_output_name}}.wasm",
+      worker_js_file,
+    ]
 
     extra_toolchain_args = {
       if (defined(invoker.extra_toolchain_args)) {

--- a/build/toolchain/wasm.gni
+++ b/build/toolchain/wasm.gni
@@ -27,10 +27,20 @@ if (use_goma) {
 template("wasm_toolchain") {
   gcc_toolchain(target_name) {
     worker_js_file = "{{root_out_dir}}/{{target_output_name}}.worker.js"
+
     # emsdk_dir and em_config are defined in wasm.gni.
     ar = "$compiler_prefix$emsdk_dir/upstream/emscripten/emar --em-config $em_config_path"
     cc = "$compiler_prefix$emsdk_dir/upstream/emscripten/emcc --em-config $em_config_path"
     cxx = "$compiler_prefix$emsdk_dir/upstream/emscripten/em++ --em-config $em_config_path"
+
+    # emscripten emits this .worker.js file conditionally depending on whether
+    # pthreads are on or not. Unfortunately, there is no way to conditionally
+    # change the outputs of the toolchain depending on flags that are specified
+    # in the target or configs. In order to resolve this, we will always
+    # specify the .worker.js file as an output, and touch the path to create a
+    # dummy file. If the target does use pthreads, this dummy file will be
+    # overwritten. If the target does not, the dummy file will satisfy the
+    # toolchain's requirement that it has this as an output.
     ld = "touch $worker_js_file && $cxx"
     readelf = "readelf"
     nm = "nm"
@@ -40,7 +50,7 @@ template("wasm_toolchain") {
 
     is_clang = true
 
-    link_outputs = [ 
+    link_outputs = [
       "{{root_out_dir}}/{{target_output_name}}.wasm",
       worker_js_file,
     ]


### PR DESCRIPTION
Also, compile with -g0 in release mode. We were getting unintentionally
bucketed into behavior for Windows and Mac here previously.