### PR TITLE
Add BUILD.gn to build brotli

### DIFF
--- a/build/secondary/third_party/brotli/BUILD.gn
+++ b/build/secondary/third_party/brotli/BUILD.gn
@@ -1,0 +1,26 @@
+# Copyright 2023 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+source_root = "//third_party/brotli"
+
+config("brotli_config") {
+  include_dirs = [ "$source_root/c/include" ]
+}
+
+source_set("brotli") {
+  sources = [
+    "$source_root/c/common/constants.c",
+    "$source_root/c/common/context.c",
+    "$source_root/c/common/dictionary.c",
+    "$source_root/c/common/platform.c",
+    "$source_root/c/common/shared_dictionary.c",
+    "$source_root/c/common/transform.c",
+    "$source_root/c/dec/bit_reader.c",
+    "$source_root/c/dec/decode.c",
+    "$source_root/c/dec/huffman.c",
+    "$source_root/c/dec/state.c",
+  ]
+
+  public_configs = [ ":brotli_config" ]
+}


### PR DESCRIPTION
Brotli is needed to support .woff2 and .woff fonts on the web. woff2 is the default format served by Google Fonts.

See also https://github.com/flutter/engine/pull/41282

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
