### PR TITLE
Revert "Fixed rtti for *nix"

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -761,10 +761,6 @@ config("no_chromium_code") {
 config("rtti") {
   if (is_win) {
     cflags_cc = [ "/GR" ]
-  } else {
-    rtti_flags = [ "-frtti" ]
-    cflags_cc = rtti_flags
-    cflags_objcc = rtti_flags
   }
 }
 config("no_rtti") {


### PR DESCRIPTION
Reverts flutter/buildroot#733

Need to figure out why both flags are getting set rather than explicitly adding the defaul tin which may result in confusing behavior 