### PR TITLE
Build with `-sINLINING_LIMIT` on wasm.

### DIFF
--- a/build/config/BUILDCONFIG.gn
+++ b/build/config/BUILDCONFIG.gn
@@ -445,6 +445,10 @@ if (is_win) {
   ]
 }
 
+if (is_wasm) {
+  _native_compiler_configs += [ "//build/config/wasm:limit_inlining" ]
+}
+
 # Executable defaults.
 _executable_configs =
     _native_compiler_configs + [ "//build/config:default_libs" ]

--- a/build/config/wasm/BUILD.gn
+++ b/build/config/wasm/BUILD.gn
@@ -1,0 +1,8 @@
+# Copyright (c) 2013 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+config("limit_inlining") {
+  cflags = [ "-sINLINING_LIMIT=1" ]
+  ldflags = [ "-sINLINING_LIMIT=1" ]
+}


### PR DESCRIPTION
This allows us to use LTO but also keep binary size low.