### PR TITLE
[Darwin] Disable NSAsserts in release builds.

### DIFF
--- a/build/config/BUILD.gn
+++ b/build/config/BUILD.gn
@@ -84,6 +84,11 @@ config("debug") {
 config("release") {
   defines = [ "NDEBUG" ]
 
+  if (is_mac || is_ios) {
+    # Disable NSAsserts in release builds.
+    defines += [ "NS_BLOCK_ASSERTIONS=1" ]
+  }
+
   # Sanitizers.
   # TODO(GYP) The GYP build has "release_valgrind_build == 0" for this
   # condition. When Valgrind is set up, we need to do the same here.


### PR DESCRIPTION
Chromium has a similar gn flag to disable asserts in release builds: https://source.chromium.org/chromium/chromium/src/+/main:build/config/BUILD.gn;drc=9dab28144192cefadbb96b778ef866ea3deb74ff;l=148

Related: https://github.com/flutter/flutter/issues/148279

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
