### PR TITLE
Generate new C++ FIDL bindings

### DIFF
--- a/build/fuchsia/fidl_gen_cpp.py
+++ b/build/fuchsia/fidl_gen_cpp.py
@@ -35,7 +35,7 @@ def main():
   parser = argparse.ArgumentParser();
 
   parser.add_argument('--fidlc-bin', dest='fidlc_bin', action='store', required=True)
-  parser.add_argument('--fidlgen-bin', dest='fidlgen_bin', action='store', required=False)
+  parser.add_argument('--fidlgen-bin', dest='fidlgen_bin', action='append', required=False)
 
   parser.add_argument('--sdk-base', dest='sdk_base', action='store', required=True)
   parser.add_argument('--root', dest='root', action='store', required=True)
@@ -82,15 +82,16 @@ def main():
 
   if args.fidlgen_output_root:
     assert os.path.exists(args.json)
-    fidlgen_command = [
-      args.fidlgen_bin,
-      '-json',
-      args.json,
-      '-root',
-      args.fidlgen_output_root
-    ]
+    for fidlgen_bin in args.fidlgen_bin:
+      fidlgen_command = [
+        fidlgen_bin,
+        '-json',
+        args.json,
+        '-root',
+        args.fidlgen_output_root
+      ]
 
-    subprocess.check_call(fidlgen_command)
+      subprocess.check_call(fidlgen_command)
 
   return 0
 

--- a/build/fuchsia/sdk.gni
+++ b/build/fuchsia/sdk.gni
@@ -78,7 +78,13 @@ template("fuchsia_fidl_library") {
   meta_json = read_file(invoker.meta, "json")
   assert(meta_json.type == "fidl_library")
 
-  _deps = [ "//build/fuchsia/pkg:fidl_cpp" ]
+  _deps = [
+    "//build/fuchsia/pkg:fidl_cpp",
+    "//build/fuchsia/pkg/fidl_cpp_hlcpp_conversion",
+    "//build/fuchsia/pkg/fidl_cpp_natural_ostream",
+    "//build/fuchsia/pkg/fidl_cpp_v2",
+    "//build/fuchsia/pkg/fidl_cpp_wire",
+  ]
 
   library_name = meta_json.name
   library_name_json = "${meta_json.name}.json"
@@ -125,13 +131,36 @@ template("fuchsia_fidl_library") {
     if (!defined(invoker.only_generate_tables) ||
         !invoker.only_generate_tables) {
       outputs += [
-        "$target_gen_dir/$library_name_slashes/cpp/fidl.h",
         "$target_gen_dir/$library_name_slashes/cpp/fidl.cc",
+        "$target_gen_dir/$library_name_slashes/cpp/fidl.h",
+        "$target_gen_dir/$library_name_slashes/cpp/fidl_test_base.h",
+
+        "$target_gen_dir/fidl/$library_name/cpp/common_types.cc",
+        "$target_gen_dir/fidl/$library_name/cpp/common_types.h",
+        "$target_gen_dir/fidl/$library_name/cpp/fidl.h",
+        "$target_gen_dir/fidl/$library_name/cpp/hlcpp_conversion.h",
+        "$target_gen_dir/fidl/$library_name/cpp/markers.h",
+        "$target_gen_dir/fidl/$library_name/cpp/natural_messaging.cc",
+        "$target_gen_dir/fidl/$library_name/cpp/natural_messaging.h",
+        "$target_gen_dir/fidl/$library_name/cpp/natural_ostream.cc",
+        "$target_gen_dir/fidl/$library_name/cpp/natural_ostream.h",
+        "$target_gen_dir/fidl/$library_name/cpp/natural_types.cc",
+        "$target_gen_dir/fidl/$library_name/cpp/natural_types.h",
+        "$target_gen_dir/fidl/$library_name/cpp/type_conversions.cc",
+        "$target_gen_dir/fidl/$library_name/cpp/type_conversions.h",
+        "$target_gen_dir/fidl/$library_name/cpp/wire.h",
+        "$target_gen_dir/fidl/$library_name/cpp/wire_messaging.cc",
+        "$target_gen_dir/fidl/$library_name/cpp/wire_messaging.h",
+        "$target_gen_dir/fidl/$library_name/cpp/wire_test_base.h",
+        "$target_gen_dir/fidl/$library_name/cpp/wire_types.cc",
+        "$target_gen_dir/fidl/$library_name/cpp/wire_types.h",
       ]
 
       args += [
         "--fidlgen-bin",
-        rebase_path("${_fuchsia_tools_path}/fidlgen"),
+        rebase_path("${_fuchsia_tools_path}/fidlgen_cpp"),
+        "--fidlgen-bin",
+        rebase_path("${_fuchsia_tools_path}/fidlgen_hlcpp"),
         "--fidlgen-output-root",
         rebase_path("$target_gen_dir"),
       ]


### PR DESCRIPTION
This is the simplest possible solution for https://fxbug.dev/126295: we don't even bother to generate separate targets; each FIDL library will invoke both fidlgen_cpp and fidlgen_hlcpp, generating sources for both.

Add the hlcpp-generated fidl_test_base.h header while I'm here.
