### PR TITLE
Add fidl_binding_deps support from the Fuchsia SDK json files

### DIFF
--- a/build/fuchsia/sdk.gni
+++ b/build/fuchsia/sdk.gni
@@ -224,6 +224,14 @@ template("_fuchsia_cc_source_library") {
     _deps += [ "../fidl:$dep" ]
   }
 
+  foreach(binding_dep, meta_json.fidl_binding_deps) {
+    # No need to check "binding_deps.binding_type" because we always
+    # generate both hlcpp and natural bindings.
+    foreach(dep, binding_dep.deps) {
+      _deps += [ "../fidl:$dep" ]
+    }
+  }
+
   source_set(target_name) {
     output_name = _output_name
     public = _public_headers


### PR DESCRIPTION
The GN rules that parse the SDK json files previously only supported the `fidl_deps` field for determining which fidl dependencies to depend on. This change adds support for the newer `fidl_binding_deps` field, which contains information about what flavor of bindings are needed (hlcpp vs natural). Since our fidl GN targets always generate both hlcpp and natural bindings, we don't need to check the binding_type in the json file.
