### PR TITLE
Optimize Wasm for speed instead of size

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -874,7 +874,7 @@ config("optimize") {
   } else if (is_android || is_fuchsia) {
     cflags = [ "-Oz" ] + common_optimize_on_cflags  # Favor size over speed.
   } else if (is_wasm) {
-    cflags = [ "-Oz" ]
+    cflags = [ "-O3" ]
   } else {
     cflags = [ "-O2" ] + common_optimize_on_cflags
   }


### PR DESCRIPTION
This matches Skia's compile flags for building CanvasKit releases.

See https://github.com/flutter/flutter/issues/123484
