### PR TITLE
Forward build_overrides to flutter/build_overrides

### DIFF
--- a/build_overrides/angle.gni
+++ b/build_overrides/angle.gni
@@ -2,37 +2,6 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-# Ensure use_xcode_clang is visibile to ANGLE.
-import("//build/toolchain/toolchain.gni")
-
-# The ANGLE build requires this file to point to the location of third-party
-# dependencies.
-angle_root = "//third_party/angle"
-
-angle_vma_version = 30000001
-
-# Flutter's buildroot looks enough like Chromium to satisfy Angle, and enough
-# to cause GN variable collisions if we don't set this.
-if (!is_fuchsia) {
-  angle_has_build = true
-}
-
-# Overrides for ANGLE's dependencies.
-angle_abseil_cpp_dir = "//flutter/third_party/abseil-cpp"
-angle_glslang_dir = "//flutter/third_party/vulkan-deps/glslang/src"
-angle_googletest_dir = "//third_party/googletest/googletest/src"
-
-# Note: This path doesn't actually exist; see
-# //build/secondary/third_party/jsoncpp/BUILD.gn
-angle_jsoncpp_dir = "//third_party/jsoncpp"
-angle_libjpeg_turbo_dir = "//third_party/libjpeg_turbo"
-angle_libpng_dir = "//flutter/third_party/libpng"
-angle_spirv_headers_dir = "//flutter/third_party/vulkan-deps/spirv-headers/src"
-angle_spirv_tools_dir = "//flutter/third_party/vulkan-deps/spirv-tools/src"
-angle_spirv_cross_dir = "//flutter/third_party/vulkan-deps/spirv-cross/src"
-angle_spirv_headers_dir = "//flutter/third_party/vulkan-deps/spirv-headers/src"
-angle_vulkan_memory_allocator_dir = "//third_party/vulkan_memory_allocator"
-
-# This is a general Chromium flag, but in the Flutter build only ANGLE needs it
-# so it is defined here.
-is_cfi = false
+# This file is a temporary shim needed during the elimination of the buildroot.
+# See: https://github.com/flutter/flutter/issues/67373
+import("//flutter/build_overrides/angle.gni")

--- a/build_overrides/build.gni
+++ b/build_overrides/build.gni
@@ -2,12 +2,6 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-# The engine build uses some Chromium-sourced versions of third-party
-# dependencies (e.g, ANGLE, abseil) to use their GN build files, but we don't
-# want the Chromium-specific parts of the build.
-build_with_chromium = false
-
-# Perfetto targets fail to build without this variable. It is used by Perfetto
-# targets to distinguish embedder builds from Perfetto standalone builds, and
-# builds in the Android tree.
-perfetto_build_with_embedder = true
+# This file is a temporary shim needed during the elimination of the buildroot.
+# See: https://github.com/flutter/flutter/issues/67373
+import("//flutter/build_overrides/build.gni")

--- a/build_overrides/glslang.gni
+++ b/build_overrides/glslang.gni
@@ -2,5 +2,6 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-glslang_spirv_tools_dir = "//flutter/third_party/vulkan-deps/spirv-tools/src"
-spirv_tools_dir = "//flutter/third_party/vulkan-deps/spirv-tools/src"
+# This file is a temporary shim needed during the elimination of the buildroot.
+# See: https://github.com/flutter/flutter/issues/67373
+import("//flutter/build_overrides/glslang.gni")

--- a/build_overrides/spirv_tools.gni
+++ b/build_overrides/spirv_tools.gni
@@ -2,9 +2,6 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-# We are building inside Flutter.
-spirv_tools_standalone = false
-
-# Paths to SPIRV-Tools dependencies in Flutter.
-spirv_tools_googletest_dir = "//third_party/googletest/googletest/src"
-spirv_tools_spirv_headers_dir = "//flutter/third_party/vulkan-deps/spirv-headers/src"
+# This file is a temporary shim needed during the elimination of the buildroot.
+# See: https://github.com/flutter/flutter/issues/67373
+import("//flutter/build_overrides/spirv_tools.gni")

--- a/build_overrides/swiftshader.gni
+++ b/build_overrides/swiftshader.gni
@@ -2,8 +2,6 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-# We are building SwiftShader in Flutter.
-swiftshader_standalone = false
-
-# Path to SwiftShader.
-swiftshader_dir = "//flutter/third_party/swiftshader"
+# This file is a temporary shim needed during the elimination of the buildroot.
+# See: https://github.com/flutter/flutter/issues/67373
+import("//flutter/build_overrides/swiftshader.gni")

--- a/build_overrides/vulkan_headers.gni
+++ b/build_overrides/vulkan_headers.gni
@@ -2,10 +2,6 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-# This file is needed by the vulkan-headers build, but doesn't need to actually
-# set anything.
-
-if (is_linux) {
-  vulkan_use_x11 = true
-  vulkan_use_wayland = true
-}
+# This file is a temporary shim needed during the elimination of the buildroot.
+# See: https://github.com/flutter/flutter/issues/67373
+import("//flutter/build_overrides/vulkan_headers.gni")

--- a/build_overrides/vulkan_loader.gni
+++ b/build_overrides/vulkan_loader.gni
@@ -2,7 +2,6 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-vulkan_headers_dir = "//flutter/third_party/vulkan-deps/vulkan-headers/src"
-
-# Vulkan loader build options
-vulkan_loader_shared = true
+# This file is a temporary shim needed during the elimination of the buildroot.
+# See: https://github.com/flutter/flutter/issues/67373
+import("//flutter/build_overrides/vulkan_loader.gni")

--- a/build_overrides/vulkan_tools.gni
+++ b/build_overrides/vulkan_tools.gni
@@ -2,8 +2,6 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-vulkan_headers_dir = "//flutter/third_party/vulkan-deps/vulkan-headers/src"
-
-# Subdirectories for generated files
-vulkan_data_subdir = ""
-vulkan_gen_subdir = ""
+# This file is a temporary shim needed during the elimination of the buildroot.
+# See: https://github.com/flutter/flutter/issues/67373
+import("//flutter/build_overrides/vulkan_tools.gni")

--- a/build_overrides/vulkan_utility_libraries.gni
+++ b/build_overrides/vulkan_utility_libraries.gni
@@ -2,4 +2,6 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-vulkan_headers_dir = "//flutter/third_party/vulkan-deps/vulkan-headers/src"
+# This file is a temporary shim needed during the elimination of the buildroot.
+# See: https://github.com/flutter/flutter/issues/67373
+import("//flutter/build_overrides/vulkan_utility_libraries.gni")

--- a/build_overrides/vulkan_validation_layers.gni
+++ b/build_overrides/vulkan_validation_layers.gni
@@ -2,13 +2,6 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-vulkan_headers_dir = "//flutter/third_party/vulkan-deps/vulkan-headers/src"
-vulkan_utility_libraries_dir = "//flutter/third_party/vulkan-deps/vulkan-utility-libraries/src"
-vvl_spirv_tools_dir = "//flutter/third_party/vulkan-deps/spirv-tools/src"
-vvl_glslang_dir = "//flutter/third_party/vulkan-deps/spirv-tools/src"
-
-# robin_hood_headers_dir = "//external/robin-hood-hashing/src/include"
-
-# Subdirectories for generated files
-vulkan_data_subdir = "vulkan-data"
-vulkan_gen_subdir = ""
+# This file is a temporary shim needed during the elimination of the buildroot.
+# See: https://github.com/flutter/flutter/issues/67373
+import("//flutter/build_overrides/vulkan_validation_layers.gni")

--- a/build_overrides/wayland.gni
+++ b/build_overrides/wayland.gni
@@ -2,7 +2,6 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-# ANGLE expects this to be here.
-
-# Flutter has no wayland third-party dir
-wayland_gn_dir = ""
+# This file is a temporary shim needed during the elimination of the buildroot.
+# See: https://github.com/flutter/flutter/issues/67373
+import("//flutter/build_overrides/wayland.gni")


### PR DESCRIPTION
In https://github.com/flutter/engine/pull/51258, all existing build_overrides from the buildroot were copied into the engine. This replaces each existing file under build_overrides in the buildroot with a shim that just imports the files landed in that patch. This allows the third-party dependencies to continue hardcoding the `//build_overrides/foo.gni` path, but provides a seamless path forward when we drop the buildroot.

Issue: https://github.com/flutter/flutter/issues/144790
Part of: https://github.com/flutter/flutter/issues/67373

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] Do not start, operate, or service Flutter CI infra until you read and understand the operator's manual. Failure to do so could result in serious injury or death.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
