### PR TITLE
Revert "[Darwin] Disable NSAsserts in release builds."

### DIFF
--- a/build/config/BUILD.gn
+++ b/build/config/BUILD.gn
@@ -84,11 +84,6 @@ config("debug") {
 config("release") {
   defines = [ "NDEBUG" ]
 
-  if (is_mac || is_ios) {
-    # Disable NSAsserts in release builds.
-    defines += [ "NS_BLOCK_ASSERTIONS=1" ]
-  }
-
   # Sanitizers.
   # TODO(GYP) The GYP build has "release_valgrind_build == 0" for this
   # condition. When Valgrind is set up, we need to do the same here.


### PR DESCRIPTION
https://github.com/flutter/buildroot/pull/860 isn't cleanly rolling into the engine due to side effects of turning off NSAsserts in release.  Revert until the fixes are in the engine.
