### PR TITLE
Move the `android_tools` root to `flutter/third_party`.

### DIFF
--- a/build/config/android/config.gni
+++ b/build/config/android/config.gni
@@ -6,7 +6,7 @@
 
 if (is_android) {
   if (!defined(default_android_sdk_root)) {
-    default_android_sdk_root = "//third_party/android_tools/sdk"
+    default_android_sdk_root = "//flutter/third_party/android_tools/sdk"
     default_android_sdk_version = "34"
     default_android_sdk_build_tools_version = "34.0.0"
   }
@@ -53,7 +53,7 @@ if (is_android) {
   android_sdk = "${android_sdk_root}/platforms/android-${android_sdk_version}"
 
   # Path to the Android NDK and SDK.
-  android_ndk_root = "//third_party/android_tools/ndk"
+  android_ndk_root = "//flutter/third_party/android_tools/ndk"
   android_ndk_include_dir = "$android_ndk_root/usr/include"
 
   android_sdk = "${android_sdk_root}/platforms/android-${android_sdk_version}"


### PR DESCRIPTION
I have a follow-up patch I'll need to use on `flutter/engine` moving all references to `flutter/third_party/android_tools`.