### PR TITLE
[dart] Add ntdll.lib for better exception handling in dart

### DIFF
--- a/build/config/BUILD.gn
+++ b/build/config/BUILD.gn
@@ -113,6 +113,7 @@ config("default_libs") {
       "dnsapi.lib",
       "iphlpapi.lib",
       "msimg32.lib",
+      "ntdll.lib",
       "odbc32.lib",
       "odbccp32.lib",
       "ole32.lib",


### PR DESCRIPTION
API added in https://dart.googlesource.com/sdk/+/386a87a8905c48342e1bb9dcbe0ff693690468a7 for better exception handling on Windows needs this library.