### PR TITLE
Add a GN arg that configures the path to the buildtools tree

### DIFF
--- a/build/config/clang/BUILD.gn
+++ b/build/config/clang/BUILD.gn
@@ -3,6 +3,7 @@
 # found in the LICENSE file.
 
 import("//build/toolchain/clang.gni")
+import("//build/toolchain/toolchain.gni")
 import("clang.gni")
 
 # Empty entry to satisfy ANGLE build, which tries to remove this config.
@@ -26,10 +27,10 @@ config("extra_warnings") {
 
 group("llvm-symbolizer_data") {
   if (is_win) {
-    data = [ "//buildtools/windows-x64/bin/llvm-symbolizer.exe" ]
+    data = [ "$buildtools_path/windows-x64/bin/llvm-symbolizer.exe" ]
   } else if (is_mac) {
-    data = [ "//buildtools/mac-${host_cpu}/clang/bin/llvm-symbolizer" ]
+    data = [ "$buildtools_path/mac-${host_cpu}/clang/bin/llvm-symbolizer" ]
   } else if (is_linux) {
-    data = [ "//buildtools/linux-${host_cpu}/clang/bin/llvm-symbolizer" ]
+    data = [ "$buildtools_path/linux-${host_cpu}/clang/bin/llvm-symbolizer" ]
   }
 }

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -20,6 +20,7 @@ import("//build/config/sanitizers/sanitizers.gni")
 import("//build/fuchsia/config.gni")
 import("//build/toolchain/ccache.gni")
 import("//build/toolchain/clang.gni")
+import("//build/toolchain/toolchain.gni")
 import("//build/toolchain/wasm.gni")
 
 declare_args() {
@@ -152,8 +153,8 @@ config("compiler") {
     if (use_custom_libcxx) {
       cflags_cc += [ "-nostdinc++" ]
       include_dirs = [
-        "//buildtools/third_party/libc++/trunk/include",
-        "//buildtools/third_party/libc++abi/trunk/include",
+        "$buildtools_path/third_party/libc++/trunk/include",
+        "$buildtools_path/third_party/libc++abi/trunk/include",
       ]
     }
   }

--- a/build/config/sanitizers/BUILD.gn
+++ b/build/config/sanitizers/BUILD.gn
@@ -4,6 +4,7 @@
 
 import("//build/config/c++/c++.gni")
 import("//build/config/sanitizers/sanitizers.gni")
+import("//build/toolchain/toolchain.gni")
 
 # Contains the dependencies needed for sanitizers to link into executables and
 # shared_libraries. Unconditionally depend upon this target as it is empty if
@@ -14,7 +15,7 @@ group("deps") {
     deps += [ ":options_sources" ]
   }
   if (use_custom_libcxx) {
-    deps += [ "//buildtools/third_party/libc++:libcxx_proxy" ]
+    deps += [ "$buildtools_path/third_party/libc++:libcxx_proxy" ]
   }
 }
 

--- a/build/fuchsia/sdk.gni
+++ b/build/fuchsia/sdk.gni
@@ -3,6 +3,7 @@
 # found in the LICENSE file.
 
 import("//build/fuchsia/config.gni")
+import("//build/toolchain/toolchain.gni")
 
 declare_args() {
   # The path to where GN targets derived from the Fuchsia SDK are instantiated.
@@ -17,7 +18,7 @@ declare_args() {
 
   # The following variables are Flutter buildroot specific.
   fuchsia_sdk_path = "//fuchsia/sdk/$host_os"
-  fuchsia_toolchain_path = "//buildtools/${host_os}-${host_cpu}/clang"
+  fuchsia_toolchain_path = "$buildtools_path/${host_os}-${host_cpu}/clang"
 }
 
 declare_args() {

--- a/build/toolchain/android/BUILD.gn
+++ b/build/toolchain/android/BUILD.gn
@@ -8,6 +8,7 @@ import("//build/toolchain/clang.gni")
 import("//build/toolchain/gcc_toolchain.gni")
 import("//build/toolchain/goma.gni")
 import("//build/toolchain/rbe.gni")
+import("//build/toolchain/toolchain.gni")
 
 # The Android GCC toolchains share most of the same parameters, so we have this
 # wrapper around gcc_toolchain to avoid duplication of logic.
@@ -69,7 +70,7 @@ template("android_toolchain") {
       assert(false, "Unknown host")
     }
 
-    prefix = rebase_path("//buildtools/$host_dir/clang/bin", root_build_dir)
+    prefix = rebase_path("$buildtools_path/$host_dir/clang/bin", root_build_dir)
 
     cc = "${compiler_prefix}${prefix}/clang"
     cxx = "${compiler_prefix}${prefix}/clang++"

--- a/build/toolchain/fuchsia/BUILD.gn
+++ b/build/toolchain/fuchsia/BUILD.gn
@@ -4,6 +4,7 @@
 
 import("//build/toolchain/clang.gni")
 import("//build/toolchain/goma.gni")
+import("//build/toolchain/toolchain.gni")
 
 if (use_goma) {
   goma_prefix = "$goma_dir/gomacc "
@@ -15,7 +16,7 @@ toolchain("fuchsia") {
   assert(target_cpu == "x64" || target_cpu == "arm64",
          "We currently only support 'x64' and 'arm64' targets for fuchsia.")
   toolchain_bin =
-      rebase_path("//buildtools/${host_os}-${host_cpu}/clang/bin", root_out_dir)
+      rebase_path("$buildtools_path/${host_os}-${host_cpu}/clang/bin", root_out_dir)
   fuchsia_sdk = rebase_path("//fuchsia/sdk/$host_os", root_out_dir)
 
   # We can't do string interpolation ($ in strings) on things with dots in

--- a/build/toolchain/linux/BUILD.gn
+++ b/build/toolchain/linux/BUILD.gn
@@ -7,6 +7,7 @@ import("//build/toolchain/ccache.gni")
 import("//build/toolchain/gcc_toolchain.gni")
 import("//build/toolchain/goma.gni")
 import("//build/toolchain/rbe.gni")
+import("//build/toolchain/toolchain.gni")
 
 declare_args() {
   toolchain_prefix = ""
@@ -33,10 +34,10 @@ if (use_goma) {
 
 if (host_cpu == "arm64") {
   rebased_clang_dir =
-      rebase_path("//buildtools/linux-arm64/clang/bin", root_build_dir)
+      rebase_path("$buildtools_path/linux-arm64/clang/bin", root_build_dir)
 } else {
   rebased_clang_dir =
-      rebase_path("//buildtools/linux-x64/clang/bin", root_build_dir)
+      rebase_path("$buildtools_path/linux-x64/clang/bin", root_build_dir)
 }
 
 gcc_toolchain("arm") {

--- a/build/toolchain/mac/BUILD.gn
+++ b/build/toolchain/mac/BUILD.gn
@@ -11,14 +11,15 @@ import("//build/toolchain/clang.gni")
 import("//build/toolchain/clang_static_analyzer.gni")
 import("//build/toolchain/goma.gni")
 import("//build/toolchain/rbe.gni")
+import("//build/toolchain/toolchain.gni")
 
 # Goma doesn't support the host-arm64 toolchain, so continue using Rosetta.
 if (host_cpu == "arm64" && !use_goma) {
   rebased_clang_dir =
-      rebase_path("//buildtools/mac-arm64/clang/bin", root_build_dir)
+      rebase_path("$buildtools_path/mac-arm64/clang/bin", root_build_dir)
 } else {
   rebased_clang_dir =
-      rebase_path("//buildtools/mac-x64/clang/bin", root_build_dir)
+      rebase_path("$buildtools_path/mac-x64/clang/bin", root_build_dir)
 }
 
 if (use_goma) {

--- a/build/toolchain/rbe.gni
+++ b/build/toolchain/rbe.gni
@@ -4,6 +4,8 @@
 
 # Defines the configuration of RBE.
 
+import("//build/toolchain/toolchain.gni")
+
 declare_args() {
   # Set to true to enable distributed compilation using Goma.
   use_rbe = false
@@ -31,7 +33,7 @@ declare_args() {
 
   rbe_platform = ""
 
-  rbe_dir = rebase_path("//buildtools/linux-x64/reclient")
+  rbe_dir = rebase_path("$buildtools_path/linux-x64/reclient")
 
   rbe_cfg = rebase_path("//flutter/build/rbe/rewrapper-linux.cfg")
 }

--- a/build/toolchain/toolchain.gni
+++ b/build/toolchain/toolchain.gni
@@ -2,4 +2,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+declare_args() {
+  buildtools_path = "//buildtools"
+}
+
 use_xcode_clang = false

--- a/build/toolchain/win/BUILD.gn
+++ b/build/toolchain/win/BUILD.gn
@@ -3,9 +3,10 @@
 # found in the LICENSE file.
 
 import("//build/toolchain/rbe.gni")
+import("//build/toolchain/toolchain.gni")
 import("//build/toolchain/win/win_toolchain_data.gni")
 
-default_clang_base_path = "//buildtools/windows-x64/clang"
+default_clang_base_path = "$buildtools_path/windows-x64/clang"
 
 declare_args() {
   # Path to the directory containing the VC binaries for the right


### PR DESCRIPTION
This is in preparation for moving //buildtools out of the buildroot and into //flutter/buildtools