### PR TITLE
Apply formatter to all GN files.

### DIFF
--- a/build/compiled_action.gni
+++ b/build/compiled_action.gni
@@ -89,7 +89,7 @@ template("compiled_action") {
                              "pool",
                              "outputs",
                            ])
-                           
+
     script = "//build/gn_run_binary.py"
 
     if (defined(invoker.inputs)) {

--- a/build/config/android/rules.gni
+++ b/build/config/android/rules.gni
@@ -4,5 +4,4 @@
 
 # TODO(dnfield): Patch icu to not depend on this file
 import("//build/config/android/config.gni")
-
 assert(is_android)

--- a/build/config/arm.gni
+++ b/build/config/arm.gni
@@ -8,7 +8,7 @@ if (current_cpu == "arm" || current_cpu == "arm64") {
     # platforms.
     if (current_cpu == "arm") {
       arm_version = 7
-    } else if(current_cpu == "arm64") {
+    } else if (current_cpu == "arm64") {
       arm_version = 8
     } else {
       assert(false, "Unconfigured arm version")

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -872,9 +872,7 @@ if (is_win) {
     } else {
       common_optimize_on_ldflags += [ "-Wl,-O2" ]
     }
-    common_optimize_on_ldflags += [
-      "-Wl,--gc-sections",
-    ]
+    common_optimize_on_ldflags += [ "-Wl,--gc-sections" ]
 
     if (!using_sanitizer && !is_wasm) {
       # Functions interposed by the sanitizers can make ld think
@@ -977,7 +975,7 @@ config("symbols") {
       ldflags = [ "-g3" ]
     } else {
       cflags = [ "-gsource-map" ]
-      ldflags = [ "-gsource-map"]
+      ldflags = [ "-gsource-map" ]
     }
   } else {
     cflags = [ "-g2" ]

--- a/build/config/mac/rules.gni
+++ b/build/config/mac/rules.gni
@@ -12,17 +12,13 @@ template("code_sign_mac") {
   assert(defined(invoker.deps))
 
   action(target_name) {
-    sources = [
-      invoker.entitlements_path,
-    ]
+    sources = [ invoker.entitlements_path ]
 
     _application_path = invoker.application_path
 
     script = mac_app_script
 
-    outputs = [
-      "$_application_path/_CodeSignature/CodeResources",
-    ]
+    outputs = [ "$_application_path/_CodeSignature/CodeResources" ]
 
     args = [
       "codesign",
@@ -51,9 +47,7 @@ template("resource_copy_mac") {
 
   copy(target_name) {
     sources = _resources
-    outputs = [
-      "$root_build_dir/$_app_name.app/$_bundle_directory/Contents/Resources/{{source_file_part}}",
-    ]
+    outputs = [ "$root_build_dir/$_app_name.app/$_bundle_directory/Contents/Resources/{{source_file_part}}" ]
 
     if (defined(invoker.deps)) {
       deps = invoker.deps
@@ -80,9 +74,7 @@ template("mac_app") {
     script = mac_app_script
 
     sources = []
-    outputs = [
-      "$root_build_dir/$app_name.app",
-    ]
+    outputs = [ "$root_build_dir/$app_name.app" ]
 
     args = [
       "structure",
@@ -109,12 +101,8 @@ template("mac_app") {
   action(plist_gen_target_name) {
     script = mac_app_script
 
-    sources = [
-      invoker.info_plist,
-    ]
-    outputs = [
-      "$root_build_dir/plist/$app_name/Info.plist",
-    ]
+    sources = [ invoker.info_plist ]
+    outputs = [ "$root_build_dir/plist/$app_name/Info.plist" ]
 
     args = [
       "plist",
@@ -129,32 +117,21 @@ template("mac_app") {
 
   copy_plist_gen_target_name = target_name + "_plist_copy"
   copy(copy_plist_gen_target_name) {
-    sources = [
-      "$root_build_dir/plist/$app_name/Info.plist",
-    ]
+    sources = [ "$root_build_dir/plist/$app_name/Info.plist" ]
 
-    outputs = [
-      "$root_build_dir/$app_name.app/Contents/{{source_file_part}}",
-    ]
+    outputs = [ "$root_build_dir/$app_name.app/Contents/{{source_file_part}}" ]
 
-    deps = [
-      ":$plist_gen_target_name",
-    ]
+    deps = [ ":$plist_gen_target_name" ]
   }
 
   copy_bin_target_name = target_name + "_bin_copy"
   copy(copy_bin_target_name) {
-    sources = [
-      "$root_build_dir/$app_name",
-    ]
+    sources = [ "$root_build_dir/$app_name" ]
 
-    outputs = [
-      "$root_build_dir/$app_name.app/Contents/MacOS/{{source_file_part}}",
-    ]
+    outputs =
+        [ "$root_build_dir/$app_name.app/Contents/MacOS/{{source_file_part}}" ]
 
-    deps = [
-      ":$bin_gen_target_name",
-    ]
+    deps = [ ":$bin_gen_target_name" ]
   }
 
   copy_all_target_name = target_name + "_all_copy"
@@ -169,8 +146,6 @@ template("mac_app") {
   # Top level group
 
   group(target_name) {
-    deps = [
-      ":$copy_all_target_name",
-    ]
+    deps = [ ":$copy_all_target_name" ]
   }
 }

--- a/build/config/sysroot.gni
+++ b/build/config/sysroot.gni
@@ -25,9 +25,11 @@ if (current_toolchain == default_toolchain && target_sysroot != "") {
 } else if (is_linux && !is_chromeos) {
   if (use_default_linux_sysroot && !is_fuchsia) {
     if (current_cpu == "x64") {
-      sysroot = rebase_path("//build/linux/debian_sid_amd64-sysroot", root_build_dir)
+      sysroot =
+          rebase_path("//build/linux/debian_sid_amd64-sysroot", root_build_dir)
     } else {
-      sysroot = rebase_path("//build/linux/debian_sid_arm64-sysroot", root_build_dir)
+      sysroot =
+          rebase_path("//build/linux/debian_sid_arm64-sysroot", root_build_dir)
     }
     assert(
         exec_script("//build/dir_exists.py", [ sysroot ], "string") == "True",

--- a/build/config/templates/templates.gni
+++ b/build/config/templates/templates.gni
@@ -36,9 +36,7 @@ template("file_template") {
     script = "//build/android/gyp/jinja_template.py"
     depfile = "$target_gen_dir/$target_name.d"
 
-    sources = [
-      invoker.input,
-    ]
+    sources = [ invoker.input ]
     outputs = [
       invoker.output,
       depfile,

--- a/build/secondary/third_party/glfw/glfw_args.gni
+++ b/build/secondary/third_party/glfw/glfw_args.gni
@@ -3,5 +3,5 @@
 # found in the LICENSE file.
 
 declare_args() {
-  glfw_vulkan_library=""
+  glfw_vulkan_library = ""
 }

--- a/build/secondary/third_party/vulkan_validation_layers/BUILD.gn
+++ b/build/secondary/third_party/vulkan_validation_layers/BUILD.gn
@@ -105,27 +105,27 @@ config("vulkan_layer_config") {
 }
 
 core_validation_sources = [
-  "$_checkout_dir/layers/utils/android_ndk_types.h",
-  "$_checkout_dir/layers/utils/convert_to_renderpass2.cpp",
-  "$_checkout_dir/layers/utils/convert_to_renderpass2.h",
+  "$_checkout_dir/layers/containers/qfo_transfer.h",
+  "$_checkout_dir/layers/containers/range_vector.h",
+  "$_checkout_dir/layers/containers/subresource_adapter.cpp",
+  "$_checkout_dir/layers/containers/subresource_adapter.h",
   "$_checkout_dir/layers/core_checks/cc_android.cpp",
   "$_checkout_dir/layers/core_checks/cc_buffer.cpp",
   "$_checkout_dir/layers/core_checks/cc_buffer_address.h",
-  "$_checkout_dir/layers/core_checks/cc_cmd_buffer_dynamic.cpp",
   "$_checkout_dir/layers/core_checks/cc_cmd_buffer.cpp",
+  "$_checkout_dir/layers/core_checks/cc_cmd_buffer_dynamic.cpp",
   "$_checkout_dir/layers/core_checks/cc_copy_blit_resolve.cpp",
-  "$_checkout_dir/layers/core_checks/core_validation.h",
   "$_checkout_dir/layers/core_checks/cc_descriptor.cpp",
-  "$_checkout_dir/layers/core_checks/cc_device_memory.cpp",
   "$_checkout_dir/layers/core_checks/cc_device.cpp",
+  "$_checkout_dir/layers/core_checks/cc_device_memory.cpp",
   "$_checkout_dir/layers/core_checks/cc_drawdispatch.cpp",
   "$_checkout_dir/layers/core_checks/cc_external_object.cpp",
   "$_checkout_dir/layers/core_checks/cc_image.cpp",
   "$_checkout_dir/layers/core_checks/cc_image_layout.cpp",
+  "$_checkout_dir/layers/core_checks/cc_pipeline.cpp",
   "$_checkout_dir/layers/core_checks/cc_pipeline_compute.cpp",
   "$_checkout_dir/layers/core_checks/cc_pipeline_graphics.cpp",
   "$_checkout_dir/layers/core_checks/cc_pipeline_ray_tracing.cpp",
-  "$_checkout_dir/layers/core_checks/cc_pipeline.cpp",
   "$_checkout_dir/layers/core_checks/cc_query.cpp",
   "$_checkout_dir/layers/core_checks/cc_queue.cpp",
   "$_checkout_dir/layers/core_checks/cc_ray_tracing.cpp",
@@ -136,6 +136,7 @@ core_validation_sources = [
   "$_checkout_dir/layers/core_checks/cc_video.cpp",
   "$_checkout_dir/layers/core_checks/cc_wsi.cpp",
   "$_checkout_dir/layers/core_checks/cc_ycbcr.cpp",
+  "$_checkout_dir/layers/core_checks/core_validation.h",
   "$_checkout_dir/layers/error_message/core_error_location.cpp",
   "$_checkout_dir/layers/error_message/core_error_location.h",
   "$_checkout_dir/layers/error_message/validation_error_enums.h",
@@ -158,8 +159,6 @@ core_validation_sources = [
   "$_checkout_dir/layers/gpu_validation/gpu_validation.cpp",
   "$_checkout_dir/layers/gpu_validation/gpu_validation.h",
   "$_checkout_dir/layers/gpu_validation/gpu_vuids.h",
-  "$_checkout_dir/layers/containers/qfo_transfer.h",
-  "$_checkout_dir/layers/containers/range_vector.h",
   "$_checkout_dir/layers/state_tracker/base_node.cpp",
   "$_checkout_dir/layers/state_tracker/base_node.h",
   "$_checkout_dir/layers/state_tracker/buffer_state.cpp",
@@ -188,22 +187,23 @@ core_validation_sources = [
   "$_checkout_dir/layers/state_tracker/render_pass_state.cpp",
   "$_checkout_dir/layers/state_tracker/render_pass_state.h",
   "$_checkout_dir/layers/state_tracker/sampler_state.h",
-  "$_checkout_dir/layers/state_tracker/shader_module.cpp",
-  "$_checkout_dir/layers/state_tracker/shader_module.h",
   "$_checkout_dir/layers/state_tracker/shader_instruction.cpp",
   "$_checkout_dir/layers/state_tracker/shader_instruction.h",
+  "$_checkout_dir/layers/state_tracker/shader_module.cpp",
+  "$_checkout_dir/layers/state_tracker/shader_module.h",
   "$_checkout_dir/layers/state_tracker/state_tracker.cpp",
   "$_checkout_dir/layers/state_tracker/state_tracker.h",
   "$_checkout_dir/layers/state_tracker/video_session_state.cpp",
   "$_checkout_dir/layers/state_tracker/video_session_state.h",
-  "$_checkout_dir/layers/containers/subresource_adapter.cpp",
-  "$_checkout_dir/layers/containers/subresource_adapter.h",
   "$_checkout_dir/layers/sync/sync_utils.cpp",
   "$_checkout_dir/layers/sync/sync_utils.h",
-  "$_checkout_dir/layers/sync/sync_vuid_maps.cpp",
-  "$_checkout_dir/layers/sync/sync_vuid_maps.h",
   "$_checkout_dir/layers/sync/sync_validation.cpp",
   "$_checkout_dir/layers/sync/sync_validation.h",
+  "$_checkout_dir/layers/sync/sync_vuid_maps.cpp",
+  "$_checkout_dir/layers/sync/sync_vuid_maps.h",
+  "$_checkout_dir/layers/utils/android_ndk_types.h",
+  "$_checkout_dir/layers/utils/convert_to_renderpass2.cpp",
+  "$_checkout_dir/layers/utils/convert_to_renderpass2.h",
 ]
 
 object_lifetimes_sources = [
@@ -214,13 +214,13 @@ object_lifetimes_sources = [
 ]
 
 stateless_validation_sources = [
+  "$_checkout_dir/layers/generated/enum_flag_bits.h",
   "$_checkout_dir/layers/generated/parameter_validation.cpp",
   "$_checkout_dir/layers/generated/parameter_validation.h",
-  "$_checkout_dir/layers/generated/enum_flag_bits.h",
   "$_checkout_dir/layers/stateless/parameter_name.h",
   "$_checkout_dir/layers/stateless/sl_buffer.cpp",
-  "$_checkout_dir/layers/stateless/sl_cmd_buffer_dynamic.cpp",
   "$_checkout_dir/layers/stateless/sl_cmd_buffer.cpp",
+  "$_checkout_dir/layers/stateless/sl_cmd_buffer_dynamic.cpp",
   "$_checkout_dir/layers/stateless/sl_descriptor.cpp",
   "$_checkout_dir/layers/stateless/sl_device_memory.cpp",
   "$_checkout_dir/layers/stateless/sl_external_object.cpp",
@@ -245,6 +245,7 @@ unique_objects_sources = []
 best_practices_sources = [
   "$_checkout_dir/layers/best_practices/best_practices_error_enums.h",
   "$_checkout_dir/layers/best_practices/best_practices_utils.cpp",
+  "$_checkout_dir/layers/best_practices/best_practices_validation.h",
   "$_checkout_dir/layers/best_practices/bp_buffer.cpp",
   "$_checkout_dir/layers/best_practices/bp_cmd_buffer.cpp",
   "$_checkout_dir/layers/best_practices/bp_copy_blit_resolve.cpp",
@@ -260,7 +261,6 @@ best_practices_sources = [
   "$_checkout_dir/layers/best_practices/bp_synchronization.cpp",
   "$_checkout_dir/layers/best_practices/bp_video.cpp",
   "$_checkout_dir/layers/best_practices/bp_wsi.cpp",
-  "$_checkout_dir/layers/best_practices/best_practices_validation.h",
   "$_checkout_dir/layers/generated/best_practices.cpp",
   "$_checkout_dir/layers/generated/best_practices.h",
 ]
@@ -271,21 +271,21 @@ debug_printf_sources = [
 ]
 
 chassis_sources = [
-  "$vulkan_headers_dir/include/vulkan/vk_layer.h",
-  "$vulkan_headers_dir/include/vulkan/vulkan.h",
   "$_checkout_dir/layers/generated/chassis.cpp",
-  "$_checkout_dir/layers/generated/valid_param_values.cpp",
-  "$_checkout_dir/layers/generated/valid_param_values.h",
   "$_checkout_dir/layers/generated/chassis.h",
   "$_checkout_dir/layers/generated/chassis_dispatch_helper.h",
   "$_checkout_dir/layers/generated/layer_chassis_dispatch.cpp",
   "$_checkout_dir/layers/generated/layer_chassis_dispatch.h",
+  "$_checkout_dir/layers/generated/valid_param_values.cpp",
+  "$_checkout_dir/layers/generated/valid_param_values.h",
   "$_checkout_dir/layers/generated/vk_dispatch_table_helper.h",
   "$_checkout_dir/layers/generated/vk_extension_helper.h",
   "$_checkout_dir/layers/generated/vk_safe_struct.cpp",
   "$_checkout_dir/layers/layer_options.cpp",
   "$_checkout_dir/layers/layer_options.h",
   "$_checkout_dir/layers/vk_layer_settings_ext.h",
+  "$vulkan_headers_dir/include/vulkan/vk_layer.h",
+  "$vulkan_headers_dir/include/vulkan/vulkan.h",
 ]
 
 layers = [ [
@@ -351,10 +351,12 @@ source_set("vulkan_layer_utils") {
     "$_checkout_dir/layers/generated",
   ]
   sources = [
-    "$vulkan_headers_dir/include/vulkan/vk_layer.h",
-    "$vulkan_headers_dir/include/vulkan/vulkan.h",
-    "$_checkout_dir/layers/utils/android_ndk_types.h",
-    "$_checkout_dir/layers/utils/cast_utils.h",
+    "$_checkout_dir/layers/containers/custom_containers.h",
+    "$_checkout_dir/layers/containers/sparse_containers.h",
+    "$_checkout_dir/layers/error_message/logging.cpp",
+    "$_checkout_dir/layers/error_message/logging.h",
+    "$_checkout_dir/layers/external/xxhash.cpp",
+    "$_checkout_dir/layers/external/xxhash.h",
     "$_checkout_dir/layers/generated/vk_enum_string_helper.h",
     "$_checkout_dir/layers/generated/vk_extension_helper.h",
     "$_checkout_dir/layers/generated/vk_format_utils.cpp",
@@ -364,20 +366,18 @@ source_set("vulkan_layer_utils") {
     "$_checkout_dir/layers/generated/vk_safe_struct.h",
     "$_checkout_dir/layers/generated/vk_typemap_helper.h",
     "$_checkout_dir/layers/generated/vk_validation_error_messages.h",
+    "$_checkout_dir/layers/utils/android_ndk_types.h",
+    "$_checkout_dir/layers/utils/cast_utils.h",
     "$_checkout_dir/layers/utils/hash_util.h",
     "$_checkout_dir/layers/utils/hash_vk_types.h",
-    "$_checkout_dir/layers/containers/sparse_containers.h",
-    "$_checkout_dir/layers/containers/custom_containers.h",
-    "$_checkout_dir/layers/vk_layer_config.cpp",
-    "$_checkout_dir/layers/vk_layer_config.h",
     "$_checkout_dir/layers/utils/vk_layer_extension_utils.cpp",
     "$_checkout_dir/layers/utils/vk_layer_extension_utils.h",
-    "$_checkout_dir/layers/error_message/logging.h",
-    "$_checkout_dir/layers/error_message/logging.cpp",
     "$_checkout_dir/layers/utils/vk_layer_utils.cpp",
     "$_checkout_dir/layers/utils/vk_layer_utils.h",
-    "$_checkout_dir/layers/external/xxhash.cpp",
-    "$_checkout_dir/layers/external/xxhash.h",
+    "$_checkout_dir/layers/vk_layer_config.cpp",
+    "$_checkout_dir/layers/vk_layer_config.h",
+    "$vulkan_headers_dir/include/vulkan/vk_layer.h",
+    "$vulkan_headers_dir/include/vulkan/vulkan.h",
   ]
   defines = [ "XXH_NO_LONG_LONG" ]
   public_configs = [
@@ -433,6 +433,7 @@ foreach(layer_info, layers) {
     } else {
       configs -= [ "//build/config/compiler:chromium_code" ]
       configs += [ "//build/config/compiler:no_chromium_code" ]
+
       # The following line is what has to change to fix chromium compilation.
       configs -= [ "//build/config/compiler:no_rtti" ]
       configs += [ "//build/config/compiler:rtti" ]
@@ -463,7 +464,7 @@ foreach(layer_info, layers) {
     }
     if (is_android) {
       libs = [
-        "c++", # Note: C++ added by Flutter.
+        "c++",  # Note: C++ added by Flutter.
         "log",
         "nativewindow",
       ]

--- a/build/toolchain/android/BUILD.gn
+++ b/build/toolchain/android/BUILD.gn
@@ -53,12 +53,9 @@ template("android_gcc_toolchain") {
         "--exec_root=$rbe_exec_root",
         "--platform=$rbe_platform",
       ]
-      compiler_args = rewrapper_args + [
-        "--labels=type=compile,compiler=clang,lang=cpp ",
-      ]
-      link_args = rewrapper_args + [
-        "--labels=type=link,tool=clang ",
-      ]
+      compiler_args =
+          rewrapper_args + [ "--labels=type=compile,compiler=clang,lang=cpp " ]
+      link_args = rewrapper_args + [ "--labels=type=link,tool=clang " ]
       compiler_prefix = string_join(" ", compiler_args)
       link_prefix = string_join(" ", link_args)
     } else if (use_ccache) {
@@ -110,8 +107,7 @@ template("android_gcc_toolchain") {
 
     android_strip = "${tool_prefix}strip"
 
-    strip_command =
-        "$android_strip --strip-unneeded -o $temp_stripped_soname {{root_out_dir}}/$soname"
+    strip_command = "$android_strip --strip-unneeded -o $temp_stripped_soname {{root_out_dir}}/$soname"
     replace_command = "if ! cmp -s $temp_stripped_soname $stripped_soname; then mv $temp_stripped_soname $stripped_soname; fi"
     postsolink = "$strip_command && $replace_command"
     solink_outputs = [ stripped_soname ]

--- a/build/toolchain/clang.gni
+++ b/build/toolchain/clang.gni
@@ -3,7 +3,7 @@
 # found in the LICENSE file.
 
 if (is_mac || is_ios) {
-  import("//build/config/ios/ios_sdk.gni") # For use_ios_simulator
+  import("//build/config/ios/ios_sdk.gni")  # For use_ios_simulator
 }
 
 declare_args() {

--- a/build/toolchain/gcc_toolchain.gni
+++ b/build/toolchain/gcc_toolchain.gni
@@ -132,9 +132,8 @@ template("gcc_toolchain") {
       }
       depsformat = "gcc"
       description = "CC {{output}}"
-      outputs = [
-        "{{source_out_dir}}/{{target_output_name}}.{{source_name_part}}.o",
-      ]
+      outputs =
+          [ "{{source_out_dir}}/{{target_output_name}}.{{source_name_part}}.o" ]
     }
 
     tool("cxx") {
@@ -145,9 +144,8 @@ template("gcc_toolchain") {
       }
       depsformat = "gcc"
       description = "CXX {{output}}"
-      outputs = [
-        "{{source_out_dir}}/{{target_output_name}}.{{source_name_part}}.o",
-      ]
+      outputs =
+          [ "{{source_out_dir}}/{{target_output_name}}.{{source_name_part}}.o" ]
     }
 
     tool("asm") {
@@ -158,9 +156,8 @@ template("gcc_toolchain") {
       }
       depsformat = "gcc"
       description = "ASM {{output}}"
-      outputs = [
-        "{{source_out_dir}}/{{target_output_name}}.{{source_name_part}}.o",
-      ]
+      outputs =
+          [ "{{source_out_dir}}/{{target_output_name}}.{{source_name_part}}.o" ]
     }
 
     tool("alink") {
@@ -168,9 +165,8 @@ template("gcc_toolchain") {
       command = "rm -f {{output}} && $ar rcs {{output}} @$rspfile"
       description = "AR {{output}}"
       rspfile_content = "{{inputs}}"
-      outputs = [
-        "{{target_out_dir}}/{{target_output_name}}{{output_extension}}",
-      ]
+      outputs =
+          [ "{{target_out_dir}}/{{target_output_name}}{{output_extension}}" ]
       default_output_extension = ".a"
       output_prefix = "lib"
     }
@@ -272,9 +268,7 @@ template("gcc_toolchain") {
       }
       description = "LINK $outfile"
       rspfile_content = "{{inputs}}"
-      outputs = [
-        outfile,
-      ]
+      outputs = [ outfile ]
       if (outfile != unstripped_outfile) {
         outputs += [ unstripped_outfile ]
       }

--- a/build/toolchain/linux/BUILD.gn
+++ b/build/toolchain/linux/BUILD.gn
@@ -26,12 +26,9 @@ if (use_goma) {
     "--exec_root=$rbe_exec_root",
     "--platform=$rbe_platform",
   ]
-  compiler_args = rewrapper_args + [
-    "--labels=type=compile,compiler=clang,lang=cpp ",
-  ]
-  link_args = rewrapper_args + [
-    "--labels=type=link,tool=clang ",
-  ]
+  compiler_args =
+      rewrapper_args + [ "--labels=type=compile,compiler=clang,lang=cpp " ]
+  link_args = rewrapper_args + [ "--labels=type=link,tool=clang " ]
   compiler_prefix = string_join(" ", compiler_args)
   link_prefix = string_join(" ", link_args)
 } else if (use_ccache) {

--- a/build/toolchain/wasm.gni
+++ b/build/toolchain/wasm.gni
@@ -58,11 +58,10 @@ template("wasm_toolchain") {
 
     is_clang = true
 
-    link_outputs = [
-      "{{root_out_dir}}/{{target_output_name}}.wasm",
-    ]
+    link_outputs = [ "{{root_out_dir}}/{{target_output_name}}.wasm" ]
 
-    if (wasm_use_pthreads || (defined(extra_toolchain_args.wasm_use_pthreads) && extra_toolchain_args.wasm_use_pthreads)) {
+    if (wasm_use_pthreads || (defined(extra_toolchain_args.wasm_use_pthreads) &&
+                              extra_toolchain_args.wasm_use_pthreads)) {
       link_outputs += [ "{{root_out_dir}}/{{target_output_name}}.worker.js" ]
     }
 

--- a/build/toolchain/win/midl.gni
+++ b/build/toolchain/win/midl.gni
@@ -101,9 +101,7 @@ template("midl") {
     sources = process_file_template(invoker.sources,
                                     [ "$out_dir/$interface_identifier_file" ])
 
-    public_deps = [
-      ":$action_name",
-    ]
+    public_deps = [ ":$action_name" ]
 
     config("midl_warnings") {
       if (is_clang) {

--- a/build_overrides/angle.gni
+++ b/build_overrides/angle.gni
@@ -21,6 +21,7 @@ if (!is_fuchsia) {
 angle_abseil_cpp_dir = "//third_party/abseil-cpp"
 angle_glslang_dir = "//third_party/vulkan-deps/glslang/src"
 angle_googletest_dir = "//third_party/googletest/googletest/src"
+
 # Note: This path doesn't actually exist; see
 # //build/secondary/third_party/jsoncpp/BUILD.gn
 angle_jsoncpp_dir = "//third_party/jsoncpp"

--- a/build_overrides/vulkan_validation_layers.gni
+++ b/build_overrides/vulkan_validation_layers.gni
@@ -5,8 +5,8 @@
 vulkan_headers_dir = "//third_party/vulkan-deps/vulkan-headers/src"
 vvl_spirv_tools_dir = "//third_party/vulkan-deps/spirv-tools/src"
 vvl_glslang_dir = "//third_party/vulkan-deps/spirv-tools/src"
-# robin_hood_headers_dir = "//external/robin-hood-hashing/src/include"
 
+# robin_hood_headers_dir = "//external/robin-hood-hashing/src/include"
 
 # Subdirectories for generated files
 vulkan_data_subdir = "vulkan-data"


### PR DESCRIPTION
There is no CI hook to check formatting of .gn and .gni files in the buildroot.

Applies the formatter to all files with no change in behavior.

The same actions were done on the engine and all files were correctly formatted already which proves the auto-formatter is working there.
