### PR TITLE
[dart] Add identifier needed for zlib roll

### DIFF
--- a/build/config/compiler/compiler.gni
+++ b/build/config/compiler/compiler.gni
@@ -10,4 +10,7 @@ declare_args() {
   use_libfuzzer = false
   is_apple = is_ios || is_mac
   use_thin_lto = false
+
+  # zlib uses this identifier
+  use_fuzzing_engine = false
 }


### PR DESCRIPTION
This is needed for dart roll that rolls zlib https://dart.googlesource.com/sdk/+/bd9c7a46e2b1f89a8487c21aafe714fa004d687f%5E%21/#F1