### PR TITLE
Emit symbol maps from emscripten.

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -295,6 +295,9 @@ config("compiler") {
       # Reduces global namespace pollution.
       "-s",
       "MODULARIZE=1",
+
+      # Always produce a symbol map so that we can map crash traces
+      "--emit-symbol-map",
     ]
   }
 

--- a/build/toolchain/wasm.gni
+++ b/build/toolchain/wasm.gni
@@ -58,7 +58,12 @@ template("wasm_toolchain") {
 
     is_clang = true
 
-    link_outputs = [ "{{root_out_dir}}/{{target_output_name}}.wasm" ]
+    link_outputs = [
+      "{{root_out_dir}}/{{target_output_name}}.wasm",
+
+      # We always output a symbol map.
+      "{{root_out_dir}}/{{target_output_name}}.js.symbols",
+    ]
 
     if (wasm_use_pthreads || (defined(extra_toolchain_args.wasm_use_pthreads) &&
                               extra_toolchain_args.wasm_use_pthreads)) {


### PR DESCRIPTION
These will be useful for mapping stack traces on release builds of CanvasKit/Skwasm