### PR TITLE
Revert "[dart] Add ntdll.lib for better exception handling in dart (#709)

### DIFF
--- a/build/config/BUILD.gn
+++ b/build/config/BUILD.gn
@@ -113,7 +113,6 @@ config("default_libs") {
       "dnsapi.lib",
       "iphlpapi.lib",
       "msimg32.lib",
-      "ntdll.lib",
       "odbc32.lib",
       "odbccp32.lib",
       "ole32.lib",


### PR DESCRIPTION
This reverts commit e18c162be6327beb90fc885e81db8fadceafb94f as there is no longer a need for the library to be added into flutter since been added to dart vm BUILD.gn in https://dart.googlesource.com/sdk/+/617925e0c5b24d5b11784056ce1b61a686bd18a5

BUG=https://github.com/flutter/flutter/issues/124532
