### PR TITLE
Fix copy not working for system files on macOS 15.1

### DIFF
--- a/build/toolchain/mac/BUILD.gn
+++ b/build/toolchain/mac/BUILD.gn
@@ -222,7 +222,8 @@ template("mac_toolchain") {
     }
 
     tool("copy") {
-      command = "ln -f {{source}} {{output}} 2>/dev/null || (rm -rf {{output}} && cp -af {{source}} {{output}})"
+      # macOS 15.1: cp -a may fail at copying permission the source file a system file.
+      command = "ln -f {{source}} {{output}} 2>/dev/null || (rm -rf {{output}} && (cp -af {{source}} {{output}} || cp -RPf {{source}} {{output}}))"
       description = "COPY {{source}} {{output}}"
     }
 


### PR DESCRIPTION
It seems that on 15.1, it is not possible to do hard link to system file (fails with `Read-only file system`) or `cp -a`, which fails with `cp: chflags: Operation not permitted`. This breaks engine build when copying `/System/Library/Fonts/Apple Color Emoji.ttc` for test fixtures.

I suspect there are private resource forks on the file that can not be created by user.

Possible solution is to copy the file without attempting to preserve permissions if everything else fails.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
