### PR TITLE
Revert "For --time'd failed gn_run_binary.py runs repeat failed command (#910)"

### DIFF
--- a/build/gn_run_binary.py
+++ b/build/gn_run_binary.py
@@ -36,15 +36,4 @@ except subprocess.CalledProcessError as ex:
   print("Command failed: " + ' '.join(args))
   print("exitCode: " + str(ex.returncode))
   print(ex.output.decode('utf-8', errors='replace'))
-
-  # For --time'd executions do another control run to confirm failures.
-  # This is to help troubleshoot https://github.com/flutter/flutter/issues/154437.
-  if sys.argv[1] == "--time":
-    try:
-      subprocess.check_output(args, stderr=subprocess.STDOUT)
-    except subprocess.CalledProcessError as ex:
-      print("2nd coming Command failed: " + ' '.join(args))
-      print("2nd coming exitCode: " + str(ex.returncode))
-      print(ex.output.decode('utf-8', errors='replace'))
-
   sys.exit(ex.returncode)


### PR DESCRIPTION
This reverts commit 4006f2730e566c2a4c2bbbbba406f888c401e094 as it showed that repeated execution of gen_snapshot was passing, so first run failure was indeed transient: https://ci.chromium.org/ui/p/flutter/builders/prod/Mac%20mac_ios_engine/12634

