### PR TITLE
Revert "Allow command execution under `/usr/bin/time` for stats collections (#909)"

### DIFF
--- a/build/compiled_action.gni
+++ b/build/compiled_action.gni
@@ -28,11 +28,6 @@
 #       of these change. If inputs is empty, the step will run only when the
 #       binary itself changes.
 #
-#   prefix_with_time_cmd (optional)
-#       [bool] If true, the command will be prefixed with "time" to measure the
-#       time, CPU and memory usage of the tool, i.e. "time <command>" with
-#       appropriate arguments for the current platform.
-#
 #   visibility
 #   deps
 #   args   (all optional)
@@ -132,15 +127,9 @@ template("compiled_action") {
       depfile = invoker.depfile
     }
 
-    args = []
-    if (defined(invoker.prefix_with_time_cmd) && invoker.prefix_with_time_cmd) {
-      args += ["--time"]
-    }
-
     # The script takes as arguments the binary to run, and then the arguments
     # to pass it.
-    args += [ rebase_path(host_executable, root_build_dir) ]
-    args += invoker.args
+    args = [ rebase_path(host_executable, root_build_dir) ] + invoker.args
   }
 }
 

--- a/build/gn_run_binary.py
+++ b/build/gn_run_binary.py
@@ -8,27 +8,16 @@ Run with:
   python gn_run_binary.py <binary_name> [args ...]
 """
 
-import platform
 import sys
 import subprocess
-
-
-args = []
-basearg = 1
-if sys.argv[1] == "--time":
-  basearg = 2
-  if (platform.system() == "Linux"):
-    args += ["/usr/bin/time", "-v"]
-  elif (platform.system() == "Darwin"):
-    args += ["/usr/bin/time", "-l"]
 
 # This script is designed to run binaries produced by the current build. We
 # always prefix it with "./" to avoid picking up system versions that might
 # also be on the path.
-path = './' + sys.argv[basearg]
+path = './' + sys.argv[1]
 
 # The rest of the arguements are passed directly to the executable.
-args += [path] + sys.argv[basearg + 1:]
+args = [path] + sys.argv[2:]
 
 try:
   subprocess.check_output(args, stderr=subprocess.STDOUT)


### PR DESCRIPTION
This reverts commit 773652167dbd506c5fb85d168e2c9038f24fed2a as investigation that it was needed for concluded and the bug fixed.
