### PR TITLE
[Fuchsia] Add with_envs.py to setup env variables for test-scripts from chromium

### DIFF
--- a/build/fuchsia/with_envs.py
+++ b/build/fuchsia/with_envs.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024, the Flutter project authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE file.
+
+import os
+import platform
+import subprocess
+import sys
+
+sys.path.insert(
+    0,
+    os.path.abspath(
+        os.path.join(os.path.dirname(__file__),
+                     '../../fuchsia/test_scripts/test/')))
+
+from common import catch_sigterm, wait_for_sigterm
+
+
+def Main():
+    """
+    Executes the test-scripts with required environment variables. It acts like
+    /usr/bin/env, but provides some extra functionality to dynamically set up
+    the environment variables.
+    """
+    # Ensures the signals can be correctly forwarded to the subprocesses.
+    catch_sigterm()
+
+    # Flutter uses a different repo structure and fuchsia sdk is not in the
+    # third_party/, so setting the DIR_SRC_ROOT does not make sense.
+    os.environ['FUCHSIA_IMAGES_ROOT'] = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), '../../fuchsia/images/'))
+
+    sdk_dir = ''
+    if platform.system() == 'Linux':
+        sdk_dir = 'linux'
+    elif platform.system() == 'Darwin':
+        sdk_dir = 'mac'
+    else:
+        assert False, 'Unsupported OS'
+    os.environ['FUCHSIA_SDK_ROOT'] = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), '../../fuchsia/sdk/', sdk_dir))
+
+    with subprocess.Popen(sys.argv[1:]) as proc:
+        try:
+            proc.wait()
+        except:
+            # Use terminate / SIGTERM to allow the subprocess exiting cleanly.
+            proc.terminate()
+
+
+if __name__ == '__main__':
+    sys.exit(Main())


### PR DESCRIPTION
It can be used by both DEPS and run_tests.py, e.g. https://github.com/flutter/engine/pull/49650.

## Pre-launch Checklist

- [V] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [V] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [V] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [V] I signed the [CLA].
- [V] I listed at least one issue that this PR fixes in the description above.
- [V] I updated/added relevant documentation (doc comments with `///`).
- [V] I added new tests to check the change I am making, or this PR is [test-exempt].
- [V] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
