### PR TITLE
Silence Clang 18 warning

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -632,6 +632,9 @@ if (is_win) {
 
       # Unqualified std::move is pretty common.
       "-Wno-unqualified-std-cast-call",
+
+      # Needed for nlohmann/json.
+      "-Wno-deprecated-literal-operator",
     ]
   }
 } else {
@@ -666,6 +669,9 @@ if (is_win) {
 
     # Needed for compiling Skia with clang-12
     "-Wno-psabi",
+
+    # Needed for nlohmann/json.
+    "-Wno-deprecated-literal-operator",
   ]
   if (!is_wasm) {
     default_warning_flags += [


### PR DESCRIPTION
The Clang 18 roll here https://github.com/flutter/engine/pull/45486 will add a new warning like:

we get errors of the form:
```
../../third_party/json/include\nlohmann/json.hpp(5142,35): error: identifier '_json' preceded by whitespace in a literal operator declaration is deprecated [-Werror,-Wdeprecated-literal-operator]
 5142 | inline nlohmann::json operator "" _json(const char* s, std::size_t n)
      |                       ~~~~~~~~~~~~^~~~~
      |                       operator""_json
```

That is, Clang rejects `operator "" _a` unless spaces are removed. This PR adds a flag to silence the warning util it is fixed upstream.