### PR TITLE
Limit GN header checking in //flutter to the first-party engine subsystems

### DIFF
--- a/.gn
+++ b/.gn
@@ -16,11 +16,12 @@ secondary_source = "//flutter/build/secondary/"
 # The set of targets known to pass 'gn check'. When all targets pass, remove
 # this.
 check_targets = [
-  "//dart/*",
-  "//flow/*",
-  "//flutter/*",
-  "//glue/*",
-  "//mojo/*",
-  "//skia/*",
-  "//sky/*",
+  "//flutter/common/*",
+  "//flutter/display_list/*",
+  "//flutter/flow/*",
+  "//flutter/fml/*",
+  "//flutter/lib/*",
+  "//flutter/impeller/*",
+  "//flutter/runtime/*",
+  "//flutter/shell/*",
 ]


### PR DESCRIPTION
Some components that do not support the GN header checks (such as the Dart SDK) are being moved into //flutter/third_party.  These directories should be excluded from "gn check".

See https://github.com/flutter/flutter/issues/143335