### PR TITLE
Add FIDL HLCPP tables.c file to the build

### DIFF
--- a/build/fuchsia/fidl_gen_cpp.py
+++ b/build/fuchsia/fidl_gen_cpp.py
@@ -43,6 +43,8 @@ def main():
   parser.add_argument('--fidlgen-output-root', dest='fidlgen_output_root', action='store', required=False)
   parser.add_argument('--output-c-tables', dest='output_c_tables', action='store', required=True)
   parser.add_argument('--target-api-level', dest='target_api_level', action='store', required=False)
+  # TODO(fxbug.dev/39388): Remove after https://fxrev.dev/953989 rolls into flutter.
+  parser.add_argument('--new-tables-path', dest='new_tables_path', action='store', required=False)
 
   args = parser.parse_args()
 
@@ -77,6 +79,13 @@ def main():
       fidlc_command.append(fidl_abspath)
 
   subprocess.check_call(fidlc_command)
+
+  # TODO(fxbug.dev/39388): Remove after https://fxrev.dev/953989 rolls into flutter.
+  if args.fidlgen_bin:
+    # Write tables.c so that GN doesn't complain about a missing output before the roll.
+    assert args.new_tables_path
+    with open(args.new_tables_path, "w") as f:
+      print("// This will contain coding tables once https://fxbug.dev/39388 is done.", file=f)
 
   if args.fidlgen_output_root:
     assert os.path.exists(args.json)

--- a/build/fuchsia/sdk.gni
+++ b/build/fuchsia/sdk.gni
@@ -136,6 +136,7 @@ template("fuchsia_fidl_library") {
         "$target_gen_dir/$library_name_slashes/cpp/fidl.cc",
         "$target_gen_dir/$library_name_slashes/cpp/fidl.h",
         "$target_gen_dir/$library_name_slashes/cpp/fidl_test_base.h",
+        "$target_gen_dir/$library_name_slashes/cpp/tables.c",
 
         "$target_gen_dir/fidl/$library_name/cpp/common_types.cc",
         "$target_gen_dir/fidl/$library_name/cpp/common_types.h",
@@ -165,6 +166,9 @@ template("fuchsia_fidl_library") {
         rebase_path("${_fuchsia_tools_path}/fidlgen_hlcpp"),
         "--fidlgen-output-root",
         rebase_path("$target_gen_dir"),
+        # TODO(fxbug.dev/39388): Remove after https://fxrev.dev/953989 rolls into flutter.
+        "--new-tables-path",
+        rebase_path("$target_gen_dir/$library_name_slashes/cpp/tables.c"),
       ]
     }
   }


### PR DESCRIPTION
This is a continuation of #795. This tables.c file is currently empty, but we will migrate the fidlc coding tables to it. See https://fxrev.dev/953989 for the full soft transition plan.