### PR TITLE
Revert "Add an optional `prefix_with_time_cmd` flag to `compiled_action`."

### DIFF
--- a/build/compiled_action.gni
+++ b/build/compiled_action.gni
@@ -28,11 +28,6 @@
 #       of these change. If inputs is empty, the step will run only when the
 #       binary itself changes.
 #
-#   prefix_with_time_cmd (optional)
-#       [bool] If true, the command will be prefixed with "time" to measure the
-#       time, CPU and memory usage of the tool, i.e. "time <command>" with
-#       appropriate arguments for the current platform.
-#
 #   visibility
 #   deps
 #   args   (all optional)
@@ -132,27 +127,9 @@ template("compiled_action") {
       depfile = invoker.depfile
     }
 
-    args = []
-    if (defined(invoker.prefix_with_time_cmd) && invoker.prefix_with_time_cmd) {
-      if (host_os == "linux") {
-        args += [
-          "time",
-          "-v",
-        ]
-      } else if (host_os == "mac") {
-        args += [
-          "time",
-          "-l",
-        ]
-      } else {
-        print("Warning: prefix_with_time_cmd is not supported on Windows.")
-      }
-    }
-
     # The script takes as arguments the binary to run, and then the arguments
     # to pass it.
-    args += [ rebase_path(host_executable, root_build_dir) ]
-    args += invoker.args
+    args = [ rebase_path(host_executable, root_build_dir) ] + invoker.args
   }
 }
 


### PR DESCRIPTION
Reverts flutter/buildroot#902.

This command doesn't work, and @zanderso's advice to use a LED build with a local branch works for now.