### PR TITLE
Keep dictionary items sorted when updating dart deps.

### DIFF
--- a/tools/dart/create_updated_flutter_deps.py
+++ b/tools/dart/create_updated_flutter_deps.py
@@ -124,8 +124,9 @@ def Main(argv):
                 else:
                   updated_value = updated_value + "'"
               else:
-                # Non-string values(dicts) copy verbatim
-                updated_value = dart_v
+                # Non-string values(dicts) copy verbatim, keeping them sorted
+                # to ensure stable ordering of items.
+                updated_value = dict(sorted(dart_v.items()))
 
               updatedfile.write("  '%s':\n   %s,\n\n" % (k, updated_value))
               break


### PR DESCRIPTION
Keeping items sorted ensures stable ordering of items during DEPS updates.

See https://github.com/flutter/engine/commit/1fde3d4f5d51158de8002cc5895084d3b3a83e43 for example of changing order of items.
