### PR TITLE
Add an optional `prefix_with_time_cmd` flag to `compiled_action`.

### DIFF
--- a/build/compiled_action.gni
+++ b/build/compiled_action.gni
@@ -28,6 +28,11 @@
 #       of these change. If inputs is empty, the step will run only when the
 #       binary itself changes.
 #
+#   prefix_with_time_cmd (optional)
+#       [bool] If true, the command will be prefixed with "time" to measure the
+#       time, CPU and memory usage of the tool, i.e. "time <command>" with
+#       appropriate arguments for the current platform.
+#
 #   visibility
 #   deps
 #   args   (all optional)
@@ -127,9 +132,27 @@ template("compiled_action") {
       depfile = invoker.depfile
     }
 
+    args = []
+    if (defined(invoker.prefix_with_time_cmd) && invoker.prefix_with_time_cmd) {
+      if (host_os == "linux") {
+        args += [
+          "time",
+          "-v",
+        ]
+      } else if (host_os == "mac") {
+        args += [
+          "time",
+          "-l",
+        ]
+      } else {
+        print("Warning: prefix_with_time_cmd is not supported on Windows.")
+      }
+    }
+
     # The script takes as arguments the binary to run, and then the arguments
     # to pass it.
-    args = [ rebase_path(host_executable, root_build_dir) ] + invoker.args
+    args += [ rebase_path(host_executable, root_build_dir) ]
+    args += invoker.args
   }
 }
 


### PR DESCRIPTION
Work on debugging https://github.com/flutter/flutter/issues/154437.

Must land and roll into flutter/engine before https://github.com/flutter/engine/pull/55633.