### PR TITLE
Increase section alignment to 64k on Android.

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -406,6 +406,10 @@ config("compiler") {
 
       # Enable identical code folding to reduce size.
       "-Wl,--icf=all",
+
+      # Currently defaults to 4k, but Android will be moving to 16k page size,
+      # and for future-proofing, 64k boundaries will be required.
+      "-Wl,-z,max-page-size=65536",
     ]
 
     if (is_clang) {


### PR DESCRIPTION
go/16k-app-guide