### PR TITLE
Expect `libpng` to be in `flutter/third_party/libpng`.

### DIFF
--- a/build_overrides/angle.gni
+++ b/build_overrides/angle.gni
@@ -26,7 +26,7 @@ angle_googletest_dir = "//third_party/googletest/googletest/src"
 # //build/secondary/third_party/jsoncpp/BUILD.gn
 angle_jsoncpp_dir = "//third_party/jsoncpp"
 angle_libjpeg_turbo_dir = "//third_party/libjpeg_turbo"
-angle_libpng_dir = "//third_party/libpng"
+angle_libpng_dir = "//flutter/third_party/libpng"
 angle_spirv_headers_dir = "//third_party/vulkan-deps/spirv-headers/src"
 angle_spirv_tools_dir = "//third_party/vulkan-deps/spirv-tools/src"
 angle_spirv_cross_dir = "//third_party/vulkan-deps/spirv-cross/src"


### PR DESCRIPTION
Will need to be synchronized with `flutter/engine` replacements of `third_party/libpng`.