### PR TITLE
Use a higher level of debug symbols for Android and other non-Linux/non-Wasm targets

### DIFF
--- a/build/config/BUILDCONFIG.gn
+++ b/build/config/BUILDCONFIG.gn
@@ -409,8 +409,8 @@ if (symbol_level == -1) {
   # Linux is slowed by having symbols as part of the target binary, whereas
   # Mac and Windows have them separate, so in Release Linux, default them off.
   # Wasm we definitely want to strip symbols in release mode because binary
-  # size is tantamount.
-  if (is_debug || is_mac || is_win) {
+  # size is paramount.
+  if (is_debug || (!is_linux && !is_wasm)) {
     symbol_level = 2
   } else if (is_asan || is_lsan || is_tsan || is_msan) {
     # Sanitizers require symbols for filename suppressions to work.


### PR DESCRIPTION
The additional symbols are needed so CI can correctly generate the binary size analysis treemaps.
