### PR TITLE
Use debug-prefix-map to avoid absolute paths in debug info

### DIFF
--- a/build/config/BUILDCONFIG.gn
+++ b/build/config/BUILDCONFIG.gn
@@ -371,6 +371,7 @@ if (is_win) {
 if (is_posix) {
   _native_compiler_configs += [
     "//build/config/gcc:no_exceptions",
+    "//build/config/gcc:relative_paths",
     "//build/config/gcc:symbol_visibility_hidden",
     "//build/config:symbol_visibility_hidden",
   ]

--- a/build/config/gcc/BUILD.gn
+++ b/build/config/gcc/BUILD.gn
@@ -3,6 +3,7 @@
 # found in the LICENSE file.
 
 import("//build/config/profiler.gni")
+import("//build/toolchain/rbe.gni")
 
 # This config causes functions not to be automatically exported from shared
 # libraries. By default, all symbols are exported but this means there are
@@ -48,4 +49,47 @@ config("no_exceptions") {
   no_exceptions_flags = [ "-fno-exceptions" ]
   cflags_cc = no_exceptions_flags
   cflags_objcc = no_exceptions_flags
+}
+
+config("relative_paths") {
+  # Make builds independent of absolute file path.  The file names
+  # embedded in debugging information will be expressed as relative to
+  # the build directory, e.g. "../.." for an "out/subdir" under //.
+  # This is consistent with the file names in __FILE__ expansions
+  # (e.g. in assertion messages), which the compiler doesn't provide a
+  # way to remap.  That way source file names in logging and
+  # symbolization can all be treated the same way.  This won't go well
+  # if root_build_dir is not a subdirectory //, but there isn't a better
+  # option to keep all source file name references uniformly relative to
+  # a single root.
+  cflags = []
+  cflags_objcc = []
+  absolute_path = rebase_path("//")
+  relative_path = ""
+  if (use_rbe) {
+    # objc builds are always local even when rbe is enabled.
+    cflags_objcc += [
+      # This makes sure that the DW_AT_comp_dir string (the current
+      # directory while running the compiler, which is the basis for all
+      # relative source file names in the DWARF info) is represented as
+      # relative to //.
+      "-fdebug-prefix-map=$absolute_path=$relative_path",
+    ]
+  } else {
+    cflags += [
+      "-fdebug-prefix-map=$absolute_path=$relative_path",
+    ]
+  }
+  cflags += [
+    # This makes sure that include directories in the toolchain are
+    # represented as relative to the build directory (because that's how
+    # we invoke the compiler), rather than absolute.  This can affect
+    # __FILE__ expansions (e.g. assertions in system headers).  We
+    # normally run a compiler that's someplace within the source tree
+    # (//buildtools/...), so its absolute installation path will have a
+    # prefix matching absolute_path and hence be mapped to relative_path
+    # in the debugging information, so this should actually be
+    # superfluous for purposes of the debugging information.
+    "-no-canonical-prefixes",
+  ]
 }

--- a/build/toolchain/mac/BUILD.gn
+++ b/build/toolchain/mac/BUILD.gn
@@ -30,8 +30,11 @@ if (use_goma) {
 } else if (use_rbe) {
   remote_wrapper =
       rebase_path("//flutter/build/rbe/remote_wrapper.sh", root_build_dir)
+  local_wrapper =
+      rebase_path("//flutter/build/rbe/local_wrapper.sh", root_build_dir)
   compiler_args = rewrapper_command + [
     "--remote_wrapper=$remote_wrapper",
+    "--local_wrapper=$local_wrapper",
     "--labels=type=compile,compiler=clang,lang=cpp ",
   ]
   cxx_prefix = string_join(" ", compiler_args)


### PR DESCRIPTION
For https://github.com/flutter/flutter/issues/147750