### PR TITLE
Add a gn flag for forcing us to compile wasm with -Oz

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -40,6 +40,9 @@ declare_args() {
   # TODO(zanderso): Remove when no longer needed in the investigation of
   # https://github.com/flutter/flutter/issues/87952.
   use_fstack_protector = false
+
+  # Prefer size over speed when compiling to wasm
+  wasm_prioritize_size = false
 }
 
 # default_include_dirs ---------------------------------------------------------
@@ -852,10 +855,14 @@ if (is_win) {
     }
   } else {
     # Non-Mac Posix linker flags.
+    # Specifically tell the linker to perform optimizations.
+    # See http://lwn.net/Articles/192624/ .
+    if (is_wasm && wasm_prioritize_size) {
+      common_optimize_on_ldflags += [ "-Oz" ]
+    } else {
+      common_optimize_on_ldflags += [ "-Wl,-O2" ]
+    }
     common_optimize_on_ldflags += [
-      # Specifically tell the linker to perform optimizations.
-      # See http://lwn.net/Articles/192624/ .
-      "-Wl,-O2",
       "-Wl,--gc-sections",
     ]
 
@@ -879,7 +886,11 @@ config("optimize") {
   } else if (is_android || is_fuchsia) {
     cflags = [ "-Oz" ] + common_optimize_on_cflags  # Favor size over speed.
   } else if (is_wasm) {
-    cflags = [ "-O3" ]
+    if (wasm_prioritize_size) {
+      cflags = [ "-Oz" ]
+    } else {
+      cflags = [ "-O3" ]
+    }
   } else {
     cflags = [ "-O2" ] + common_optimize_on_cflags
   }


### PR DESCRIPTION
While we're still building CanvasKit with `-O3`, we want to build skwasm with `-Oz`, so make that a flag that we can tweak.