### PR TITLE
Pass stack protection flag on Android

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -35,10 +35,7 @@ declare_args() {
   # this flag may be set to allow such calls.
   allow_deprecated_api_calls = false
 
-  # Whether -fstack-protector --param=ssp-buffer-size=4 should be passed
-  # unconditionally.
-  # TODO(zanderso): Remove when no longer needed in the investigation of
-  # https://github.com/flutter/flutter/issues/87952.
+  # This flag is deprecated and will be removed. The value will be ignored.
   use_fstack_protector = false
 
   # Prefer size over speed when compiling to wasm
@@ -98,20 +95,16 @@ config("compiler") {
     cflags_objcc += common_flags
 
     # Stack protection.
-    if (use_fstack_protector) {
+    if (is_mac) {
+      cflags += [ "-fstack-protector-all" ]
+    } else if (!is_ios && !is_wasm) {
       cflags += [
         "-fstack-protector",
-        "--param=ssp-buffer-size=4",
+        # 8 is the default, but make this explicit here so that we don't have to
+        # go hunting for the flag name if we ever want a value that is
+        # different from the default.
+        "--param=ssp-buffer-size=8",
       ]
-    } else {
-      if (is_mac) {
-        cflags += [ "-fstack-protector-all" ]
-      } else if (is_linux) {
-        cflags += [
-          "-fstack-protector",
-          "--param=ssp-buffer-size=4",
-        ]
-      }
     }
 
     # Linker warnings.


### PR DESCRIPTION
For b/338202330.

This increases binary size of libflutter.so in android_release_arm64 by ~55KB (+0.5%) uncompressed, and by ~30KB (+0.6%) gzip'd.

Tested in https://github.com/flutter/engine/pull/52774