### PR TITLE
Revert "Output .js files from wasm modules as ES6 modules. (#844)"

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -296,8 +296,6 @@ config("compiler") {
       # Reduces global namespace pollution.
       "-s",
       "MODULARIZE=1",
-      "-s",
-      "EXPORT_ES6",
 
       # Always produce a symbol map so that we can map crash traces
       "--emit-symbol-map",


### PR DESCRIPTION
This reverts commit 6c01dbca494b78e32f9e4aa704514faabfba74e8.

The corresponding engine change is causing issues with the engine -> framework roll and is being reverted.