### PR TITLE
Remove exec_script() that always returns the empty string

### DIFF
--- a/build/config/android/BUILD.gn
+++ b/build/config/android/BUILD.gn
@@ -9,15 +9,6 @@ config("sdk") {
   if (sysroot != "") {
     cflags = [ "--sysroot=" + sysroot ]
     ldflags = [ "-L" + rebase_path("$android_lib", root_build_dir) ]
-
-    # Need to get some linker flags out of the sysroot.
-    sysroot_ld_path = rebase_path("//build/config/linux/sysroot_ld_path.py")
-    ldflags += [ exec_script(sysroot_ld_path,
-                             [
-                               rebase_path("//build/linux/sysroot_ld_path.sh"),
-                               sysroot,
-                             ],
-                             "value") ]
   }
 }
 


### PR DESCRIPTION
For https://github.com/flutter/flutter/issues/144430

Validated in https://github.com/flutter/engine/pull/51306