### PR TITLE
Change location of emsdk.

### DIFF
--- a/build/toolchain/wasm.gni
+++ b/build/toolchain/wasm.gni
@@ -10,7 +10,7 @@ import("//build/toolchain/goma.gni")
 
 declare_args() {
   # The location of an activated embedded emsdk.
-  emsdk_dir = rebase_path("//buildtools/emsdk")
+  emsdk_dir = rebase_path("//flutter/prebuilts/emsdk")
 
   wasm_use_pthreads = false
   wasm_use_dwarf = false


### PR DESCRIPTION
This changes the location the build files look for the emscripten toolchain. It is meant to go in alongside https://github.com/flutter/engine/pull/51299 which actually changes the DEPS file to place emsdk in a different place.