### PR TITLE
Fix pretty printing in malioc execution script

### DIFF
--- a/build/gn_run_malioc.py
+++ b/build/gn_run_malioc.py
@@ -40,7 +40,7 @@ except subprocess.CalledProcessError as ex:
     # Attempt to pretty print the json output, but fall back to printing the
     # raw output if doing so fails.
     try:
-      parsed = json.load(malioc_json)
+      parsed = json.loads(malioc_json)
       print(json.dumps(parsed, indent=2))
     except:
       print(malioc_json)


### PR DESCRIPTION
Whoopies. This fix makes pretty printing actually work. Without this it'll always fail to parse and fall back to raw output.