### PR TITLE
Add /usr/local/lib to the macOS rpath.

### DIFF
--- a/build/config/mac/BUILD.gn
+++ b/build/config/mac/BUILD.gn
@@ -16,6 +16,7 @@ config("mac_dynamic_flags") {
 
     # Path for loading shared libraries for unbundled binaries.
     "-Wl,-rpath,@loader_path/.",
+    "-Wl,-rpath,/usr/local/lib/.",
 
     # Path for loading shared libraries for bundled binaries. Get back from
     # Binary.app/Contents/MacOS.


### PR DESCRIPTION
The global installation of MoltenVK resides here. This makes the playgrounds use MoltenVK again.