### PR TITLE
Changes a few compile options for the new emscripten (3.1.70)

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -292,6 +292,8 @@ config("compiler") {
       "NO_EXIT_RUNTIME=1",
       "-s",
       "STRICT=1",
+      "-s",
+      "ENVIRONMENT=web,worker",
 
       # Reduces global namespace pollution.
       "-s",

--- a/build/toolchain/wasm.gni
+++ b/build/toolchain/wasm.gni
@@ -62,11 +62,6 @@ template("wasm_toolchain") {
       "{{root_out_dir}}/{{target_output_name}}.js.symbols",
     ]
 
-    if (wasm_use_pthreads || (defined(extra_toolchain_args.wasm_use_pthreads) &&
-                              extra_toolchain_args.wasm_use_pthreads)) {
-      link_outputs += [ "{{root_out_dir}}/{{target_output_name}}.worker.js" ]
-    }
-
     if (is_debug && !wasm_use_dwarf) {
       link_outputs += [ "{{root_out_dir}}/{{target_output_name}}.wasm.map" ]
     }


### PR DESCRIPTION
* Specifying the environments explicitly avoids emitting extra code to handle node.js and other environments.
* Newer versions of emscripten don't actually produce a .worker.js file anymore, even in pthread builds.