### PR TITLE
Forward inputs from wasm libraries.

### DIFF
--- a/build/toolchain/wasm.gni
+++ b/build/toolchain/wasm.gni
@@ -105,6 +105,7 @@ template("wasm_lib") {
     "defines",
     "deps",
     "includes",
+    "inputs",
     "sources",
     "include_dirs",
     "public_configs",


### PR DESCRIPTION
Some upcoming changes to Skwasm will require us to specify some additional input files that are not sources.