### PR TITLE
Remove unused `jsoncpp` override.

### DIFF
--- a/build_overrides/angle.gni
+++ b/build_overrides/angle.gni
@@ -21,10 +21,6 @@ if (!is_fuchsia) {
 angle_abseil_cpp_dir = "//third_party/abseil-cpp"
 angle_glslang_dir = "//third_party/vulkan-deps/glslang/src"
 angle_googletest_dir = "//third_party/googletest/googletest/src"
-
-# Note: This path doesn't actually exist; see
-# //build/secondary/third_party/jsoncpp/BUILD.gn
-angle_jsoncpp_dir = "//third_party/jsoncpp"
 angle_libjpeg_turbo_dir = "//third_party/libjpeg_turbo"
 angle_libpng_dir = "//third_party/libpng"
 angle_spirv_headers_dir = "//third_party/vulkan-deps/spirv-headers/src"


### PR DESCRIPTION
I believe this was removed in https://github.com/flutter/engine/pull/8230.

I'll verify this by rolling buildroot and removing the `BUILD.gn` files from the engine.