### PR TITLE
Re-introduce ccache support

### DIFF
--- a/build/toolchain/android/BUILD.gn
+++ b/build/toolchain/android/BUILD.gn
@@ -3,6 +3,7 @@
 # found in the LICENSE file.
 
 import("//build/config/sysroot.gni")  # Imports android/config.gni.
+import("//build/toolchain/ccache.gni")
 import("//build/toolchain/clang.gni")
 import("//build/toolchain/gcc_toolchain.gni")
 import("//build/toolchain/rbe.gni")
@@ -55,6 +56,11 @@ template("android_toolchain") {
       ]
       assembler_prefix = ""
       compiler_prefix = string_join(" ", compiler_args)
+      link_prefix = ""
+    } else if (use_ccache) {
+      # ccache only supports compilation, not linking.
+      assembler_prefix = "ccache "
+      compiler_prefix = ""
       link_prefix = ""
     } else {
       compiler_prefix = ""

--- a/build/toolchain/ccache.gni
+++ b/build/toolchain/ccache.gni
@@ -19,7 +19,12 @@
 # speed, you can do:
 # export CCACHE_CPP2=yes
 
+import("//build/toolchain/rbe.gni") # for use_rbe
+
 declare_args() {
   # Set to true to enable ccache.  Probably doesn't work on windows.
   use_ccache = false
 }
+
+assert(!is_win || !use_ccache, "ccache is not supported on Windows")
+assert(!use_ccache || !use_rbe, "ccache is not supported with RBE")

--- a/build/toolchain/fuchsia/BUILD.gn
+++ b/build/toolchain/fuchsia/BUILD.gn
@@ -4,12 +4,17 @@
 
 import("//build/toolchain/clang.gni")
 import("//build/toolchain/rbe.gni")
+import("//build/toolchain/ccache.gni")
 import("//build/toolchain/toolchain.gni")
 
 if (use_rbe) {
   compiler_args =
       rewrapper_command + [ "--labels=type=compile,compiler=clang,lang=cpp " ]
   compiler_prefix = string_join(" ", compiler_args)
+  link_prefix = ""
+} else if (use_ccache) {
+  # ccache only supports compilation, not linking.
+  compiler_prefix = "ccache"
   link_prefix = ""
 } else {
   compiler_prefix = ""

--- a/build/toolchain/linux/BUILD.gn
+++ b/build/toolchain/linux/BUILD.gn
@@ -3,6 +3,7 @@
 # found in the LICENSE file.
 
 import("//build/config/sysroot.gni")
+import("//build/toolchain/ccache.gni")
 import("//build/toolchain/gcc_toolchain.gni")
 import("//build/toolchain/rbe.gni")
 import("//build/toolchain/toolchain.gni")
@@ -22,6 +23,10 @@ if (use_rbe) {
     "--labels=type=compile,compiler=clang,lang=cpp ",
   ]
   compiler_prefix = string_join(" ", compiler_args)
+  link_prefix = ""
+} else if (use_ccache) {
+  # ccache only supports compilation, not linking.
+  compiler_prefix = "ccache "
   link_prefix = ""
 } else {
   compiler_prefix = ""

--- a/build/toolchain/mac/BUILD.gn
+++ b/build/toolchain/mac/BUILD.gn
@@ -10,6 +10,7 @@ import("//build/config/sysroot.gni")
 import("//build/toolchain/clang.gni")
 import("//build/toolchain/clang_static_analyzer.gni")
 import("//build/toolchain/rbe.gni")
+import("//build/toolchain/ccache.gni")
 import("//build/toolchain/toolchain.gni")
 
 if (host_cpu == "arm64") {
@@ -20,7 +21,12 @@ if (host_cpu == "arm64") {
       rebase_path("$buildtools_path/mac-x64/clang/bin", root_build_dir)
 }
 
-if (use_rbe) {
+if (use_ccache) {
+  # ccache only supports compilation, not linking.
+  cxx_prefix = "ccache "
+  objc_prefix = "ccache "
+  link_prefix = ""
+} else if (use_rbe) {
   remote_wrapper =
       rebase_path("//flutter/build/rbe/remote_wrapper.sh", root_build_dir)
   local_wrapper =

--- a/build/toolchain/wasm.gni
+++ b/build/toolchain/wasm.gni
@@ -17,6 +17,13 @@ declare_args() {
 
 em_config_path = "$emsdk_dir/.emscripten"
 
+if (use_ccache) {
+  # ccache only supports compilation, not linking.
+  compiler_prefix = "ccache "
+} else {
+  compiler_prefix = ""
+}
+
 template("wasm_toolchain") {
   gcc_toolchain(target_name) {
     extra_toolchain_args = {
@@ -27,9 +34,9 @@ template("wasm_toolchain") {
 
     # emsdk_dir and em_config are defined in wasm.gni.
     ar = "$emsdk_dir/upstream/emscripten/emar --em-config $em_config_path"
-    cc = "$emsdk_dir/upstream/emscripten/emcc --em-config $em_config_path"
-    cxx = "$emsdk_dir/upstream/emscripten/em++ --em-config $em_config_path"
-    asm = cc
+    cc = "$compiler_prefix$emsdk_dir/upstream/emscripten/emcc --em-config $em_config_path"
+    cxx = "$compiler_prefix$emsdk_dir/upstream/emscripten/em++ --em-config $em_config_path"
+    asm = "$emsdk_dir/upstream/emscripten/emcc --em-config $em_config_path"
 
     # emscripten emits this .worker.js file conditionally depending on whether
     # pthreads are on or not. Unfortunately, there is no way to conditionally
@@ -39,7 +46,7 @@ template("wasm_toolchain") {
     # dummy file. If the target does use pthreads, this dummy file will be
     # overwritten. If the target does not, the dummy file will satisfy the
     # toolchain's requirement that it has this as an output.
-    ld = "$cxx"
+    ld = "$emsdk_dir/upstream/emscripten/em++ --em-config $em_config_path"
     readelf = "readelf"
     nm = "nm"
 


### PR DESCRIPTION
Recent change 9a4ba8138aed94000ac5070590a21030008903bb removed ccache support from the build process. This commit re-introduces ccache support and updates GN files accordingly. Since ccache only supports compilation, updates have been made to the compiler prefixes. Additionally, assertions have been added to ensure ccache is not used on Windows or in conjunction with RBE.

Fixes https://github.com/flutter/flutter/issues/149100

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
