### PR TITLE
Reland "Output .js files from wasm modules as ES6 modules. (#844)"

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -296,6 +296,8 @@ config("compiler") {
       # Reduces global namespace pollution.
       "-s",
       "MODULARIZE=1",
+      "-s",
+      "EXPORT_ES6",
 
       # Always produce a symbol map so that we can map crash traces
       "--emit-symbol-map",


### PR DESCRIPTION
To go with the reland of ES6 modules stuff here: https://github.com/flutter/engine/pull/53688