### PR TITLE
Add build config prevent_unsafe_narrowing to support abseil roll

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -998,3 +998,43 @@ config("no_symbols") {
     cflags = [ "-g0" ]
   }
 }
+
+# prevent_unsafe_narrowing ----------------------------------------------------
+#
+# Warnings that prevent narrowing or comparisons of integer types that are
+# likely to cause out-of-bound read/writes or Undefined Behaviour. In
+# particular, size_t is used for memory sizes, allocation, indexing, and
+# offsets. Using other integer types along with size_t produces risk of
+# memory-safety bugs and thus security exploits.
+#
+# In order to prevent these bugs, allocation sizes were historically limited to
+# sizes that can be represented within 31 bits of information, allowing `int` to
+# be safely misused instead of `size_t` (https://crbug.com/169327). In order to
+# support increasing the allocation limit we require strictly adherence to
+# using the correct types, avoiding lossy conversions, and preventing overflow.
+# To do so, enable this config and fix errors by converting types to be
+# `size_t`, which is both large enough and unsigned, when dealing with memory
+# sizes, allocations, indices, or offsets.In cases where type conversion is not
+# possible or is superfluous, use base::strict_cast<> or base::checked_cast<>
+# to convert to size_t as needed.
+# See also: https://docs.google.com/document/d/1CTbQ-5cQjnjU8aCOtLiA7G6P0i5C6HpSDNlSNq6nl5E
+#
+# To enable in a GN target, use:
+#   configs += [ "//build/config/compiler:prevent_unsafe_narrowing" ]
+config("prevent_unsafe_narrowing") {
+  if (is_clang) {
+    cflags = [
+      "-Wshorten-64-to-32",
+      "-Wimplicit-int-conversion",
+      "-Wsign-compare",
+      "-Wsign-conversion",
+    ]
+    if (!is_nacl) {
+      cflags += [
+        # Avoid bugs of the form `if (size_t i = size; i >= 0; --i)` while
+        # fixing types to be sign-correct.
+        "-Wtautological-unsigned-zero-compare",
+      ]
+    }
+  }
+}

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -1028,13 +1028,9 @@ config("prevent_unsafe_narrowing") {
       "-Wimplicit-int-conversion",
       "-Wsign-compare",
       "-Wsign-conversion",
+      # Avoid bugs of the form `if (size_t i = size; i >= 0; --i)` while
+      # fixing types to be sign-correct.
+      "-Wtautological-unsigned-zero-compare",
     ]
-    if (!is_nacl) {
-      cflags += [
-        # Avoid bugs of the form `if (size_t i = size; i >= 0; --i)` while
-        # fixing types to be sign-correct.
-        "-Wtautological-unsigned-zero-compare",
-      ]
-    }
   }
 }


### PR DESCRIPTION
Related to https://flutter-review.googlesource.com/c/third_party/abseil-cpp/+/52880

Chromium added this config, we're missing it, newer versions of abseil want it.